### PR TITLE
reader wiring for data, codelists, standards & their schemas

### DIFF
--- a/cdisc_rules_engine/data_service/postgresql_data_service.py
+++ b/cdisc_rules_engine/data_service/postgresql_data_service.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Union
 import pandas as pd
+import logging
 
 from pathlib import Path
 
@@ -9,6 +10,14 @@ from cdisc_rules_engine.constants.domains import SUPPLEMENTARY_DOMAINS
 from cdisc_rules_engine.data_service.sql_data_service import SQLDataService
 from cdisc_rules_engine.data_service.sql_interface import PostgresQLInterface
 from cdisc_rules_engine.models.test_dataset import TestDataset
+from cdisc_rules_engine.readers.data_reader import DataReader
+from cdisc_rules_engine.readers.codelist_reader import CodelistReader
+from cdisc_rules_engine.readers.metadata_standards_reader import MetadataStandardsReader
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+SCHEMA_PATH = Path(__file__).parent / "schemas"
 
 
 @dataclass
@@ -31,11 +40,13 @@ class PostgresQLDataService(SQLDataService):
         postgres_interface: PostgresQLInterface,
         datasets_path: Path = None,
         define_xml_path: Path = None,
+        codelists_path: Path = None,
+        metadata_standards_path: Path = None,
         terminology_paths: dict = None,
         data_dfs: dict[str, pd.DataFrame] = None,
         pre_processed_dfs: dict[str, pd.DataFrame] = None,
     ):
-        super().__init__(datasets_path, define_xml_path, terminology_paths)
+        super().__init__(datasets_path, define_xml_path, codelists_path, metadata_standards_path, terminology_paths)
         self.data_dfs = data_dfs
         self.pre_processed_dfs = pre_processed_dfs
         self.pgi = postgres_interface
@@ -60,7 +71,7 @@ class PostgresQLDataService(SQLDataService):
         pgi.init_database()
 
         # create metadata table in postgres
-        pgi.execute_sql_file(str(Path(__file__).parent / "schemas" / "clinical_data_metadata_schema.sql"))
+        pgi.execute_sql_file(str(SCHEMA_PATH / "clinical_data_metadata_schema.sql"))
 
         # generate timestamp
         timestamp = datetime.now().astimezone()
