### PR TITLE
feat: CHECK OPERATORS: has_different_values

### DIFF
--- a/cdisc_rules_engine/check_operators/sql_operators.py
+++ b/cdisc_rules_engine/check_operators/sql_operators.py
@@ -1217,12 +1217,13 @@ class PostgresQLOperators(BaseType):
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)
     def has_different_values(self, other_value: dict):
-        """
-        The operator ensures that the target column has different values.
-        """
-        target: str = self.replace_prefix(other_value.get("target"))
-        is_valid: bool = len(self.validation_df[target].unique()) > 1
-        return self.validation_df.convert_to_series([is_valid] * len(self.validation_df[target]))
+        target_column = other_value.get("target").lower()
+        operation_name = f"{target_column}_has_different_values"
+        db_table = self.sql_data_service.cache.get_db_table_hash(self.table_id)
+
+        return self._do_check_operator(
+            operation_name, lambda: f"(SELECT COUNT(DISTINCT {target_column}) FROM {db_table}) > 1"
+        )
 
     @log_operator_execution
     @type_operator(FIELD_DATAFRAME)

--- a/tests/unit/test_check_operators/test_sql_relationship_integrity_checks.py
+++ b/tests/unit/test_check_operators/test_sql_relationship_integrity_checks.py
@@ -1,0 +1,75 @@
+import pandas as pd
+import pytest
+
+from cdisc_rules_engine.check_operators.sql_operators import PostgresQLOperators
+from cdisc_rules_engine.data_service.postgresql_data_service import (
+    PostgresQLDataService,
+)
+
+
+@pytest.mark.parametrize(
+    "data, expected_result",
+    [
+        (
+            {
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP3",
+                    "AEHOSP2",
+                    "AEHOSP2",
+                ],
+            },
+            [True, True, True, True, True, True],
+        ),
+    ],
+)
+def test_has_different_values(data, expected_result):
+    table_name = "test_has_different_values"
+    tds = PostgresQLDataService.from_column_data(table_name=table_name, column_data=data)
+    sql_ops = PostgresQLOperators({"validation_dataset_id": table_name, "sql_data_service": tds})
+    result = sql_ops.has_different_values({"target": "target"})
+    assert result.equals(pd.Series(expected_result))
+
+
+@pytest.mark.parametrize(
+    "data, expected_result",
+    [
+        (
+            {
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP3",
+                    "AEHOSP2",
+                    "AEHOSP2",
+                ],
+            },
+            [False, False, False, False, False, False],
+        ),
+        (
+            {
+                "target": [
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                    "AEHOSP1",
+                ],
+            },
+            [True, True, True, True, True, True],
+        ),
+    ],
+)
+def test_has_same_values(data, expected_result):
+    """
+    Unit test for the SQL-based has_same_values operator.
+    """
+    table_name = "test_has_same_values"
+    tds = PostgresQLDataService.from_column_data(table_name=table_name, column_data=data)
+    sql_ops = PostgresQLOperators({"validation_dataset_id": table_name, "sql_data_service": tds})
+    result = sql_ops.has_same_values({"target": "target"})
+    assert result.equals(pd.Series(expected_result))

--- a/tests/unit/test_check_operators/test_sql_relationship_integrity_checks.py
+++ b/tests/unit/test_check_operators/test_sql_relationship_integrity_checks.py
@@ -65,9 +65,6 @@ def test_has_different_values(data, expected_result):
     ],
 )
 def test_has_same_values(data, expected_result):
-    """
-    Unit test for the SQL-based has_same_values operator.
-    """
     table_name = "test_has_same_values"
     tds = PostgresQLDataService.from_column_data(table_name=table_name, column_data=data)
     sql_ops = PostgresQLOperators({"validation_dataset_id": table_name, "sql_data_service": tds})


### PR DESCRIPTION
Adds has_different_values and has_same values check operators. This is part of the relationship integrity checks test file.

Close https://github.com/verisianHQ/cdisc-rules-engine/issues/116 
Close https://github.com/verisianHQ/cdisc-rules-engine/issues/117

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210950886060749
  - https://app.asana.com/0/0/1210950757098843