### PR TITLE
fix: SQL schema changes

### DIFF
--- a/cdisc_rules_engine/data_service/schemas/clinical_data_metadata_schema.sql
+++ b/cdisc_rules_engine/data_service/schemas/clinical_data_metadata_schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS public.data_metadata (
     -- general fields
-    id SERIAL PRIMARY KEY,
+    id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     created_at TIMESTAMPTZ,
     updated_at TIMESTAMPTZ,
     -- general dataset metadata

--- a/cdisc_rules_engine/data_service/schemas/xml/analysis_results.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/analysis_results.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS analysis_results (
-    result_id SERIAL PRIMARY KEY,
+    result_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     version_id INTEGER NOT NULL REFERENCES metadata_versions(version_id),
     result_oid VARCHAR(200) NOT NULL,
     display_oid VARCHAR(200),

--- a/cdisc_rules_engine/data_service/schemas/xml/codelist_items.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/codelist_items.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS codelist_items (
-    item_id SERIAL PRIMARY KEY,
+    item_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     codelist_id INTEGER NOT NULL REFERENCES codelists(codelist_id),
     coded_value VARCHAR(500),
     decode_text TEXT,

--- a/cdisc_rules_engine/data_service/schemas/xml/codelists.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/codelists.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS codelists (
-    codelist_id SERIAL PRIMARY KEY,
+    codelist_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     version_id INTEGER NOT NULL REFERENCES metadata_versions(version_id),
     codelist_oid VARCHAR(200) NOT NULL,
     codelist_name VARCHAR(200),

--- a/cdisc_rules_engine/data_service/schemas/xml/comments.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/comments.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS comments (
-    comment_id SERIAL PRIMARY KEY,
+    comment_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     version_id INTEGER NOT NULL REFERENCES metadata_versions(version_id),
     comment_oid VARCHAR(200) NOT NULL,
     comment_text TEXT,

--- a/cdisc_rules_engine/data_service/schemas/xml/dataset_variables.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/dataset_variables.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS dataset_variables (
-    dataset_var_id SERIAL PRIMARY KEY,
+    dataset_var_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     dataset_id INTEGER NOT NULL REFERENCES datasets(dataset_id),
     variable_id INTEGER NOT NULL REFERENCES variables(variable_id),
     order_number INTEGER,

--- a/cdisc_rules_engine/data_service/schemas/xml/datasets.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/datasets.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS datasets (
-    dataset_id SERIAL PRIMARY KEY,
+    dataset_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     version_id INTEGER NOT NULL REFERENCES metadata_versions(version_id),
     dataset_oid VARCHAR(200) NOT NULL,
     domain VARCHAR(10),

--- a/cdisc_rules_engine/data_service/schemas/xml/documents.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/documents.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS documents (
-    document_id SERIAL PRIMARY KEY,
+    document_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     version_id INTEGER NOT NULL REFERENCES metadata_versions(version_id),
     leaf_id VARCHAR(200) NOT NULL,
     href VARCHAR(500),

--- a/cdisc_rules_engine/data_service/schemas/xml/metadata_versions.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/metadata_versions.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS metadata_versions (
-    version_id SERIAL PRIMARY KEY,
+    version_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     study_id INTEGER NOT NULL REFERENCES studies(study_id),
     version_oid VARCHAR(200) NOT NULL,
     version_name VARCHAR(500),

--- a/cdisc_rules_engine/data_service/schemas/xml/methods.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/methods.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS methods (
-    method_id SERIAL PRIMARY KEY,
+    method_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     version_id INTEGER NOT NULL REFERENCES metadata_versions(version_id),
     method_oid VARCHAR(200) NOT NULL,
     method_name VARCHAR(500),

--- a/cdisc_rules_engine/data_service/schemas/xml/studies.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/studies.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS studies (
-    study_id SERIAL PRIMARY KEY,
+    study_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     study_oid VARCHAR(100) UNIQUE NOT NULL,
     study_name VARCHAR(200),
     study_description TEXT,

--- a/cdisc_rules_engine/data_service/schemas/xml/value_list_items.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/value_list_items.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS value_list_items (
-    value_item_id SERIAL PRIMARY KEY,
+    value_item_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     value_list_id INTEGER NOT NULL REFERENCES value_lists(value_list_id),
     item_oid VARCHAR(200),
     order_number INTEGER,

--- a/cdisc_rules_engine/data_service/schemas/xml/value_lists.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/value_lists.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS value_lists (
-    value_list_id SERIAL PRIMARY KEY,
+    value_list_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     version_id INTEGER NOT NULL REFERENCES metadata_versions(version_id),
     value_list_oid VARCHAR(200) NOT NULL,
     UNIQUE (version_id, value_list_oid)

--- a/cdisc_rules_engine/data_service/schemas/xml/variable_codelist_refs.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/variable_codelist_refs.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS variable_codelist_refs (
-    ref_id SERIAL PRIMARY KEY,
+    ref_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     variable_id INTEGER NOT NULL REFERENCES variables(variable_id),
     codelist_id INTEGER NOT NULL REFERENCES codelists(codelist_id),
     UNIQUE (variable_id, codelist_id)

--- a/cdisc_rules_engine/data_service/schemas/xml/variable_value_lists.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/variable_value_lists.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS variable_value_lists (
-    ref_id SERIAL PRIMARY KEY,
+    ref_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     variable_id INTEGER NOT NULL REFERENCES variables(variable_id),
     value_list_id INTEGER NOT NULL REFERENCES value_lists(value_list_id),
     UNIQUE (variable_id, value_list_id)

--- a/cdisc_rules_engine/data_service/schemas/xml/variables.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/variables.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS variables (
-    variable_id SERIAL PRIMARY KEY,
+    variable_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     version_id INTEGER NOT NULL REFERENCES metadata_versions(version_id),
     variable_oid VARCHAR(200) NOT NULL,
     variable_name VARCHAR(40),

--- a/cdisc_rules_engine/data_service/schemas/xml/where_clause_conditions.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/where_clause_conditions.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS where_clause_conditions (
-    condition_id SERIAL PRIMARY KEY,
+    condition_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     where_clause_id INTEGER NOT NULL REFERENCES where_clauses(where_clause_id),
     item_oid VARCHAR(200),
     comparator VARCHAR(10),

--- a/cdisc_rules_engine/data_service/schemas/xml/where_clauses.sql
+++ b/cdisc_rules_engine/data_service/schemas/xml/where_clauses.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS where_clauses (
-    where_clause_id SERIAL PRIMARY KEY,
+    where_clause_id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     version_id INTEGER NOT NULL REFERENCES metadata_versions(version_id),
     where_clause_oid VARCHAR(200) NOT NULL,
     UNIQUE (version_id, where_clause_oid)

--- a/cdisc_rules_engine/data_service/sql_data_preprocessor.py
+++ b/cdisc_rules_engine/data_service/sql_data_preprocessor.py
@@ -2,15 +2,14 @@
 Data Preprocessor for SDTM and ADaM clinical data.
 """
 
-import logging
-from datetime import datetime
-from typing import Dict, List, Optional, Set, Any
-from collections import defaultdict
 import json
+import logging
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set
 
-
-from cdisc_rules_engine.data_service.sql_interface import PostgresQLInterface
 from cdisc_rules_engine.data_service.db_cache import DBCache
+from cdisc_rules_engine.data_service.sql_interface import PostgresQLInterface
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +73,7 @@ class DataPreprocessor:
         """Create table to store preprocessing results."""
         create_table_query = """
             CREATE TABLE IF NOT EXISTS public.preprocessing_results (
-                id SERIAL PRIMARY KEY,
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
                 run_id UUID DEFAULT gen_random_uuid(),
                 timestamp TIMESTAMPTZ NOT NULL,
                 stage TEXT NOT NULL,
@@ -96,7 +95,7 @@ class DataPreprocessor:
 
         validation_errors_table = """
             CREATE TABLE IF NOT EXISTS public.preprocessing_validation_errors (
-                id SERIAL PRIMARY KEY,
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
                 run_id UUID,
                 validation_type TEXT NOT NULL,
                 source_table TEXT,

--- a/cdisc_rules_engine/data_service/sql_serialiser.py
+++ b/cdisc_rules_engine/data_service/sql_serialiser.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Dict, Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 
 class SQLSerialiser:
@@ -8,7 +8,7 @@ class SQLSerialiser:
     def python_to_sql_type(value: Any) -> str:
         """Map python types to SQL types."""
         if isinstance(value, (int, float)):
-            return "REAL"
+            return "DOUBLE PRECISION"
         elif isinstance(value, str):
             return "TEXT"
         else:
@@ -20,7 +20,7 @@ class SQLSerialiser:
         if type.lower() in ("char", "s"):
             return "TEXT"
         elif type.lower() in ("num", "numeric", "d"):
-            return "REAL"
+            return "DOUBLE PRECISION"
         else:
             raise ValueError(f"Unsupported type: {type}")
 
@@ -42,9 +42,13 @@ class SQLSerialiser:
 
         if len(columns) > 0:
             columns_sql = ",\n    ".join(columns)
-            return f"CREATE TABLE IF NOT EXISTS {table_name} (\n id SERIAL PRIMARY KEY, {columns_sql}\n);"
+            return f"""CREATE TABLE IF NOT EXISTS {table_name} (
+                    id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY, {columns_sql}
+                );"""
         else:
-            return f"CREATE TABLE IF NOT EXISTS {table_name} (\n id SERIAL PRIMARY KEY \n);"
+            return f"""CREATE TABLE IF NOT EXISTS {table_name} (
+                        id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY
+                    );"""
 
     @classmethod
     def create_table_query_from_data_metadata_dict(
@@ -63,9 +67,13 @@ class SQLSerialiser:
 
         if len(columns) > 0:
             columns_sql = ",\n    ".join(columns)
-            return f"CREATE TABLE IF NOT EXISTS {table_name} (\n id SERIAL PRIMARY KEY, {columns_sql}\n);"
+            return f"""CREATE TABLE IF NOT EXISTS {table_name} (
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY, {columns_sql}
+            );"""
         else:
-            return f"CREATE TABLE IF NOT EXISTS {table_name} (\n id SERIAL PRIMARY KEY \n);"
+            return f"""CREATE TABLE IF NOT EXISTS {table_name} (
+                    id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY
+                );"""
 
     @classmethod
     def insert_dict(cls, table_name: str, data: Dict[str, Any]) -> Tuple[str, List[Any]]:


### PR DESCRIPTION
Updates the SQL schemas to a more modern style (`generated always as identity` rather than `serial`)

Switches from `REAL`(float) to `DOUBLE PRECISION`, as SAS uses doubles and otherwise we may lose data

No regression changes