@@ -122,7 +133,93 @@ class PostgresQLDataService(SQLDataService):
         Iterate through dataset files in `self.datasets_path`
         and create corresponding SQL tables.
         """
-        pass
+        if not self.datasets_path or not self.datasets_path.exists():
+            logger.info("No datasets path provided or path doesn't exist")
+            return
+
+        self.pgi.execute_sql_file(str(SCHEMA_PATH / "clinical_data_metadata_schema.sql"))
+
+        timestamp = datetime.now().astimezone()
+
+        for file_path in self.datasets_path.iterdir():
+            self._process_dataset_file(file_path, timestamp)
+
+    def _process_dataset_file(self, file_path: Path, timestamp: datetime) -> None:
+        """Process a single dataset file."""
+        try:
+            reader = DataReader(str(file_path))
+            metadata_info = reader.read_metadata()
+
+            domain = metadata_info["metadata"]["domain"]
+            table_name = f"dataset_{domain.lower()}"  # TODO: obvs this naming convention will change
+
+            logger.info(f"Loading dataset {file_path.name} into table {table_name}")
+
+            metadata_rows = []
+            first_chunk_processed = False
+
+            for chunk_data in reader.read():
+                if not first_chunk_processed and chunk_data:
+                    first_chunk = chunk_data[0]
+                    self._create_table_with_indexes(table_name, first_chunk)
+
+                    metadata_rows = self._build_metadata_rows(file_path, metadata_info, domain, first_chunk, timestamp)
+                    first_chunk_processed = True
+
+                if chunk_data:
+                    self.pgi.insert_data(table_name, chunk_data)
+
+            if metadata_rows:
+                self.pgi.insert_data("data_metadata", metadata_rows)
+
+            logger.info(f"Successfully loaded {file_path.name}")
+
+        except Exception as e:
+            logger.error(f"Failed to load {file_path.name}: {e}")
+
+    def _create_table_with_indexes(self, table_name: str, first_chunk: dict) -> None:
+        """Create table and add indexes for CDISC variables."""
+        self.pgi.create_table_from_data(table_name, first_chunk)
+
+        for col in ("USUBJID", "STUDYID", "DOMAIN", "SEQ", "IDVAR", "IDVARVAL"):
+            if col in first_chunk:
+                self.pgi.execute_sql(
+                    f"CREATE INDEX IF NOT EXISTS idx_{table_name}_{col.lower()} ON {table_name}({col})"
+                )
+
+    def _build_metadata_rows(
+        self, file_path: Path, metadata_info: dict, domain: str, first_chunk: dict, timestamp: datetime
+    ) -> list[dict]:
+        """Build metadata rows for all variables in the dataset."""
+
+        # TODO: here is where the preprocessor for is_supp, rdomain, is_split, unsplit_name, etc. could go, wdu think?
+
+        metadata_rows = []
+        for var_info in metadata_info["variables"]:
+            metadata_rows.append(
+                {
+                    "created_at": timestamp,
+                    "updated_at": timestamp,
+                    "dataset_filename": file_path.name,
+                    "dataset_filepath": str(file_path),
+                    "dataset_id": domain,
+                    "dataset_name": domain,
+                    "dataset_label": metadata_info["metadata"].get("dataset_label", ""),
+                    "dataset_domain": None,  # data_domain
+                    "dataset_is_supp": None,  # is_supp
+                    "dataset_rdomain": None,  # rdomain
+                    "dataset_is_split": None,  # is_split
+                    "dataset_unsplit_name": None,  # unsplit_name
+                    "dataset_preprocessed": None,
+                    "var_name": var_info.get("name", ""),
+                    "var_label": var_info.get("label"),
+                    "var_type": var_info.get("type") or var_info.get("ctype"),
+                    "var_length": var_info.get("length"),
+                    "var_format": var_info.get("format"),
+                }
+            )
+
+        return metadata_rows
 
     def _create_definexml_tables(self) -> None:
         """
@@ -141,13 +238,62 @@ class PostgresQLDataService(SQLDataService):
         """
         Create all necessary SQL tables for IG standards.
         """
-        pass
+        if not self.metadata_standards_path:
+            # TODO: Implement caching system to retrieve previously loaded IG metadata standards
+            logger.info("No metadata standards path provided, will use cached IG metadata in future implementation")
+            return
+
+        if not self.metadata_standards_path.exists():
+            logger.warning(f"Metadata standards path {self.metadata_standards_path} does not exist")
+            return
+
+        self.pgi.execute_sql_file(str(SCHEMA_PATH / "ig_datasets.sql"))
+        self.pgi.execute_sql_file(str(SCHEMA_PATH / "ig_variables.sql"))
+
+        for file_path in self.metadata_standards_path.iterdir():
+            try:
+                reader = MetadataStandardsReader(str(file_path))
+                ig_data = reader.read()
+
+                if ig_data.get("datasets"):
+                    self.pgi.insert_data("ig_datasets", ig_data["datasets"])
+
+                if ig_data.get("variables"):
+                    self.pgi.insert_data("ig_variables", ig_data["variables"])
+
+                logger.info(f"Loaded IG metadata from {file_path.name}")
+
+            except Exception as e:
+                logger.error(f"Failed to load IG metadata {file_path.name}: {e}")
+                continue
 
     def _create_codelist_tables(self) -> None:
         """
         Create all necessary SQL tables for CDISC codelists.
         """
-        pass
+        if not self.codelists_path:
+            # TODO: Implement caching system to retrieve previously loaded codelists
+            logger.info("No codelists path provided, will use cached codelists in future implementation")
+            return
+
+        if not self.codelists_path.exists():
+            logger.warning(f"Codelists path {self.codelists_path} does not exist")
+            return
+
+        self.pgi.execute_sql_file(str(SCHEMA_PATH / "codelists.sql"))
+
+        for file_path in self.codelists_path.iterdir():
+            try:
+                reader = CodelistReader(str(file_path))
+                codelist_data = reader.read()
+
+                if codelist_data:
+                    self.pgi.insert_data("codelists", codelist_data)
+                    logger.info(f"Loaded codelist from {file_path.name}")
+
+            except Exception as e:
+                logger.error(f"Failed to load codelist {file_path.name}: {e}")
+                continue
 
     def get_uploaded_dataset_ids(self) -> list[str]:
         query = "SELECT DISTINCT dataset_id FROM data_metadata;"

--- a/cdisc_rules_engine/data_service/postgresql_data_service.py
+++ b/cdisc_rules_engine/data_service/postgresql_data_service.py
@@ -179,7 +179,7 @@ class PostgresQLDataService(SQLDataService):
 
     def _create_table_with_indexes(self, table_name: str, first_chunk: dict) -> None:
         """Create table and add indexes for CDISC variables."""
-        self.pgi.create_table_from_data(table_name, first_chunk, primary_key="USUBJID")
+        self.pgi.create_table_from_data(table_name, first_chunk)
 
         for col in ("USUBJID", "STUDYID", "DOMAIN", "SEQ", "IDVAR", "IDVARVAL"):
             if col in first_chunk:

--- a/cdisc_rules_engine/data_service/postgresql_data_service.py
+++ b/cdisc_rules_engine/data_service/postgresql_data_service.py
@@ -150,7 +150,6 @@ class PostgresQLDataService(SQLDataService):
             reader = DataReader(str(file_path))
             metadata_info = reader.read_metadata()
 
-            domain = metadata_info["metadata"]["domain"]
             table_name = file_path.stem.lower()
 
             logger.info(f"Loading dataset {file_path.name} into table {table_name}")
@@ -163,7 +162,9 @@ class PostgresQLDataService(SQLDataService):
                     first_chunk = chunk_data[0]
                     self._create_table_with_indexes(table_name, first_chunk)
 
-                    metadata_rows = self._build_metadata_rows(file_path, metadata_info, domain, first_chunk, timestamp)
+                    metadata_rows = self._build_metadata_rows(
+                        file_path, table_name, metadata_info, first_chunk, timestamp
+                    )
                     first_chunk_processed = True
 
                 if chunk_data:
@@ -188,15 +189,15 @@ class PostgresQLDataService(SQLDataService):
                 )
 
     def _build_metadata_rows(
-        self, file_path: Path, metadata_info: dict, domain: str, first_chunk: dict, timestamp: datetime
+        self, file_path: Path, name: str, metadata_info: dict, first_chunk: dict, timestamp: datetime
     ) -> list[dict]:
         """Build metadata rows for all variables in the dataset."""
 
-        domain = metadata_info["metadata"]["domain"]
-        is_supp = domain.startswith("SUPP")
-        rdomain = metadata_info["metadata"].get("rdomain", None)
-        unsplit_name = PostgresQLDataService._get_unsplit_name(file_path.stem, domain, rdomain)
-        is_split = file_path.stem != unsplit_name
+        domain = first_chunk.get("DOMAIN", None)
+        is_supp = domain.startswith(SUPPLEMENTARY_DOMAINS) if domain is not None else False
+        rdomain = first_chunk.get("RDOMAIN", None)
+        unsplit_name = PostgresQLDataService._get_unsplit_name(name, domain, rdomain)
+        is_split = name != unsplit_name
 
         metadata_rows = []
         for var_info in metadata_info["variables"]:
@@ -207,7 +208,7 @@ class PostgresQLDataService(SQLDataService):
                     "dataset_filename": file_path.name,
                     "dataset_filepath": str(file_path),
                     "dataset_id": domain,
-                    "dataset_name": domain,
+                    "dataset_name": domain or name,
                     "dataset_label": metadata_info["metadata"].get("dataset_label", ""),
                     "dataset_domain": domain,
                     "dataset_is_supp": is_supp,

--- a/cdisc_rules_engine/data_service/postgresql_data_service.py
+++ b/cdisc_rules_engine/data_service/postgresql_data_service.py
@@ -151,7 +151,7 @@ class PostgresQLDataService(SQLDataService):
             metadata_info = reader.read_metadata()
 
             domain = metadata_info["metadata"]["domain"]
-            table_name = f"dataset_{domain.lower()}"  # TODO: obvs this naming convention will change
+            table_name = file_path.stem.lower()
 
             logger.info(f"Loading dataset {file_path.name} into table {table_name}")
 
@@ -179,7 +179,7 @@ class PostgresQLDataService(SQLDataService):
 
     def _create_table_with_indexes(self, table_name: str, first_chunk: dict) -> None:
         """Create table and add indexes for CDISC variables."""
-        self.pgi.create_table_from_data(table_name, first_chunk)
+        self.pgi.create_table_from_data(table_name, first_chunk, primary_key="USUBJID")
 
         for col in ("USUBJID", "STUDYID", "DOMAIN", "SEQ", "IDVAR", "IDVARVAL"):
             if col in first_chunk:
@@ -192,7 +192,11 @@ class PostgresQLDataService(SQLDataService):
     ) -> list[dict]:
         """Build metadata rows for all variables in the dataset."""
 
-        # TODO: here is where the preprocessor for is_supp, rdomain, is_split, unsplit_name, etc. could go, wdu think?
+        domain = metadata_info["metadata"]["domain"]
+        is_supp = domain.startswith("SUPP")
+        rdomain = metadata_info["metadata"].get("rdomain", None)
+        unsplit_name = PostgresQLDataService._get_unsplit_name(file_path.stem, domain, rdomain)
+        is_split = file_path.stem != unsplit_name
 
         metadata_rows = []
         for var_info in metadata_info["variables"]:
@@ -205,11 +209,11 @@ class PostgresQLDataService(SQLDataService):
                     "dataset_id": domain,
                     "dataset_name": domain,
                     "dataset_label": metadata_info["metadata"].get("dataset_label", ""),
-                    "dataset_domain": None,  # data_domain
-                    "dataset_is_supp": None,  # is_supp
-                    "dataset_rdomain": None,  # rdomain
-                    "dataset_is_split": None,  # is_split
-                    "dataset_unsplit_name": None,  # unsplit_name
+                    "dataset_domain": domain,
+                    "dataset_is_supp": is_supp,
+                    "dataset_rdomain": rdomain,
+                    "dataset_is_split": is_split,
+                    "dataset_unsplit_name": unsplit_name,
                     "dataset_preprocessed": None,
                     "var_name": var_info.get("name", ""),
                     "var_label": var_info.get("label"),
@@ -271,11 +275,6 @@ class PostgresQLDataService(SQLDataService):
         """
         Create all necessary SQL tables for CDISC codelists.
         """
-        if not self.codelists_path:
-            # TODO: Implement caching system to retrieve previously loaded codelists
-            logger.info("No codelists path provided, will use cached codelists in future implementation")
-            return
-
         if not self.codelists_path.exists():
             logger.warning(f"Codelists path {self.codelists_path} does not exist")
             return

--- a/cdisc_rules_engine/data_service/postgresql_data_service.py
+++ b/cdisc_rules_engine/data_service/postgresql_data_service.py
@@ -189,15 +189,15 @@ class PostgresQLDataService(SQLDataService):
                 )
 
     def _build_metadata_rows(
-        self, file_path: Path, name: str, metadata_info: dict, first_chunk: dict, timestamp: datetime
+        self, file_path: Path, table_name: str, metadata_info: dict, first_chunk: dict, timestamp: datetime
     ) -> list[dict]:
         """Build metadata rows for all variables in the dataset."""
 
         domain = first_chunk.get("DOMAIN", None)
         is_supp = domain.startswith(SUPPLEMENTARY_DOMAINS) if domain is not None else False
         rdomain = first_chunk.get("RDOMAIN", None)
-        unsplit_name = PostgresQLDataService._get_unsplit_name(name, domain, rdomain)
-        is_split = name != unsplit_name
+        unsplit_name = PostgresQLDataService._get_unsplit_name(table_name, domain, rdomain)
+        is_split = table_name != unsplit_name
 
         metadata_rows = []
         for var_info in metadata_info["variables"]:
@@ -207,8 +207,8 @@ class PostgresQLDataService(SQLDataService):
                     "updated_at": timestamp,
                     "dataset_filename": file_path.name,
                     "dataset_filepath": str(file_path),
-                    "dataset_id": domain,
-                    "dataset_name": domain or name,
+                    "dataset_id": table_name,
+                    "dataset_name": table_name,
                     "dataset_label": metadata_info["metadata"].get("dataset_label", ""),
                     "dataset_domain": domain,
                     "dataset_is_supp": is_supp,

--- a/cdisc_rules_engine/data_service/schemas/codelists.sql
+++ b/cdisc_rules_engine/data_service/schemas/codelists.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS codelists (
+    standard_type VARCHAR(10),
+    version_date DATE,
+    item_code VARCHAR(255),
+    codelist_code VARCHAR(255),
+    extensible VARCHAR(10),
+    name VARCHAR(500),
+    value VARCHAR(500),
+    synonym TEXT,
+    definition TEXT,
+    term VARCHAR(500),
+    standard_and_date VARCHAR(255),
+    PRIMARY KEY (standard_type, version_date, codelist_code, item_code)
+)

--- a/cdisc_rules_engine/data_service/schemas/ig_datasets.sql
+++ b/cdisc_rules_engine/data_service/schemas/ig_datasets.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS ig_datasets (
+    standard_type VARCHAR(10),
+    version VARCHAR(20),
+    class VARCHAR(50),
+    dataset_name VARCHAR(50),
+    dataset_label VARCHAR(255),
+    structure VARCHAR(50),
+    structure_name VARCHAR(50),
+    structure_description VARCHAR(500),
+    subclass VARCHAR(50),
+    notes TEXT,
+    PRIMARY KEY (standard_type, version, dataset_name)
+)

--- a/cdisc_rules_engine/data_service/schemas/ig_variables.sql
+++ b/cdisc_rules_engine/data_service/schemas/ig_variables.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS ig_variables (
+    standard_type VARCHAR(10),
+    version VARCHAR(20),
+    variable_order INTEGER,
+    class VARCHAR(50),
+    dataset_name VARCHAR(50),
+    variable_name VARCHAR(50),
+    variable_label VARCHAR(255),
+    structure_name VARCHAR(50),
+    variable_set VARCHAR(50),
+    type VARCHAR(50),
+    codelist_code VARCHAR(255),
+    submission_value TEXT,
+    value_domain TEXT,
+    value_list TEXT,
+    role VARCHAR(50),
+    notes TEXT,
+    core VARCHAR(20),
+    PRIMARY KEY (standard_type, version, dataset_name, variable_name)
+)

--- a/cdisc_rules_engine/data_service/sql_data_service.py
+++ b/cdisc_rules_engine/data_service/sql_data_service.py
@@ -10,6 +10,8 @@ class SQLDataService(ABC):
         self,
         datasets_path: Path = None,
         define_xml_path: Path = None,
+        codelists_path: Path = None,
+        metadata_standards_path: Path = None,
         terminology_paths: dict = None,
     ):
         """
@@ -24,13 +26,15 @@ class SQLDataService(ABC):
         """
         self.datasets_path = datasets_path
         self.define_xml_path = define_xml_path
+        self.codelists_path = codelists_path
+        self.metadata_standards_path = metadata_standards_path
         self.terminology_paths = terminology_paths
 
         self._create_sql_tables_from_dataset_paths()
         self._create_definexml_tables()
-        self._create_terminology_tables()
-        self._create_standards_tables()
         self._create_codelist_tables()
+        self._create_standards_tables()
+        self._create_terminology_tables()
 
     @abstractmethod
     def from_list_of_testdatasets(cls, test_datasets: list[TestDataset]) -> None:


### PR DESCRIPTION
wiring the readers to the data service
clinical data, metadata standards and codelists are wired
had to split up the clinical data table creation into multiple support functions so black and prettier wouldn't complain it was too complex.
testing TO COME - these wires are built on pre-existing functional and tested readers so not much to test but alas.

I've added schema sql files for the ig variables, datasets and the codelists for execution upon the creation functions for the metadata standards and the codelists.