### PR TITLE
feat: Initial operations logic

### DIFF
--- a/cdisc_rules_engine/check_operators/sql_operators.py
+++ b/cdisc_rules_engine/check_operators/sql_operators.py
@@ -67,6 +67,7 @@ class PostgresQLOperators(BaseType):
         self.value_level_metadata = data.get("value_level_metadata", [])
         self.column_codelist_map = data.get("column_codelist_map", {})
         self.codelist_term_maps = data.get("codelist_term_maps", [])
+        self.operation_variables = data.get("operation_variables", {})
 
     def _assert_valid_value_and_cast(self, value):
         return value

--- a/cdisc_rules_engine/check_operators/sql_operators.py
+++ b/cdisc_rules_engine/check_operators/sql_operators.py
@@ -496,7 +496,7 @@ class PostgresQLOperators(BaseType):
         other_value: dict,
         operator: str,
     ):
-        target_column = self.replace_prefix(other_value.get("target")).lower()
+        target_column = self.replace_prefix(other_value.get("target"))
         comparator = (
             other_value.get("comparator").lower()
             if isinstance(other_value.get("comparator"), str)

--- a/cdisc_rules_engine/data_service/db_cache.py
+++ b/cdisc_rules_engine/data_service/db_cache.py
@@ -35,37 +35,37 @@ class DBCache:
         return {k: v["db_table"] for k, v in self.cache.items()}
 
     def get_db_table_cache(self, table_key: str) -> Union[DBTableCache, None]:
-        return self.cache.get(table_key, None)
+        return self.cache.get(table_key.lower(), None)
 
     def get_db_table_hash(self, table_key: str) -> Union[str, None]:
-        if self.get_db_table_cache(table_key):
-            return self.get_db_table_cache(table_key).get("db_table", None)
+        if self.get_db_table_cache(table_key.lower()):
+            return self.get_db_table_cache(table_key.lower()).get("db_table", None)
         return None
 
     def get_columns(self, table_key: str) -> dict:
-        if self.get_db_table_cache(table_key):
-            return self.get_db_table_cache(table_key).get("columns", {})
+        if self.get_db_table_cache(table_key.lower()):
+            return self.get_db_table_cache(table_key.lower()).get("columns", {})
         return {}
 
     def get_db_column_hash(self, table_key: str, column_key: str) -> Union[str, None]:
-        if self.get_columns(table_key):
-            return self.get_columns(table_key).get(column_key, None)
+        if self.get_columns(table_key.lower()):
+            return self.get_columns(table_key.lower()).get(column_key.lower(), None)
 
     def add_db_column_if_missing(self, table_key: str, column_key: str) -> Tuple[bool, str, str]:
-        existing_column_hash = self.get_db_column_hash(table_key, column_key)
+        existing_column_hash = self.get_db_column_hash(table_key.lower(), column_key.lower())
         if existing_column_hash is not None:
             return (True, column_key, existing_column_hash)
         else:
-            column_hash = generate_hash(column_key)
-            self.get_db_table_cache(table_key).get("columns")[column_key] = column_hash
+            column_hash = generate_hash(column_key.lower())
+            self.get_db_table_cache(table_key.lower()).get("columns")[column_key.lower()] = column_hash
             return (False, column_key, column_hash)
 
     def add_db_table_if_missing(self, table_key: str, columns: dict[str, str]) -> Tuple[bool, str, str]:
-        existing_table_hash = self.get_db_table_hash(table_key)
+        existing_table_hash = self.get_db_table_hash(table_key.lower())
         if existing_table_hash is not None:
             return (True, table_key, existing_table_hash)
         else:
-            table_hash = generate_hash(table_key)
+            table_hash = generate_hash(table_key.lower())
             self.cache[table_key] = DBTableCache(db_table=table_key, columns=columns)
             # now comes the tricky part, which is to add columns...
             return (False, table_key, table_hash)

--- a/cdisc_rules_engine/models/sql_operation_params.py
+++ b/cdisc_rules_engine/models/sql_operation_params.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class SqlOperationParams:
+    """
+    This class defines input parameters for rule operations.
+    Rule operations are defined in DataProcessor class.
+    """
+
+    # Required parameters (no defaults) first
+    domain: str
+    standard: str
+    standard_version: str
+    target: str
+    grouping: bool = False  # Add later?
+
+    # Optional parameters with defaults
+    # standard_substandard: str = None
+    # attribute_name: str = None
+    # case_sensitive: bool = True
+    # codelist: str = None
+    # codelist_code: str = None
+    # codelists: list = None
+    # ct_attribute: str = None
+    # ct_package_types: List[str] = None
+    # ct_package: list = None
+    # ct_packages: list = None
+    # ct_version: str = None
+    # ct_package_type: str = None
+    # term_code: str = None
+    # term_value: str = None
+    # dictionary_term_type: str = None
+    # external_dictionaries: ExternalDictionariesContainer = None
+    # external_dictionary_term_variable: str = None
+    # external_dictionary_type: str = None
+    # filter: dict = None
+    # grouping: List[str] = None
+    # grouping_aliases: List[str] = None
+    # key_name: str = None
+    # key_value: str = None
+    # level: str = None
+    # map: List[dict] = None
+    # original_target: str = None
+    # returntype: str = None
+    # target: str = None

--- a/cdisc_rules_engine/sql_operations/__init__.py
+++ b/cdisc_rules_engine/sql_operations/__init__.py
@@ -1,0 +1,5 @@
+from cdisc_rules_engine.sql_operations.sql_operations_factory import (
+    SqlOperationsFactory,
+)
+
+sql_operations_factory = SqlOperationsFactory()

--- a/cdisc_rules_engine/sql_operations/distinct.py
+++ b/cdisc_rules_engine/sql_operations/distinct.py
@@ -8,7 +8,7 @@ class SqlDistinct(SqlBaseOperation):
         if not self.params.grouping:
             cache = self.data_service.cache
             dataset_id = cache.get_db_table_hash(self.params.domain)
-            column_id = cache.get_db_table_hash(self.params.target)
+            column_id = cache.get_db_column_hash(self.params.domain, self.params.target)
             return f"(SELECT DISTINCT {column_id} FROM {dataset_id})"
         else:
             """grouped = self.params.dataframe.groupby(self.params.grouping, as_index=False, group_keys=False).data

--- a/cdisc_rules_engine/sql_operations/distinct.py
+++ b/cdisc_rules_engine/sql_operations/distinct.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
+
+
+class SqlDistinct(SqlBaseOperation):
+    def _execute_operation(self):
+        if not self.params.grouping:
+            cache = self.data_service.cache
+            dataset_id = cache.get_db_table_hash(self.params.domain)
+            column_id = cache.get_db_table_hash(self.params.target)
+            return f"(SELECT DISTINCT {column_id} FROM {dataset_id})"
+        else:
+            """grouped = self.params.dataframe.groupby(self.params.grouping, as_index=False, group_keys=False).data
+            if isinstance(self.params.dataframe.data, pd.DataFrame):
+                result = grouped[self.params.target].agg(self._unique_values_for_column)
+            else:
+                result = grouped[self.params.target].unique().rename({self.params.target: self.params.operation_id})
+                result = result.apply(set).to_frame().reset_index()"""
+            raise NotImplementedError("Grouping functionality is not implemented yet.")
+
+    def _unique_values_for_column(self, column):
+        return pd.Series({self.params.operation_id: set(column.unique())})

--- a/cdisc_rules_engine/sql_operations/maximum.py
+++ b/cdisc_rules_engine/sql_operations/maximum.py
@@ -1,0 +1,15 @@
+from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
+
+
+class SqlMaximum(SqlBaseOperation):
+    def _execute_operation(self):
+        if not self.params.grouping:
+            cache = self.data_service.cache
+            dataset_id = cache.get_db_table_hash(self.params.domain)
+            column_id = cache.get_db_column_hash(self.params.domain, self.params.target)
+            return f"(SELECT MAX({column_id}) FROM {dataset_id})"
+        else:
+            """result = self.params.dataframe.groupby(
+                self.params.grouping, as_index=False
+            ).data.max()"""
+            raise NotImplementedError("Grouping functionality is not implemented yet.")

--- a/cdisc_rules_engine/sql_operations/sql_base_operation.py
+++ b/cdisc_rules_engine/sql_operations/sql_base_operation.py
@@ -38,9 +38,9 @@ class SqlBaseOperation:
         Custom exceptions should be allowed to propagate up while other exceptions are logged.
         """
         try:
-            logger.info(f"Starting operation {self.params.operation_name}")
+            logger.info(f"Starting operation {self.__class__.__name__}")
             result = self._execute_operation()
-            logger.info(f"Operation {self.params.operation_name} completed.")
+            logger.info(f"Operation {self.__class__.__name__} completed.")
             return result
         except (
             EngineError,
@@ -58,12 +58,12 @@ class SqlBaseOperation:
             UnsupportedDictionaryType,
             FailedSchemaValidation,
         ) as e:
-            logger.debug(f"error in operation {self.params.operation_name}: {str(e)}")
+            logger.debug(f"error in operation {self.__class__.__name__}: {str(e)}")
             raise
         except Exception as e:
             # Log unexpected errors
             logger.error(
-                f"error in operation {self.params.operation_name}: {str(e)}",
+                f"error in operation {self.__class__.__name__}: {str(e)}",
                 exc_info=True,
             )
             # error_message = str(e)

--- a/cdisc_rules_engine/sql_operations/sql_base_operation.py
+++ b/cdisc_rules_engine/sql_operations/sql_base_operation.py
@@ -1,0 +1,89 @@
+from abc import abstractmethod
+
+from cdisc_rules_engine.data_service.postgresql_data_service import (
+    PostgresQLDataService,
+)
+from cdisc_rules_engine.exceptions.custom_exceptions import (
+    DatasetNotFoundError,
+    DomainNotFoundInDefineXMLError,
+    EngineError,
+    FailedSchemaValidation,
+    InvalidDatasetFormat,
+    InvalidDictionaryVariable,
+    InvalidMatchKeyError,
+    MissingDataError,
+    NumberOfAttemptsExceeded,
+    ReferentialIntegrityError,
+    RuleExecutionError,
+    RuleFormatError,
+    UnsupportedDictionaryType,
+    VariableMetadataNotFoundError,
+)
+from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
+from cdisc_rules_engine.services import logger
+
+
+class SqlBaseOperation:
+    def __init__(self, params: SqlOperationParams, data_service: PostgresQLDataService):
+        self.params = params
+        self.data_service = data_service
+
+    @abstractmethod
+    def _execute_operation(self):
+        raise NotImplementedError(f"Operation {self.__class__.__name__} exists but is not implemented")
+
+    def execute(self) -> str:
+        """
+        Execute the operation with error handling.
+        Custom exceptions should be allowed to propagate up while other exceptions are logged.
+        """
+        try:
+            logger.info(f"Starting operation {self.params.operation_name}")
+            result = self._execute_operation()
+            logger.info(f"Operation {self.params.operation_name} completed.")
+            return result
+        except (
+            EngineError,
+            DatasetNotFoundError,
+            ReferentialIntegrityError,
+            MissingDataError,
+            RuleExecutionError,
+            RuleFormatError,
+            InvalidMatchKeyError,
+            VariableMetadataNotFoundError,
+            DomainNotFoundInDefineXMLError,
+            InvalidDatasetFormat,
+            NumberOfAttemptsExceeded,
+            InvalidDictionaryVariable,
+            UnsupportedDictionaryType,
+            FailedSchemaValidation,
+        ) as e:
+            logger.debug(f"error in operation {self.params.operation_name}: {str(e)}")
+            raise
+        except Exception as e:
+            # Log unexpected errors
+            logger.error(
+                f"error in operation {self.params.operation_name}: {str(e)}",
+                exc_info=True,
+            )
+            # error_message = str(e)
+            # if isinstance(e, TypeError) and any(
+            #     phrase in error_message
+            #     for phrase in [
+            #         "NoneType",
+            #         "None",
+            #         "object is None",
+            #         "'NoneType'",
+            #         "None has no attribute",
+            #         "unsupported operand type",
+            #         "bad operand type",
+            #         "object is not",
+            #         "cannot be None",
+            #     ]
+            # ):
+            #     return None
+            raise
+
+    @staticmethod
+    def _replace_variable_wildcards(variables_metadata, domain):
+        return [var["name"].replace("--", domain) for var in variables_metadata]

--- a/cdisc_rules_engine/sql_operations/sql_operations_factory.py
+++ b/cdisc_rules_engine/sql_operations/sql_operations_factory.py
@@ -3,6 +3,7 @@ from cdisc_rules_engine.data_service.postgresql_data_service import (
 )
 from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
 from cdisc_rules_engine.sql_operations.distinct import SqlDistinct
+from cdisc_rules_engine.sql_operations.maximum import SqlMaximum
 from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
 
 
@@ -22,7 +23,7 @@ class SqlOperationsFactory:
         "get_model_filtered_variables": None,
         "get_parent_model_column_order": None,
         "map": None,
-        "max": None,
+        "max": SqlMaximum,
         "max_date": None,
         "mean": None,
         "min": None,

--- a/cdisc_rules_engine/sql_operations/sql_operations_factory.py
+++ b/cdisc_rules_engine/sql_operations/sql_operations_factory.py
@@ -1,0 +1,73 @@
+from cdisc_rules_engine.data_service.postgresql_data_service import (
+    PostgresQLDataService,
+)
+from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
+from cdisc_rules_engine.sql_operations.distinct import SqlDistinct
+from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
+
+
+class SqlOperationsFactory:
+    _operations_map = {
+        "codelist_extensible": None,
+        "codelist_terms": None,
+        "dataset_names": None,
+        "define_extensible_codelists": None,
+        "distinct": SqlDistinct,
+        "dy": None,
+        "extract_metadata": None,
+        "get_column_order_from_dataset": None,
+        "get_column_order_from_library": None,
+        "get_codelist_attributes": None,
+        "get_model_column_order": None,
+        "get_model_filtered_variables": None,
+        "get_parent_model_column_order": None,
+        "map": None,
+        "max": None,
+        "max_date": None,
+        "mean": None,
+        "min": None,
+        "min_date": None,
+        "record_count": None,
+        "valid_meddra_code_references": None,
+        "valid_whodrug_references": None,
+        "whodrug_code_hierarchy": None,
+        "valid_meddra_term_references": None,
+        "valid_meddra_code_term_pairs": None,
+        "variable_exists": None,
+        "variable_names": None,
+        "variable_library_metadata": None,
+        "variable_value_count": None,
+        "variable_count": None,
+        "variable_is_null": None,
+        "domain_is_custom": None,
+        "domain_label": None,
+        "required_variables": None,
+        "expected_variables": None,
+        "permissible_variables": None,
+        "study_domains": None,
+        "valid_codelist_dates": None,
+        "label_referenced_variable_metadata": None,
+        "name_referenced_variable_metadata": None,
+        "define_variable_metadata": None,
+        "valid_external_dictionary_value": None,
+        "valid_external_dictionary_code": None,
+        "valid_external_dictionary_code_term_pair": None,
+        "valid_define_external_dictionary_version": None,
+        "get_dataset_filtered_variables": None,
+    }
+
+    def get_service(
+        self,
+        name: str,
+        params: SqlOperationParams,
+        data_service: PostgresQLDataService,
+    ) -> SqlBaseOperation:
+        if name in self._operations_map:
+            operation = self._operations_map.get(name)
+            if operation is None:
+                raise NotImplementedError(f"Operation {name} is not implemented")
+            return operation(params, data_service)
+
+        raise ValueError(
+            f"Operation name must be in  {list(self._operations_map.keys())}, " f"given operation name is {name}"
+        )

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -1,8 +1,11 @@
 import re
+from ast import Dict
 from typing import List, Optional, Set, Tuple
-from cdisc_rules_engine.data_service.postgresql_data_service import SQLDatasetMetadata
-from cdisc_rules_engine.models.library_metadata_container import (
-    LibraryMetadataContainer,
+
+from cdisc_rules_engine.config import config as default_config
+from cdisc_rules_engine.data_service.postgresql_data_service import (
+    PostgresQLDataService,
+    SQLDatasetMetadata,
 )
 
 # import os
@@ -18,14 +21,17 @@ from cdisc_rules_engine.models.library_metadata_container import (
 # from cdisc_rules_engine.constants.rule_constants import ALL_KEYWORD
 # from cdisc_rules_engine.constants.use_cases import USE_CASE_DOMAINS
 from cdisc_rules_engine.interfaces import ConditionInterface
+from cdisc_rules_engine.models.library_metadata_container import (
+    LibraryMetadataContainer,
+)
 
 # from cdisc_rules_engine.models.operation_params import OperationParams
-
 # from cdisc_rules_engine.models.rule_conditions import AllowedConditionsKeys
 # from cdisc_rules_engine.operations import operations_factory
+from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
 from cdisc_rules_engine.services import logger
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
-from cdisc_rules_engine.config import config as default_config
+from cdisc_rules_engine.sql_operations import sql_operations_factory
 
 # from cdisc_rules_engine.utilities.data_processor import DataProcessor
 # from cdisc_rules_engine.utilities.utils import (
@@ -272,162 +278,46 @@ class SQLRuleProcessor:
     #         return None
     #     return f"{ct_package_type.lower()}ct"
 
-    # TODO: this is where operations are triggered
     def perform_rule_operations(
         self,
         rule: dict,
-        dataset_id: str,
-        # dataset: DatasetInterface,
-        # domain: str,
-        # datasets: Iterable[SDTMDatasetMetadata],
-        # dataset_path: str,
-        standard: str,
-        standard_version: str,
-        standard_substandard: str,
-        # external_dictionaries: ExternalDictionariesContainer = ExternalDictionariesContainer(),
-        **kwargs,
-    ) -> str:
+        domain: str,
+        data_service: PostgresQLDataService,
+    ) -> Dict[str, str]:
         """
-        Applies rule operations to the dataset.
-        Returns the processed dataset. Operation result is appended as a new column.
+        Each operation creates an output variable
         """
         operations: List[dict] = rule.get("operations") or []
-        if not operations:
-            # stop function execution if no operations have been provided
-            return dataset_id
+        output_variables: Dict[str, str] = {}
 
-        # dataset_copy = dataset.copy()
-        # previous_operations = []
-        # for operation in operations:
-        #     # change -- pattern to domain name
-        #     original_target: str = operation.get("name")
-        #     target: str = original_target
-        #     domain: str = operation.get("domain", domain)
-        #     if target and target.startswith("--") and domain:
-        #         # Not a study wide operation
-        #         target = target.replace("--", domain)
-        #         domain = domain.replace("--", domain)
+        for operation in operations:
+            name = operation.get("operator")
+            output_variable = operation.get("id")
+            # change -- pattern to domain name
+            original_target: str = operation.get("name")
+            target: str = original_target
+            domain: str = operation.get("domain", domain)
+            if target and target.startswith("--") and domain:
+                # Not a study wide operation
+                target = target.replace("--", domain)
 
-        #     # get necessary operation
-        #     operation_params = OperationParams(
-        #         core_id=rule.get("core_id"),
-        #         operation_id=operation.get("id"),
-        #         operation_name=operation.get("operator"),
-        #         dataframe=dataset_copy,
-        #         target=target,
-        #         original_target=original_target,
-        #         domain=domain,
-        #         dataset_path=dataset_path,
-        #         directory_path=get_directory_path(dataset_path),
-        #         datasets=datasets,
-        #         grouping=operation.get("group", []),
-        #         standard=standard,
-        #         standard_version=standard_version,
-        #         standard_substandard=standard_substandard,
-        #         external_dictionaries=external_dictionaries,
-        #         ct_version=operation.get("version"),
-        #         ct_package_type=SQLRuleProcessor._ct_package_type_api_name(operation.get("ct_package_type")),
-        #         ct_attribute=operation.get("attribute"),
-        #         ct_package_types=[
-        #             SQLRuleProcessor._ct_package_type_api_name(ct_package_type)
-        #             for ct_package_type in operation.get("ct_package_types", [])
-        #         ],
-        #         ct_packages=kwargs.get("ct_packages"),
-        #         ct_package=kwargs.get("codelist_term_maps"),
-        #         attribute_name=operation.get("attribute_name", ""),
-        #         key_name=operation.get("key_name", ""),
-        #         key_value=operation.get("key_value", ""),
-        #         case_sensitive=operation.get("case_sensitive", True),
-        #         external_dictionary_type=operation.get("external_dictionary_type"),
-        #         external_dictionary_term_variable=operation.get("external_dictionary_term_variable"),
-        #         dictionary_term_type=operation.get("dictionary_term_type"),
-        #         filter=operation.get("filter", None),
-        #         grouping_aliases=operation.get("group_aliases"),
-        #         level=operation.get("level"),
-        #         returntype=operation.get("returntype"),
-        #         codelists=operation.get("codelists"),
-        #         codelist=operation.get("codelist"),
-        #         codelist_code=operation.get("codelist_code"),
-        #         map=operation.get("map"),
-        #         term_code=operation.get("term_code"),
-        #         term_value=operation.get("term_value"),
-        #     )
+                # TODO: WTF is this line doing?
+                # domain = domain.replace("--", domain)
 
-        #     # execute operation
-        #     dataset_copy = self._execute_operation(operation_params, dataset_copy, previous_operations)
-        #     previous_operations.append(operation_params.operation_name)
+            # build parameters for the operation
+            params = SqlOperationParams(
+                domain=domain,
+                target=target,
+                standard=data_service.ig_specs.get("standard"),
+                standard_version=data_service.ig_specs.get("standard_version"),
+            )
 
-        #     logger.info(f"Processed rule operation. " f"operation={operation_params.operation_name}, rule={rule}")
-        return dataset_id
+            operation = sql_operations_factory.get_service(name, params=params, data_service=data_service)
+            query = operation.execute()
+            output_variables[output_variable] = query
 
-    # def _execute_operation(
-    #     self,
-    #     operation_params: OperationParams,
-    #     dataset: DatasetInterface,
-    #     previous_operations: List[str] = [],
-    # ):
-    #     """
-    #     Internal method that executes the given operation.
-    #     Checks the cache first, if the operation result is not found
-    #     in cache -> executes it and adds to the cache.
-    #     """
-    #     # check cache
-    #     cache_key = get_operations_cache_key(
-    #         core_id=operation_params.core_id,
-    #         directory_path=operation_params.directory_path,
-    #         operation_name=operation_params.operation_name,
-    #         domain=operation_params.domain,
-    #         grouping=";".join(operation_params.grouping),
-    #         target_variable=operation_params.target,
-    #         dataset_path=operation_params.dataset_path,
-    #         operation_id=operation_params.operation_id,
-    #     )
-    #     if previous_operations:
-    #         cache_key = f'{cache_key}-{";".join(previous_operations)}'
-    #     result: DatasetInterface = self.cache.get(cache_key)
-    #     if result is not None:
-    #         return result
-
-    #     if not self.is_current_domain(operation_params.dataframe, operation_params.domain):
-    #         # download other domain
-    #         domain_details: dict = search_in_list_of_dicts(
-    #             operation_params.datasets,
-    #             lambda item: item.unsplit_name == operation_params.domain,
-    #         )
-    #         if domain_details is None:
-    #             raise DomainNotFoundError(
-    #                 f"Operation {operation_params.operation_name} requires Domain "
-    #                 f"{operation_params.domain} but Domain not found in dataset"
-    #             )
-    #         filename = get_dataset_name_from_details(domain_details)
-    #         file_path: str = os.path.join(
-    #             get_directory_path(operation_params.dataset_path),
-    #             filename,
-    #         )
-    #         operation_params.dataframe = self.data_service.get_dataset(dataset_name=file_path)
-
-    #     # call the operation
-    #     operation = operations_factory.get_service(
-    #         operation_params.operation_name,
-    #         operation_params=operation_params,
-    #         original_dataset=dataset,
-    #         cache=self.cache,
-    #         data_service=self.data_service,
-    #         library_metadata=self.library_metadata,
-    #     )
-    #     result = operation.execute()
-    #     if not DataProcessor.is_dummy_data(self.data_service):
-    #         self.cache.add(cache_key, result)
-    #     return result
-
-    # def is_current_domain(self, dataset, target_domain):
-    #     if not target_domain:
-    #         return True
-    #     elif not self.is_relationship_dataset(target_domain):
-    #         return "DOMAIN" in dataset and dataset["DOMAIN"].iloc[0] == target_domain
-    #     else:
-    #         # Always lookup relationship datasets when performing operations on them.
-    #         return False
+            logger.info(f"Processed rule operation. " f"operation={name}, rule={rule}")
+        return output_variables
 
     # def is_relationship_dataset(self, dataset_name: str) -> bool:
     #     # TODO: this should come from the library and from the dataset metadata

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -1,5 +1,4 @@
 import re
-from ast import Dict
 from typing import List, Optional, Set, Tuple
 
 from cdisc_rules_engine.config import config as default_config
@@ -281,42 +280,48 @@ class SQLRuleProcessor:
     def perform_rule_operations(
         self,
         rule: dict,
-        domain: str,
+        current_domain: str,
         data_service: PostgresQLDataService,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         """
         Each operation creates an output variable
         """
         operations: List[dict] = rule.get("operations") or []
-        output_variables: Dict[str, str] = {}
+        output_variables: dict[str, str] = {}
 
         for operation in operations:
-            name = operation.get("operator")
-            output_variable = operation.get("id")
+            rule_name = operation.get("operator", "")
+            output_variable = operation.get("id", "")
+
+            if not output_variable.startswith("$"):
+                raise ValueError(
+                    f"Output variable must start with '$', "
+                    f"but got '{output_variable}' in rule {rule.get('core_id', 'unknown')}"
+                )
+
             # change -- pattern to domain name
-            original_target: str = operation.get("name")
-            target: str = original_target
-            domain: str = operation.get("domain", domain)
-            if target and target.startswith("--") and domain:
+            target_variable: str = operation.get("name")
+            operation_domain: str = operation.get("domain", current_domain)
+            if target_variable and target_variable.startswith("--") and current_domain:
                 # Not a study wide operation
-                target = target.replace("--", domain)
+                target_variable = target_variable.replace("--", current_domain)
 
                 # TODO: WTF is this line doing?
                 # domain = domain.replace("--", domain)
 
             # build parameters for the operation
             params = SqlOperationParams(
-                domain=domain,
-                target=target,
+                domain=operation_domain,
+                target=target_variable,
                 standard=data_service.ig_specs.get("standard"),
                 standard_version=data_service.ig_specs.get("standard_version"),
             )
 
-            operation = sql_operations_factory.get_service(name, params=params, data_service=data_service)
+            operation = sql_operations_factory.get_service(rule_name, params=params, data_service=data_service)
             query = operation.execute()
             output_variables[output_variable] = query
 
-            logger.info(f"Processed rule operation. " f"operation={name}, rule={rule}")
+            logger.info(f"Processed rule operation. " f"operation={rule_name}, rule={rule}")
         return output_variables
 
     # def is_relationship_dataset(self, dataset_name: str) -> bool:

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -5477,7 +5477,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ecstat\" does not exist\nLINE 1: ...T vvysd1wffdcpr2craguuto0xcgiyatsg8kmtzm8uqywo = (ecstat IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ec.ectrt\".\n"
+                                            "message": "column \"ecstat\" does not exist\nLINE 1: ...c SET vjhsnkywknxhmvnhbyevbx6n21dazufbuvhejogw = (ecstat IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ec.ectrt\".\n"
                                         }
                                     ]
                                 ]
@@ -5492,7 +5492,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"expresp\" does not exist\nLINE 1: ...q6jxlunfdnbicbq9kz4znsblh489slvqlebng1vli = (NOT (expresp IS...\n                                                             ^\n"
+                                            "message": "column \"expresp\" does not exist\nLINE 1: ...vc7nvim9bv416pnsbid2aep6usztvmegxcgivffz4 = (NOT (expresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -5624,7 +5624,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aeoccur\" does not exist\nLINE 1: ... vxxinsoodferefqx8epyaigcvz6bdep8pyhvaeuhirys = ((AEOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"aeoccur\" does not exist\nLINE 1: ... SET vozjgeipaiworw5r2gpvehwjfoer5mrggdy2espg = ((AEOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -5737,7 +5737,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dspresp\" does not exist\nLINE 1: ...v0yuwui1miiau7olqyoj8kn3ivlktqizr71xeaerc = (NOT (dspresp IS...\n                                                             ^\n"
+                                            "message": "column \"dspresp\" does not exist\nLINE 1: ...9fghfjvd6cgbhyeyvvzckn3irgzhitrmlarpnqur0 = (NOT (dspresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -5752,7 +5752,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dvpresp\" does not exist\nLINE 1: ...9sw1vqnwpx6ofpck4y4xarrmvqymajkiwkvttijn4 = (NOT (dvpresp IS...\n                                                             ^\n"
+                                            "message": "column \"dvpresp\" does not exist\nLINE 1: ...mppl4gw1pfa9kqmmsrtueptoeyiqo9h2rz8iqhp1o = (NOT (dvpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -6624,7 +6624,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ecstat\" does not exist\nLINE 1: ...T vvysd1wffdcpr2craguuto0xcgiyatsg8kmtzm8uqywo = (ecstat IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ec.ectrt\".\n"
+                                            "message": "column \"ecstat\" does not exist\nLINE 1: ...c SET vjhsnkywknxhmvnhbyevbx6n21dazufbuvhejogw = (ecstat IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ec.ectrt\".\n"
                                         }
                                     ]
                                 ]
@@ -6639,7 +6639,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"expresp\" does not exist\nLINE 1: ...q6jxlunfdnbicbq9kz4znsblh489slvqlebng1vli = (NOT (expresp IS...\n                                                             ^\n"
+                                            "message": "column \"expresp\" does not exist\nLINE 1: ...vc7nvim9bv416pnsbid2aep6usztvmegxcgivffz4 = (NOT (expresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -6678,7 +6678,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aeoccur\" does not exist\nLINE 1: ... vxxinsoodferefqx8epyaigcvz6bdep8pyhvaeuhirys = ((AEOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"aeoccur\" does not exist\nLINE 1: ... SET vozjgeipaiworw5r2gpvehwjfoer5mrggdy2espg = ((AEOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -6709,7 +6709,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dspresp\" does not exist\nLINE 1: ...v0yuwui1miiau7olqyoj8kn3ivlktqizr71xeaerc = (NOT (dspresp IS...\n                                                             ^\n"
+                                            "message": "column \"dspresp\" does not exist\nLINE 1: ...9fghfjvd6cgbhyeyvvzckn3irgzhitrmlarpnqur0 = (NOT (dspresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -6724,7 +6724,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dvpresp\" does not exist\nLINE 1: ...9sw1vqnwpx6ofpck4y4xarrmvqymajkiwkvttijn4 = (NOT (dvpresp IS...\n                                                             ^\n"
+                                            "message": "column \"dvpresp\" does not exist\nLINE 1: ...mppl4gw1pfa9kqmmsrtueptoeyiqo9h2rz8iqhp1o = (NOT (dvpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -8578,7 +8578,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"exoccur\" does not exist\nLINE 1: ... vrjhotkwvklotvnoosjwjznc50izlnvsjod6bdnlrdq0 = ((EXOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"exoccur\" does not exist\nLINE 1: ...T vp3dtwfmht8k6tw1opvck7j27wn5fstn5795o3qbuuy = ((EXOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -8701,7 +8701,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aeoccur\" does not exist\nLINE 1: ... vxxinsoodferefqx8epyaigcvz6bdep8pyhvaeuhirys = ((AEOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"aeoccur\" does not exist\nLINE 1: ... SET vozjgeipaiworw5r2gpvehwjfoer5mrggdy2espg = ((AEOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -8806,7 +8806,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dsoccur\" does not exist\nLINE 1: ...SET vz538si63amuw93tjhj40x2gszgatnkdwlhhivojw = ((DSOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"dsoccur\" does not exist\nLINE 1: ... v2gdijsbozlewpjr0aolhxawowcrkfpjtlcvnxkocaku = ((DSOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -8821,7 +8821,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dvoccur\" does not exist\nLINE 1: ... vknbkpckcyflnydqwadermxvlidifshl2dqupjzjk1ba = ((DVOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"dvoccur\" does not exist\nLINE 1: ...T vukdxwagcqpvsw1xu6cznaeumeynufeioegthdnvcao = ((DVOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -9689,7 +9689,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"exoccur\" does not exist\nLINE 1: ... vrjhotkwvklotvnoosjwjznc50izlnvsjod6bdnlrdq0 = ((EXOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"exoccur\" does not exist\nLINE 1: ...T vp3dtwfmht8k6tw1opvck7j27wn5fstn5795o3qbuuy = ((EXOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -9728,7 +9728,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aeoccur\" does not exist\nLINE 1: ... vxxinsoodferefqx8epyaigcvz6bdep8pyhvaeuhirys = ((AEOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"aeoccur\" does not exist\nLINE 1: ... SET vozjgeipaiworw5r2gpvehwjfoer5mrggdy2espg = ((AEOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -9759,7 +9759,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dsoccur\" does not exist\nLINE 1: ...SET vz538si63amuw93tjhj40x2gszgatnkdwlhhivojw = ((DSOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"dsoccur\" does not exist\nLINE 1: ... v2gdijsbozlewpjr0aolhxawowcrkfpjtlcvnxkocaku = ((DSOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -9774,7 +9774,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dvoccur\" does not exist\nLINE 1: ... vknbkpckcyflnydqwadermxvlidifshl2dqupjzjk1ba = ((DVOCCUR IS...\n                                                             ^\n"
+                                            "message": "column \"dvoccur\" does not exist\nLINE 1: ...T vukdxwagcqpvsw1xu6cznaeumeynufeioegthdnvcao = ((DVOCCUR IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -11018,7 +11018,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ecstat\" does not exist\nLINE 1: ...T vnsbsfgs4u1vqjjmkclfmuyjcdje7rsiqwqy2qjehra = ((ECSTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ec.ectrt\".\n"
+                                            "message": "column \"ecstat\" does not exist\nLINE 1: ... vqxqzfavkqjweh26ov5amz1bykcszgntxvkgpsvesoyi = ((ECSTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ec.ectrt\".\n"
                                         }
                                     ]
                                 ]
@@ -11033,7 +11033,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"expresp\" does not exist\nLINE 1: ...ET v1iiwy4wibp5dprudivgfixeuhbdrqnandj6jxztsak = (expresp IS...\n                                                             ^\n"
+                                            "message": "column \"expresp\" does not exist\nLINE 1: ...ex SET vkk7xyesjh6xnkkdq0hoe4tstvdhgnpl2w0iyl0 = (expresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -11165,7 +11165,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aestat\" does not exist\nLINE 1: ... vauh7sagwrdnq7a8qwr1wzswshoqhcsno1do2ojrumf0 = ((AESTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aeseq\".\n"
+                                            "message": "column \"aestat\" does not exist\nLINE 1: ... vdnb0n2kbaxnugvabwywjonaagd44hj3bgdhuako5ytc = ((AESTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aeseq\".\n"
                                         }
                                     ]
                                 ]
@@ -11278,7 +11278,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dspresp\" does not exist\nLINE 1: ...SET vvpdytczd5yxcfdvj1v2csvcbjdxxgskkxgcp0gcuu = (dspresp IS...\n                                                             ^\n"
+                                            "message": "column \"dspresp\" does not exist\nLINE 1: ...ET vc6mb9xehot2xmqpbqvgdkyecydcsxzxwofaal81pmg = (dspresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -11293,7 +11293,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dvpresp\" does not exist\nLINE 1: ...ET vumqugwme3dp2vtwinsvv4yexmg927uv7uzxojxx4cw = (dvpresp IS...\n                                                             ^\n"
+                                            "message": "column \"dvpresp\" does not exist\nLINE 1: ...v SET vyorsntjmrryu3i5rjpz34avitwu3esj4qoiu7ic = (dvpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -12102,7 +12102,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ecstat\" does not exist\nLINE 1: ...T vnsbsfgs4u1vqjjmkclfmuyjcdje7rsiqwqy2qjehra = ((ECSTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ec.ectrt\".\n"
+                                            "message": "column \"ecstat\" does not exist\nLINE 1: ... vqxqzfavkqjweh26ov5amz1bykcszgntxvkgpsvesoyi = ((ECSTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ec.ectrt\".\n"
                                         }
                                     ]
                                 ]
@@ -12117,7 +12117,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"expresp\" does not exist\nLINE 1: ...ET v1iiwy4wibp5dprudivgfixeuhbdrqnandj6jxztsak = (expresp IS...\n                                                             ^\n"
+                                            "message": "column \"expresp\" does not exist\nLINE 1: ...ex SET vkk7xyesjh6xnkkdq0hoe4tstvdhgnpl2w0iyl0 = (expresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -12156,7 +12156,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aestat\" does not exist\nLINE 1: ... vauh7sagwrdnq7a8qwr1wzswshoqhcsno1do2ojrumf0 = ((AESTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aeseq\".\n"
+                                            "message": "column \"aestat\" does not exist\nLINE 1: ... vdnb0n2kbaxnugvabwywjonaagd44hj3bgdhuako5ytc = ((AESTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aeseq\".\n"
                                         }
                                     ]
                                 ]
@@ -12187,7 +12187,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dspresp\" does not exist\nLINE 1: ...SET vvpdytczd5yxcfdvj1v2csvcbjdxxgskkxgcp0gcuu = (dspresp IS...\n                                                             ^\n"
+                                            "message": "column \"dspresp\" does not exist\nLINE 1: ...ET vc6mb9xehot2xmqpbqvgdkyecydcsxzxwofaal81pmg = (dspresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -12202,7 +12202,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dvpresp\" does not exist\nLINE 1: ...ET vumqugwme3dp2vtwinsvv4yexmg927uv7uzxojxx4cw = (dvpresp IS...\n                                                             ^\n"
+                                            "message": "column \"dvpresp\" does not exist\nLINE 1: ...v SET vyorsntjmrryu3i5rjpz34avitwu3esj4qoiu7ic = (dvpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -13148,7 +13148,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...deh5congjccoptdujvq80 = ((TAETORD IS NULL OR TAETORD = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...lwkxp0jdhpuitv9s4pluc = ((TAETORD IS NULL OR TAETORD = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -13201,7 +13201,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...deh5congjccoptdujvq80 = ((TAETORD IS NULL OR TAETORD = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...lwkxp0jdhpuitv9s4pluc = ((TAETORD IS NULL OR TAETORD = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -13267,7 +13267,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"iedrvfl\" does not exist\nLINE 1: ... SET vhfpgizfrl2zh8spygl0pkvlcff8ofvzbt4viqbl0 = (iedrvfl IS...\n                                                             ^\n"
+                                            "message": "column \"iedrvfl\" does not exist\nLINE 1: ...T vjv0tbu4txe7lbqaap4xequceplnczx2zofq64lm2eju = (iedrvfl IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -14137,7 +14137,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...xzejmrs3h0yzz5nwwoi = ((AEBDSYCD IS NULL OR AEBDSYCD = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1uomsgso3vycisvyvue = ((AEBDSYCD IS NULL OR AEBDSYCD = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -14218,7 +14218,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...xzejmrs3h0yzz5nwwoi = ((AEBDSYCD IS NULL OR AEBDSYCD = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1uomsgso3vycisvyvue = ((AEBDSYCD IS NULL OR AEBDSYCD = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -14692,7 +14692,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"teenrl\" does not exist\nLINE 1: ...T verya25llfzryfnrmz1drpk9pjjw2e8mslzfg8avzjm = ((TEENRL IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"te.testrl\".\n"
+                                            "message": "column \"teenrl\" does not exist\nLINE 1: ...T v2bj2mgevlafh5acpalihdinz3ytmzkcrtycykp05qe = ((TEENRL IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"te.testrl\".\n"
                                         }
                                     ]
                                 ]
@@ -14976,7 +14976,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"pctptref\" does not exist\nLINE 1: ...SET vpbg1a1wtjyved7zzu1dlf8kymbwmxttiah7vgq68 = ((PCTPTREF I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"pc.pctpt\" or the column \"pc.pctptnum\".\n"
+                                            "message": "column \"pctptref\" does not exist\nLINE 1: ...T vi7qjh4fyy0dryvtjlpgmg3dqyxrcafclezflf3kogy = ((PCTPTREF I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"pc.pctpt\" or the column \"pc.pctptnum\".\n"
                                         }
                                     ]
                                 ]
@@ -15887,7 +15887,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...SET vfyipxqjtrnqwjbm8ic9vjetw1kopayxijfbctka34 = (dsdecod IS...\n                                                             ^\n"
+                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...m SET vtkndtiwbcy2x1hfldkve70o93fod5vl5ybdwhrs = (dsdecod IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16038,7 +16038,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...SET vfyipxqjtrnqwjbm8ic9vjetw1kopayxijfbctka34 = (dsdecod IS...\n                                                             ^\n"
+                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...m SET vtkndtiwbcy2x1hfldkve70o93fod5vl5ybdwhrs = (dsdecod IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16183,7 +16183,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...exvqrsequs8jvslbbodjo = ((VISITDY IS NULL OR VISITDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...057gyhgxqtafmhxixqims = ((VISITDY IS NULL OR VISITDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -16248,7 +16248,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...exvqrsequs8jvslbbodjo = ((VISITDY IS NULL OR VISITDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...057gyhgxqtafmhxixqims = ((VISITDY IS NULL OR VISITDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -16398,7 +16398,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16543,7 +16543,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16713,7 +16713,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16728,7 +16728,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16786,7 +16786,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"sv.svupdes\".\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"sv.svupdes\".\n"
                                         }
                                     ]
                                 ]
@@ -16801,7 +16801,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16874,7 +16874,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16889,7 +16889,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16975,7 +16975,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -16990,7 +16990,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vk6y5gjhnutqrasczr9qtilwevlbjyqhsidx7hsrw = ((SVPRESP IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vyosddfyqqctfoseumbkoffdurbzsyy4sysbhmq2q = ((SVPRESP IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -17063,7 +17063,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -17078,7 +17078,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vk6y5gjhnutqrasczr9qtilwevlbjyqhsidx7hsrw = ((SVPRESP IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vyosddfyqqctfoseumbkoffdurbzsyy4sysbhmq2q = ((SVPRESP IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -18253,7 +18253,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"actarm\" does not exist\nLINE 1: ... vbsjxckkxocgjw5sd54193daiihyqni9m3oxcznxmzoe = ((ACTARM IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.arm\".\n"
+                                            "message": "column \"actarm\" does not exist\nLINE 1: ...T vdncq3djuyiugwmjwwsmdrpdyxzrlt6nmc1xvmjpvrg = ((ACTARM IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.arm\".\n"
                                         }
                                     ]
                                 ]
@@ -18459,7 +18459,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"actarm\" does not exist\nLINE 1: ... vbsjxckkxocgjw5sd54193daiihyqni9m3oxcznxmzoe = ((ACTARM IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.arm\".\n"
+                                            "message": "column \"actarm\" does not exist\nLINE 1: ...T vdncq3djuyiugwmjwwsmdrpdyxzrlt6nmc1xvmjpvrg = ((ACTARM IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.arm\".\n"
                                         }
                                     ]
                                 ]
@@ -22605,7 +22605,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"vsdrvfl\" does not exist\nLINE 1: ...xihhxqd8bc5xc2rkpszvljlwudftfj5xzztnse2z0 = (NOT (vsdrvfl IS...\n                                                             ^\n"
+                                            "message": "column \"vsdrvfl\" does not exist\nLINE 1: ...4b6ccpp3djop8o17gyf4x3kfyqw8zkfvblvtlh7qu = (NOT (vsdrvfl IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -22804,7 +22804,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"vsdrvfl\" does not exist\nLINE 1: ...xihhxqd8bc5xc2rkpszvljlwudftfj5xzztnse2z0 = (NOT (vsdrvfl IS...\n                                                             ^\n"
+                                            "message": "column \"vsdrvfl\" does not exist\nLINE 1: ...4b6ccpp3djop8o17gyf4x3kfyqw8zkfvblvtlh7qu = (NOT (vsdrvfl IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -24271,7 +24271,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...n8uyrctveqwfhzlta1ak1q8 = ((AGDOSE IS NULL OR AGDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...d2pnfurb5wkz08ygqobb1cg = ((AGDOSE IS NULL OR AGDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24286,7 +24286,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...cnpvfhutwpb3z8kudim90bi = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...dmzmdpgqpw8rzfmmslmi0iq = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24301,7 +24301,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...mij3de7qfzvmcccewidchsy = ((ECDOSE IS NULL OR ECDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ktfxcu7uywhmkio18wcescq = ((ECDOSE IS NULL OR ECDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24316,7 +24316,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...nfos8tuedeujvydjbr0yqwc = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ndlkxb59y6gawtx4jqc0xjo = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24331,7 +24331,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...2h6dxcojxq6m9ftjzam80to = ((MLDOSE IS NULL OR MLDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...gxoli46m3popi7ssyh3nvfu = ((MLDOSE IS NULL OR MLDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24346,7 +24346,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...f8utmp0sddejgvq0a35u8o4 = ((PRDOSE IS NULL OR PRDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...w9p81pstjw1lcpm4mvh4eyi = ((PRDOSE IS NULL OR PRDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24361,7 +24361,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...n2gna6rbtrbx6c5iv75bkog = ((SUDOSE IS NULL OR SUDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ypjca23yha02lwbda4optxm = ((SUDOSE IS NULL OR SUDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24532,7 +24532,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...n8uyrctveqwfhzlta1ak1q8 = ((AGDOSE IS NULL OR AGDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...d2pnfurb5wkz08ygqobb1cg = ((AGDOSE IS NULL OR AGDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24547,7 +24547,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...cnpvfhutwpb3z8kudim90bi = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...dmzmdpgqpw8rzfmmslmi0iq = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24562,7 +24562,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...mij3de7qfzvmcccewidchsy = ((ECDOSE IS NULL OR ECDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ktfxcu7uywhmkio18wcescq = ((ECDOSE IS NULL OR ECDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24577,7 +24577,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...nfos8tuedeujvydjbr0yqwc = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ndlkxb59y6gawtx4jqc0xjo = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24592,7 +24592,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...2h6dxcojxq6m9ftjzam80to = ((MLDOSE IS NULL OR MLDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...gxoli46m3popi7ssyh3nvfu = ((MLDOSE IS NULL OR MLDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24607,7 +24607,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...f8utmp0sddejgvq0a35u8o4 = ((PRDOSE IS NULL OR PRDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...w9p81pstjw1lcpm4mvh4eyi = ((PRDOSE IS NULL OR PRDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24622,7 +24622,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...n2gna6rbtrbx6c5iv75bkog = ((SUDOSE IS NULL OR SUDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ypjca23yha02lwbda4optxm = ((SUDOSE IS NULL OR SUDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24736,7 +24736,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...n8uyrctveqwfhzlta1ak1q8 = ((AGDOSE IS NULL OR AGDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...d2pnfurb5wkz08ygqobb1cg = ((AGDOSE IS NULL OR AGDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24751,7 +24751,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...cnpvfhutwpb3z8kudim90bi = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...dmzmdpgqpw8rzfmmslmi0iq = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24766,7 +24766,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...mij3de7qfzvmcccewidchsy = ((ECDOSE IS NULL OR ECDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ktfxcu7uywhmkio18wcescq = ((ECDOSE IS NULL OR ECDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24781,7 +24781,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...nfos8tuedeujvydjbr0yqwc = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ndlkxb59y6gawtx4jqc0xjo = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24796,7 +24796,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...2h6dxcojxq6m9ftjzam80to = ((MLDOSE IS NULL OR MLDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...gxoli46m3popi7ssyh3nvfu = ((MLDOSE IS NULL OR MLDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24811,7 +24811,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...f8utmp0sddejgvq0a35u8o4 = ((PRDOSE IS NULL OR PRDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...w9p81pstjw1lcpm4mvh4eyi = ((PRDOSE IS NULL OR PRDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -24826,7 +24826,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...n2gna6rbtrbx6c5iv75bkog = ((SUDOSE IS NULL OR SUDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ypjca23yha02lwbda4optxm = ((SUDOSE IS NULL OR SUDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -25011,7 +25011,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...n8uyrctveqwfhzlta1ak1q8 = ((AGDOSE IS NULL OR AGDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...d2pnfurb5wkz08ygqobb1cg = ((AGDOSE IS NULL OR AGDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -25026,7 +25026,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...cnpvfhutwpb3z8kudim90bi = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...dmzmdpgqpw8rzfmmslmi0iq = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -25041,7 +25041,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...mij3de7qfzvmcccewidchsy = ((ECDOSE IS NULL OR ECDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ktfxcu7uywhmkio18wcescq = ((ECDOSE IS NULL OR ECDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -25056,7 +25056,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...nfos8tuedeujvydjbr0yqwc = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ndlkxb59y6gawtx4jqc0xjo = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -25071,7 +25071,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...2h6dxcojxq6m9ftjzam80to = ((MLDOSE IS NULL OR MLDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...gxoli46m3popi7ssyh3nvfu = ((MLDOSE IS NULL OR MLDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -25086,7 +25086,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...f8utmp0sddejgvq0a35u8o4 = ((PRDOSE IS NULL OR PRDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...w9p81pstjw1lcpm4mvh4eyi = ((PRDOSE IS NULL OR PRDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -25101,7 +25101,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...n2gna6rbtrbx6c5iv75bkog = ((SUDOSE IS NULL OR SUDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ypjca23yha02lwbda4optxm = ((SUDOSE IS NULL OR SUDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -25744,7 +25744,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"seupdes\" does not exist\nLINE 1: ... vpqq53jim9hemykzudbygooxpvqsltnpoygjtdafgsfa = ((SEUPDES IS...\n                                                             ^\n"
+                                            "message": "column \"seupdes\" does not exist\nLINE 1: ... vm5sxrgfr0nladbplyvb9cqeru3z6kdzkkxbbikzjirg = ((SEUPDES IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -28634,7 +28634,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...p9twthba9xrdojpbyxpusnf3516er6fwqnzoauyqu = (NOT (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...vbriviko3vkmixegbcde4ptgvrxqdb4ab2mxtmkak = (NOT (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -28703,7 +28703,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...p9twthba9xrdojpbyxpusnf3516er6fwqnzoauyqu = (NOT (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...vbriviko3vkmixegbcde4ptgvrxqdb4ab2mxtmkak = (NOT (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -29907,7 +29907,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"lbspcufl\" does not exist\nLINE 1: ...vg9ymj4smsjz0zqs4rbun9sdowk8gmed15xawc80m = (NOT (lbspcufl I...\n                                                             ^\n"
+                                            "message": "column \"lbspcufl\" does not exist\nLINE 1: ...rry0kudj2gzlw0fgnlofkravygkpsoqvjppnrodwq = (NOT (lbspcufl I...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -30617,7 +30617,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -30667,7 +30667,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -30720,7 +30720,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -30770,7 +30770,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -33631,7 +33631,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -33646,7 +33646,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -33858,7 +33858,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -33873,7 +33873,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -33944,7 +33944,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -33959,7 +33959,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -34017,7 +34017,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -34032,7 +34032,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -34415,7 +34415,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...l7djuc201oy0fb8vb3o = ((FTTPTNUM IS NULL OR FTTPTNUM = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...qvujk9ljojwfqtdyw4g = ((FTTPTNUM IS NULL OR FTTPTNUM = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -34479,7 +34479,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...s1bpaunsspxzequbaam = ((VSTPTNUM IS NULL OR VSTPTNUM = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...lrmxpefgrzhsgqdlh4w = ((VSTPTNUM IS NULL OR VSTPTNUM = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -34529,7 +34529,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...l7djuc201oy0fb8vb3o = ((FTTPTNUM IS NULL OR FTTPTNUM = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...qvujk9ljojwfqtdyw4g = ((FTTPTNUM IS NULL OR FTTPTNUM = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -38803,7 +38803,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...iduhso8saestqrzanag = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...rirdb6hsd6wtaht9n1w = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -38818,7 +38818,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...iduhso8saestqrzanag = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...rirdb6hsd6wtaht9n1w = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -38833,7 +38833,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...iduhso8saestqrzanag = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...rirdb6hsd6wtaht9n1w = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -38848,7 +38848,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...iduhso8saestqrzanag = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...rirdb6hsd6wtaht9n1w = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -38863,7 +38863,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...iduhso8saestqrzanag = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...rirdb6hsd6wtaht9n1w = ((VISITNUM IS NULL OR VISITNUM = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -41522,7 +41522,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmenrf\" does not exist\nLINE 1: ...T vu8thxchojg70v5xvspj8vlsm7y36bpytjn21cj9cnu = ((DMENRF IS ...\n                                                             ^\n"
+                                            "message": "column \"dmenrf\" does not exist\nLINE 1: ... vbbzm8wjwnxbi8gz7azb7gtvoqluuwauwkbi4f8ghlzu = ((DMENRF IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -41537,7 +41537,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfendtc\" does not exist\nLINE 1: ...T vpumcqzsh3es00wzrc0pvcjnkorfofx71zojnf0nroq = ((RFENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aeendtc\".\n"
+                                            "message": "column \"rfendtc\" does not exist\nLINE 1: ...T vco9vuc69afodu24wvfqenmpqp7ka3uxiqb4gsbhpsk = ((RFENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aeendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -41636,7 +41636,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmenrf\" does not exist\nLINE 1: ...T vu8thxchojg70v5xvspj8vlsm7y36bpytjn21cj9cnu = ((DMENRF IS ...\n                                                             ^\n"
+                                            "message": "column \"dmenrf\" does not exist\nLINE 1: ... vbbzm8wjwnxbi8gz7azb7gtvoqluuwauwkbi4f8ghlzu = ((DMENRF IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -41651,7 +41651,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfendtc\" does not exist\nLINE 1: ...T vpumcqzsh3es00wzrc0pvcjnkorfofx71zojnf0nroq = ((RFENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmendtc\".\n"
+                                            "message": "column \"rfendtc\" does not exist\nLINE 1: ...T vco9vuc69afodu24wvfqenmpqp7ka3uxiqb4gsbhpsk = ((RFENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -41745,7 +41745,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmenrf\" does not exist\nLINE 1: ...T vu8thxchojg70v5xvspj8vlsm7y36bpytjn21cj9cnu = ((DMENRF IS ...\n                                                             ^\n"
+                                            "message": "column \"dmenrf\" does not exist\nLINE 1: ... vbbzm8wjwnxbi8gz7azb7gtvoqluuwauwkbi4f8ghlzu = ((DMENRF IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -41760,7 +41760,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfendtc\" does not exist\nLINE 1: ...T vpumcqzsh3es00wzrc0pvcjnkorfofx71zojnf0nroq = ((RFENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aeendtc\".\n"
+                                            "message": "column \"rfendtc\" does not exist\nLINE 1: ...T vco9vuc69afodu24wvfqenmpqp7ka3uxiqb4gsbhpsk = ((RFENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aeendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -41818,7 +41818,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmenrf\" does not exist\nLINE 1: ...T vu8thxchojg70v5xvspj8vlsm7y36bpytjn21cj9cnu = ((DMENRF IS ...\n                                                             ^\n"
+                                            "message": "column \"dmenrf\" does not exist\nLINE 1: ... vbbzm8wjwnxbi8gz7azb7gtvoqluuwauwkbi4f8ghlzu = ((DMENRF IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -41833,7 +41833,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfendtc\" does not exist\nLINE 1: ...T vpumcqzsh3es00wzrc0pvcjnkorfofx71zojnf0nroq = ((RFENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmendtc\".\n"
+                                            "message": "column \"rfendtc\" does not exist\nLINE 1: ...T vco9vuc69afodu24wvfqenmpqp7ka3uxiqb4gsbhpsk = ((RFENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -41907,7 +41907,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vi5yuqjz5gix5qujgyb2011akigwayvuq0xlnzean2w = (ssstresc I...\n                                                             ^\n"
+                                            "message": "Operation max_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -41922,7 +41922,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 4:                         AND $max_ds_dsstdtc IS NOT NULL\n                                    ^\n"
+                                            "message": "Operation max_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -42024,7 +42024,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vi5yuqjz5gix5qujgyb2011akigwayvuq0xlnzean2w = (ssstresc I...\n                                                             ^\n"
+                                            "message": "Operation max_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -42039,7 +42039,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 4:                         AND $max_ds_dsstdtc IS NOT NULL\n                                    ^\n"
+                                            "message": "Operation max_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -44547,7 +44547,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -44600,7 +44600,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -44666,7 +44666,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -44719,7 +44719,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -50639,7 +50639,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"lbdrvfl\" does not exist\nLINE 1: ...5kgze8zdnipnh4sqfdwj1xxoxncnh3bprwublmgza = (NOT (lbdrvfl IS...\n                                                             ^\n"
+                                            "message": "column \"lbdrvfl\" does not exist\nLINE 1: ...ET v6va7v7haeo1j2ykppwi2pnk9afjkxadc6mxdc = (NOT (lbdrvfl IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -50710,7 +50710,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"lbstat\" does not exist\nLINE 1: ... vwszjdqnl5seusw8ttbhw7lyvzfpq5vacx2zwv2nl1dk = ((LBSTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"lb.lbcat\".\n"
+                                            "message": "column \"lbstat\" does not exist\nLINE 1: ... vefrhan1auwkbt7ap54gpi6putwzqmyop4rxeey499oa = ((LBSTAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"lb.lbcat\".\n"
                                         }
                                     ]
                                 ]
@@ -51664,7 +51664,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"idvar\" does not exist\nLINE 1: ...T vvlzbaj7j0rpsutrl4531yft84uorzt2hmcf43jivfe = ((IDVAR IS N...\n                                                             ^\n"
+                                            "message": "column \"idvar\" does not exist\nLINE 1: ... vpe4gwez4rwrglrgkubvihacbj0vrpcq9ddhi6fbwd4a = ((IDVAR IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -51679,7 +51679,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"idvar\" does not exist\nLINE 1: ...T vvlzbaj7j0rpsutrl4531yft84uorzt2hmcf43jivfe = ((IDVAR IS N...\n                                                             ^\n"
+                                            "message": "column \"idvar\" does not exist\nLINE 1: ... vpe4gwez4rwrglrgkubvihacbj0vrpcq9ddhi6fbwd4a = ((IDVAR IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -51819,7 +51819,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"idvar\" does not exist\nLINE 1: ...T vvlzbaj7j0rpsutrl4531yft84uorzt2hmcf43jivfe = ((IDVAR IS N...\n                                                             ^\n"
+                                            "message": "column \"idvar\" does not exist\nLINE 1: ... vpe4gwez4rwrglrgkubvihacbj0vrpcq9ddhi6fbwd4a = ((IDVAR IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -51834,7 +51834,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"idvar\" does not exist\nLINE 1: ...T vvlzbaj7j0rpsutrl4531yft84uorzt2hmcf43jivfe = ((IDVAR IS N...\n                                                             ^\n"
+                                            "message": "column \"idvar\" does not exist\nLINE 1: ... vpe4gwez4rwrglrgkubvihacbj0vrpcq9ddhi6fbwd4a = ((IDVAR IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -51849,7 +51849,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"idvar\" does not exist\nLINE 1: ...T vvlzbaj7j0rpsutrl4531yft84uorzt2hmcf43jivfe = ((IDVAR IS N...\n                                                             ^\n"
+                                            "message": "column \"idvar\" does not exist\nLINE 1: ... vpe4gwez4rwrglrgkubvihacbj0vrpcq9ddhi6fbwd4a = ((IDVAR IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -52146,7 +52146,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"actarmcd\" does not exist\nLINE 1: ...ET vbbxri4uquq5xz46u1omehitus3umitnszth1rgu28 = ((ACTARMCD I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.armcd\".\n"
+                                            "message": "column \"actarmcd\" does not exist\nLINE 1: ... SET vecehzzvaabqi8ko0a4wab8x6vrf7eag7dlukx44 = ((ACTARMCD I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.armcd\".\n"
                                         }
                                     ]
                                 ]
@@ -52252,7 +52252,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"actarmcd\" does not exist\nLINE 1: ...ET vbbxri4uquq5xz46u1omehitus3umitnszth1rgu28 = ((ACTARMCD I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.armcd\".\n"
+                                            "message": "column \"actarmcd\" does not exist\nLINE 1: ... SET vecehzzvaabqi8ko0a4wab8x6vrf7eag7dlukx44 = ((ACTARMCD I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.armcd\".\n"
                                         }
                                     ]
                                 ]
@@ -52371,7 +52371,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"actarm\" does not exist\nLINE 1: ... vbsjxckkxocgjw5sd54193daiihyqni9m3oxcznxmzoe = ((ACTARM IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.arm\".\n"
+                                            "message": "column \"actarm\" does not exist\nLINE 1: ...T vdncq3djuyiugwmjwwsmdrpdyxzrlt6nmc1xvmjpvrg = ((ACTARM IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.arm\".\n"
                                         }
                                     ]
                                 ]
@@ -52477,7 +52477,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"actarm\" does not exist\nLINE 1: ... vbsjxckkxocgjw5sd54193daiihyqni9m3oxcznxmzoe = ((ACTARM IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.arm\".\n"
+                                            "message": "column \"actarm\" does not exist\nLINE 1: ...T vdncq3djuyiugwmjwwsmdrpdyxzrlt6nmc1xvmjpvrg = ((ACTARM IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ta.arm\".\n"
                                         }
                                     ]
                                 ]
@@ -53456,7 +53456,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($disposition_event_count AS...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -53532,7 +53532,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($disposition_event_count AS...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -53598,7 +53598,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($disposition_event_count AS...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -53712,7 +53712,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($disposition_event_count AS...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -53790,7 +53790,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"tmrpt\" does not exist\nLINE 1: ...SET vghoifkr7unm6pburcbacethbducb6rjesgvx3vdou = (tmrpt IS N...\n                                                             ^\n"
+                                            "message": "column \"tmrpt\" does not exist\nLINE 1: ...ET vsalyywpszqvne66ovcywdus8ymhivys2urrwi2lpto = (tmrpt IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -53878,7 +53878,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"tmrpt\" does not exist\nLINE 1: ...SET vghoifkr7unm6pburcbacethbducb6rjesgvx3vdou = (tmrpt IS N...\n                                                             ^\n"
+                                            "message": "column \"tmrpt\" does not exist\nLINE 1: ...ET vsalyywpszqvne66ovcywdus8ymhivys2urrwi2lpto = (tmrpt IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -54215,10 +54215,17 @@
                             {
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation domain_label is not implemented"
+                                        }
+                                    ]
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -54265,10 +54272,17 @@
                             {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation domain_label is not implemented"
+                                        }
+                                    ]
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -54318,10 +54332,17 @@
                             {
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation domain_label is not implemented"
+                                        }
+                                    ]
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -54368,10 +54389,17 @@
                             {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation domain_label is not implemented"
+                                        }
+                                    ]
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -56754,7 +56782,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rsubjid\" does not exist\nLINE 1: ...SET vdtstylsyay3zesa3uyjhcfxrjqzame6ejvy8hsow = ((RSUBJID IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.usubjid\" or the column \"dm.subjid\".\n"
+                                            "message": "column \"rsubjid\" does not exist\nLINE 1: ...T vw8befygjbah1t8tqbwvwz6tbhvqep6evc2pmks79os = ((RSUBJID IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.usubjid\" or the column \"dm.subjid\".\n"
                                         }
                                     ]
                                 ]
@@ -56854,7 +56882,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"mhstdtc\" does not exist\nLINE 1: ...T vwiqqcdoz8c0mrurvffenjpjioppbtir7upvfnekiy8 = ((MHSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.rfstdtc\".\n"
+                                            "message": "column \"mhstdtc\" does not exist\nLINE 1: ... vmzceeu1n5sjshjqov7rnjgmurkjxgm5m2s1efstb4l8 = ((MHSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.rfstdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -56958,7 +56986,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"mhstdtc\" does not exist\nLINE 1: ...T vwiqqcdoz8c0mrurvffenjpjioppbtir7upvfnekiy8 = ((MHSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.rfstdtc\".\n"
+                                            "message": "column \"mhstdtc\" does not exist\nLINE 1: ... vmzceeu1n5sjshjqov7rnjgmurkjxgm5m2s1efstb4l8 = ((MHSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.rfstdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -57203,7 +57231,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"lbscat\" does not exist\nLINE 1: ...ET vm2q5beqdchm2g78nqms7ke3hjdcuih1mqmdgemldu = ((LBSCAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"lb.lbcat\".\n"
+                                            "message": "column \"lbscat\" does not exist\nLINE 1: ...T vp43yyqirzrhvoon5gb8zzkiji6hdwyt8zhc0hzqgwg = ((LBSCAT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"lb.lbcat\".\n"
                                         }
                                     ]
                                 ]
@@ -57355,10 +57383,17 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation max_date is not implemented"
+                                        }
+                                    ]
+                                ]
                             },
                             {
                                 "dataset": "ex.xpt",
@@ -57370,7 +57405,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfxendtc\" does not exist\nLINE 1: ...crw9qaptgi6dixwaa1helmstzbvozrabmohcavjmu = (NOT (rfxendtc I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ex.exendtc\".\n"
+                                            "message": "Operation max_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -57437,10 +57472,17 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation max_date is not implemented"
+                                        }
+                                    ]
+                                ]
                             },
                             {
                                 "dataset": "ex.xpt",
@@ -57452,7 +57494,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfxendtc\" does not exist\nLINE 1: ...crw9qaptgi6dixwaa1helmstzbvozrabmohcavjmu = (NOT (rfxendtc I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ex.exendtc\".\n"
+                                            "message": "Operation max_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -57503,10 +57545,17 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation max_date is not implemented"
+                                        }
+                                    ]
+                                ]
                             },
                             {
                                 "dataset": "ex.xpt",
@@ -57518,7 +57567,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfxendtc\" does not exist\nLINE 1: ...crw9qaptgi6dixwaa1helmstzbvozrabmohcavjmu = (NOT (rfxendtc I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ex.exendtc\".\n"
+                                            "message": "Operation max_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -57585,10 +57634,17 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation min_date is not implemented"
+                                        }
+                                    ]
+                                ]
                             },
                             {
                                 "dataset": "ex.xpt",
@@ -57600,7 +57656,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfxstdtc\" does not exist\nLINE 1: ...onh2jyz2igfsxmarj7kqxfmxzqgimcsqaa8hzqtny = (NOT (rfxstdtc I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ex.exstdtc\".\n"
+                                            "message": "Operation min_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -58932,7 +58988,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -58947,7 +59003,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -59015,7 +59071,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -59030,7 +59086,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -59045,7 +59101,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -59060,7 +59116,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -60943,7 +60999,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -60958,7 +61014,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61057,7 +61113,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"mhendtc\" does not exist\nLINE 1: ...ET vubyxiuppohaeae1or3fb1noikhor474wiihxhs1ki = ((MHENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.rfendtc\".\n"
+                                            "message": "column \"mhendtc\" does not exist\nLINE 1: ...SET vqu5lrdlz1yn6tvysufcva9w8dspdw2jc4d4adsui = ((MHENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.rfendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -61170,7 +61226,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"mhendtc\" does not exist\nLINE 1: ...ET vubyxiuppohaeae1or3fb1noikhor474wiihxhs1ki = ((MHENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.rfendtc\".\n"
+                                            "message": "column \"mhendtc\" does not exist\nLINE 1: ...SET vqu5lrdlz1yn6tvysufcva9w8dspdw2jc4d4adsui = ((MHENDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.rfendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -61244,7 +61300,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vi5yuqjz5gix5qujgyb2011akigwayvuq0xlnzean2w = (ssstresc I...\n                                                             ^\n"
+                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vpykwat6p4srw9sj11lfktbkvqbr9mtvt8llwxedxz0 = (ssstresc I...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61338,7 +61394,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vi5yuqjz5gix5qujgyb2011akigwayvuq0xlnzean2w = (ssstresc I...\n                                                             ^\n"
+                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vpykwat6p4srw9sj11lfktbkvqbr9mtvt8llwxedxz0 = (ssstresc I...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61427,7 +61483,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...p9twthba9xrdojpbyxpusnf3516er6fwqnzoauyqu = (NOT (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...vbriviko3vkmixegbcde4ptgvrxqdb4ab2mxtmkak = (NOT (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61442,7 +61498,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...SET vfyipxqjtrnqwjbm8ic9vjetw1kopayxijfbctka34 = (dsdecod IS...\n                                                             ^\n"
+                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...m SET vtkndtiwbcy2x1hfldkve70o93fod5vl5ybdwhrs = (dsdecod IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61503,7 +61559,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...p9twthba9xrdojpbyxpusnf3516er6fwqnzoauyqu = (NOT (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...vbriviko3vkmixegbcde4ptgvrxqdb4ab2mxtmkak = (NOT (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61518,7 +61574,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...SET vfyipxqjtrnqwjbm8ic9vjetw1kopayxijfbctka34 = (dsdecod IS...\n                                                             ^\n"
+                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...m SET vtkndtiwbcy2x1hfldkve70o93fod5vl5ybdwhrs = (dsdecod IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61533,7 +61589,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...SET vfyipxqjtrnqwjbm8ic9vjetw1kopayxijfbctka34 = (dsdecod IS...\n                                                             ^\n"
+                                            "message": "column \"dsdecod\" does not exist\nLINE 1: ...e SET vtkndtiwbcy2x1hfldkve70o93fod5vl5ybdwhrs = (dsdecod IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61615,7 +61671,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aesdth\" does not exist\nLINE 1: ...ET v3jrwuahaxxs6ui9wbxr15bejsfouuf1ynl95rsrpea = (aesdth IS ...\n                                                             ^\n"
+                                            "message": "column \"aesdth\" does not exist\nLINE 1: ...T vnzvn1t4hafownstj9pqruoec6k3mdqrs1vwrcabifk8 = (aesdth IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61630,7 +61686,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...p9twthba9xrdojpbyxpusnf3516er6fwqnzoauyqu = (NOT (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...vbriviko3vkmixegbcde4ptgvrxqdb4ab2mxtmkak = (NOT (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61691,7 +61747,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aesdth\" does not exist\nLINE 1: ...ET v3jrwuahaxxs6ui9wbxr15bejsfouuf1ynl95rsrpea = (aesdth IS ...\n                                                             ^\n"
+                                            "message": "column \"aesdth\" does not exist\nLINE 1: ...T vnzvn1t4hafownstj9pqruoec6k3mdqrs1vwrcabifk8 = (aesdth IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61706,7 +61762,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...p9twthba9xrdojpbyxpusnf3516er6fwqnzoauyqu = (NOT (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...vbriviko3vkmixegbcde4ptgvrxqdb4ab2mxtmkak = (NOT (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61780,7 +61836,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aeout\" does not exist\nLINE 1: ...T vn20az6izmohp6tae5acpqslpwj663ncykgcimfavals = (aeout IS N...\n                                                             ^\n"
+                                            "message": "column \"aeout\" does not exist\nLINE 1: ... SET vuum1iyb5wtdxcnubcthpvyufctehu7x7dhmnhaqm = (aeout IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61795,7 +61851,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...p9twthba9xrdojpbyxpusnf3516er6fwqnzoauyqu = (NOT (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...vbriviko3vkmixegbcde4ptgvrxqdb4ab2mxtmkak = (NOT (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61856,7 +61912,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aeout\" does not exist\nLINE 1: ...T vn20az6izmohp6tae5acpqslpwj663ncykgcimfavals = (aeout IS N...\n                                                             ^\n"
+                                            "message": "column \"aeout\" does not exist\nLINE 1: ... SET vuum1iyb5wtdxcnubcthpvyufctehu7x7dhmnhaqm = (aeout IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -61871,7 +61927,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...p9twthba9xrdojpbyxpusnf3516er6fwqnzoauyqu = (NOT (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...vbriviko3vkmixegbcde4ptgvrxqdb4ab2mxtmkak = (NOT (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -62795,7 +62851,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vi5yuqjz5gix5qujgyb2011akigwayvuq0xlnzean2w = (ssstresc I...\n                                                             ^\n"
+                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vpykwat6p4srw9sj11lfktbkvqbr9mtvt8llwxedxz0 = (ssstresc I...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -62916,7 +62972,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vi5yuqjz5gix5qujgyb2011akigwayvuq0xlnzean2w = (ssstresc I...\n                                                             ^\n"
+                                            "message": "column \"ssstresc\" does not exist\nLINE 1: ...ET vpykwat6p4srw9sj11lfktbkvqbr9mtvt8llwxedxz0 = (ssstresc I...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -63839,7 +63895,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmstrf\" does not exist\nLINE 1: ...ET v6ffxsymncdisj2urxqtnnbjr4fyvhpgr5yztchlhq = ((DMSTRF IS ...\n                                                             ^\n"
+                                            "message": "column \"dmstrf\" does not exist\nLINE 1: ...T vxextob2vx5eny393pgywwzkbcatttlhxdnknbhwshm = ((DMSTRF IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -63854,7 +63910,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfstdtc\" does not exist\nLINE 1: ... vpmufjwwdoo4c3nu3lgfllqz5hw1zz86l61ryhygocyy = ((RFSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aestdtc\".\n"
+                                            "message": "column \"rfstdtc\" does not exist\nLINE 1: ...T vs3gubojijvnumzk6muialyqshi4gbejmndlygfk4ts = ((RFSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aestdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -63945,7 +64001,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmstrf\" does not exist\nLINE 1: ...ET v6ffxsymncdisj2urxqtnnbjr4fyvhpgr5yztchlhq = ((DMSTRF IS ...\n                                                             ^\n"
+                                            "message": "column \"dmstrf\" does not exist\nLINE 1: ...T vxextob2vx5eny393pgywwzkbcatttlhxdnknbhwshm = ((DMSTRF IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -63960,7 +64016,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfstdtc\" does not exist\nLINE 1: ... vpmufjwwdoo4c3nu3lgfllqz5hw1zz86l61ryhygocyy = ((RFSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmstdtc\".\n"
+                                            "message": "column \"rfstdtc\" does not exist\nLINE 1: ...T vs3gubojijvnumzk6muialyqshi4gbejmndlygfk4ts = ((RFSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmstdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -64054,7 +64110,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmstrf\" does not exist\nLINE 1: ...ET v6ffxsymncdisj2urxqtnnbjr4fyvhpgr5yztchlhq = ((DMSTRF IS ...\n                                                             ^\n"
+                                            "message": "column \"dmstrf\" does not exist\nLINE 1: ...T vxextob2vx5eny393pgywwzkbcatttlhxdnknbhwshm = ((DMSTRF IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -64069,7 +64125,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfstdtc\" does not exist\nLINE 1: ... vpmufjwwdoo4c3nu3lgfllqz5hw1zz86l61ryhygocyy = ((RFSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aestdtc\".\n"
+                                            "message": "column \"rfstdtc\" does not exist\nLINE 1: ...T vs3gubojijvnumzk6muialyqshi4gbejmndlygfk4ts = ((RFSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aestdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -64127,7 +64183,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmstrf\" does not exist\nLINE 1: ...ET v6ffxsymncdisj2urxqtnnbjr4fyvhpgr5yztchlhq = ((DMSTRF IS ...\n                                                             ^\n"
+                                            "message": "column \"dmstrf\" does not exist\nLINE 1: ...T vxextob2vx5eny393pgywwzkbcatttlhxdnknbhwshm = ((DMSTRF IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -64142,7 +64198,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfstdtc\" does not exist\nLINE 1: ... vpmufjwwdoo4c3nu3lgfllqz5hw1zz86l61ryhygocyy = ((RFSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmstdtc\".\n"
+                                            "message": "column \"rfstdtc\" does not exist\nLINE 1: ...T vs3gubojijvnumzk6muialyqshi4gbejmndlygfk4ts = ((RFSTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmstdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -66671,7 +66727,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -66686,7 +66742,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67016,7 +67072,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67031,7 +67087,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67529,7 +67585,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67544,7 +67600,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67559,7 +67615,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67574,7 +67630,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$TV_VISITNUM\"\nLINE 1: ...czt1rlrvd0 = (visitnum IS NOT NULL AND visitnum = '$TV_VISIT...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$TV_VISITNUM\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$TV_VISIT...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67589,7 +67645,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67604,7 +67660,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67937,7 +67993,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67952,7 +68008,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67967,7 +68023,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$TV_VISITNUM\"\nLINE 1: ...czt1rlrvd0 = (visitnum IS NOT NULL AND visitnum = '$TV_VISIT...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$TV_VISITNUM\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$TV_VISIT...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67982,7 +68038,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -67997,7 +68053,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -68589,7 +68645,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -68604,7 +68660,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -68619,7 +68675,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$TV_VISITNUM\"\nLINE 1: ...czt1rlrvd0 = (visitnum IS NOT NULL AND visitnum = '$TV_VISIT...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$TV_VISITNUM\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$TV_VISIT...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -68634,7 +68690,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -68649,7 +68705,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...SET vzakp6wfhnl84cjw6rpcztiziagbpx3mpo9tto2mdq = (svpresp IS...\n                                                             ^\n"
+                                            "message": "column \"svpresp\" does not exist\nLINE 1: ...T vxmzdvxg4qwwaydtv7auuzdor9393ihfrtyz1zjozjjg = (svpresp IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -73489,10 +73545,17 @@
                             {
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation domain_label is not implemented"
+                                        }
+                                    ]
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -73539,10 +73602,17 @@
                             {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation domain_label is not implemented"
+                                        }
+                                    ]
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -73592,10 +73662,17 @@
                             {
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation domain_label is not implemented"
+                                        }
+                                    ]
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -73642,10 +73719,17 @@
                             {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation domain_label is not implemented"
+                                        }
+                                    ]
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -74041,7 +74125,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...SET vl0yjg899vfqwxytycybbmoluksdtcsnsurtj1ar5m = ($exvamt_ex...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74056,7 +74140,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...SET vl0yjg899vfqwxytycybbmoluksdtcsnsurtj1ar5m = ($exvamt_ex...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74126,7 +74210,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...SET vl0yjg899vfqwxytycybbmoluksdtcsnsurtj1ar5m = ($exvamt_ex...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74141,7 +74225,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...SET vl0yjg899vfqwxytycybbmoluksdtcsnsurtj1ar5m = ($exvamt_ex...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74215,7 +74299,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vpuszj8irp3qchqdwzqvtfvrjkxijos41qbxwumikai = ($exvamtu_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74230,7 +74314,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vpuszj8irp3qchqdwzqvtfvrjkxijos41qbxwumikai = ($exvamtu_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74300,7 +74384,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vpuszj8irp3qchqdwzqvtfvrjkxijos41qbxwumikai = ($exvamtu_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74315,7 +74399,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vpuszj8irp3qchqdwzqvtfvrjkxijos41qbxwumikai = ($exvamtu_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74795,7 +74879,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...l4bf6zcwdvndodu2mp8 = ((LBSTREFN IS NULL OR LBSTREFN = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0o0rpezcjx2m1eawacw = ((LBSTREFN IS NULL OR LBSTREFN = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -74870,7 +74954,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...l4bf6zcwdvndodu2mp8 = ((LBSTREFN IS NULL OR LBSTREFN = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0o0rpezcjx2m1eawacw = ((LBSTREFN IS NULL OR LBSTREFN = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -74949,7 +75033,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74964,7 +75048,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74979,7 +75063,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -74994,7 +75078,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75009,7 +75093,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75024,7 +75108,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75039,7 +75123,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75054,7 +75138,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75069,7 +75153,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75084,7 +75168,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75099,7 +75183,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75114,7 +75198,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75129,7 +75213,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75284,7 +75368,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75299,7 +75383,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75314,7 +75398,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75329,7 +75413,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75344,7 +75428,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75359,7 +75443,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75374,7 +75458,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75389,7 +75473,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75404,7 +75488,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75419,7 +75503,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75434,7 +75518,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75449,7 +75533,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75464,7 +75548,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75619,7 +75703,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75634,7 +75718,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75649,7 +75733,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75664,7 +75748,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75679,7 +75763,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75694,7 +75778,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75709,7 +75793,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75724,7 +75808,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75739,7 +75823,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75754,7 +75838,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75769,7 +75853,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75784,7 +75868,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75799,7 +75883,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75954,7 +76038,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75969,7 +76053,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75984,7 +76068,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -75999,7 +76083,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76014,7 +76098,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76029,7 +76113,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76044,7 +76128,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76059,7 +76143,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76074,7 +76158,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76089,7 +76173,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76104,7 +76188,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76119,7 +76203,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76134,7 +76218,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76289,7 +76373,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76351,7 +76435,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76366,7 +76450,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76381,7 +76465,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76396,7 +76480,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76411,7 +76495,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76426,7 +76510,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76441,7 +76525,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76456,7 +76540,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76471,7 +76555,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76486,7 +76570,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76501,7 +76585,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76516,7 +76600,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76531,7 +76615,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76546,7 +76630,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76700,7 +76784,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76715,7 +76799,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76730,7 +76814,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76745,7 +76829,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76760,7 +76844,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76775,7 +76859,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76790,7 +76874,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76805,7 +76889,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76820,7 +76904,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76835,7 +76919,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76850,7 +76934,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76865,7 +76949,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76880,7 +76964,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -76895,7 +76979,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77049,7 +77133,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77064,7 +77148,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77079,7 +77163,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77094,7 +77178,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77109,7 +77193,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77124,7 +77208,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77139,7 +77223,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77154,7 +77238,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77169,7 +77253,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77184,7 +77268,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77199,7 +77283,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77214,7 +77298,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77229,7 +77313,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77244,7 +77328,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77398,7 +77482,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77413,7 +77497,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77428,7 +77512,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77443,7 +77527,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77458,7 +77542,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77473,7 +77557,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77488,7 +77572,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77503,7 +77587,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77518,7 +77602,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77533,7 +77617,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77548,7 +77632,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77563,7 +77647,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77578,7 +77662,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77593,7 +77677,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77747,7 +77831,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -77762,7 +77846,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ... SET vrptvwzbetqijvnqsgxjd73gnfvskavvr2mk4mbik = ($mids_exis...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -78983,7 +79067,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...cnpvfhutwpb3z8kudim90bi = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...dmzmdpgqpw8rzfmmslmi0iq = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -78998,7 +79082,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...nfos8tuedeujvydjbr0yqwc = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ndlkxb59y6gawtx4jqc0xjo = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -79101,7 +79185,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...cnpvfhutwpb3z8kudim90bi = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...dmzmdpgqpw8rzfmmslmi0iq = ((CMDOSE IS NULL OR CMDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -79116,7 +79200,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...nfos8tuedeujvydjbr0yqwc = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ndlkxb59y6gawtx4jqc0xjo = ((EXDOSE IS NULL OR EXDOSE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -80777,7 +80861,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svupdes\" does not exist\nLINE 1: ...ET v0gyudy9vylybxi4lo527ncwc5c9uulvsq23kk4t0i = ((SVUPDES IS...\n                                                             ^\n"
+                                            "message": "column \"svupdes\" does not exist\nLINE 1: ... vecupqdlwhrp2hvhaifnsdmsguuhcafehkh9lkgplswg = ((SVUPDES IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -80792,7 +80876,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svupdes\" does not exist\nLINE 1: ...ET v0gyudy9vylybxi4lo527ncwc5c9uulvsq23kk4t0i = ((SVUPDES IS...\n                                                             ^\n"
+                                            "message": "column \"svupdes\" does not exist\nLINE 1: ... vecupqdlwhrp2hvhaifnsdmsguuhcafehkh9lkgplswg = ((SVUPDES IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -81049,7 +81133,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svupdes\" does not exist\nLINE 1: ...ET v0gyudy9vylybxi4lo527ncwc5c9uulvsq23kk4t0i = ((SVUPDES IS...\n                                                             ^\n"
+                                            "message": "column \"svupdes\" does not exist\nLINE 1: ... vecupqdlwhrp2hvhaifnsdmsguuhcafehkh9lkgplswg = ((SVUPDES IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -81110,7 +81194,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svupdes\" does not exist\nLINE 1: ...ET v0gyudy9vylybxi4lo527ncwc5c9uulvsq23kk4t0i = ((SVUPDES IS...\n                                                             ^\n"
+                                            "message": "column \"svupdes\" does not exist\nLINE 1: ... vecupqdlwhrp2hvhaifnsdmsguuhcafehkh9lkgplswg = ((SVUPDES IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -81125,7 +81209,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svupdes\" does not exist\nLINE 1: ...ET v0gyudy9vylybxi4lo527ncwc5c9uulvsq23kk4t0i = ((SVUPDES IS...\n                                                             ^\n"
+                                            "message": "column \"svupdes\" does not exist\nLINE 1: ... vecupqdlwhrp2hvhaifnsdmsguuhcafehkh9lkgplswg = ((SVUPDES IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -81382,7 +81466,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"svupdes\" does not exist\nLINE 1: ...ET v0gyudy9vylybxi4lo527ncwc5c9uulvsq23kk4t0i = ((SVUPDES IS...\n                                                             ^\n"
+                                            "message": "column \"svupdes\" does not exist\nLINE 1: ... vecupqdlwhrp2hvhaifnsdmsguuhcafehkh9lkgplswg = ((SVUPDES IS...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -81592,7 +81676,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"race\" does not exist\nLINE 1: ...f78fuadia98aa5cbyi2rs1rxtmcouza1gxsn4u0aq = (NOT (race IS NO...\n                                                             ^\n"
+                                            "message": "column \"race\" does not exist\nLINE 1: ...kpzyu52mm5xvdumtzdyj0afe4qemacaf3cfsnxpe4 = (NOT (race IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -81668,7 +81752,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"race\" does not exist\nLINE 1: ...f78fuadia98aa5cbyi2rs1rxtmcouza1gxsn4u0aq = (NOT (race IS NO...\n                                                             ^\n"
+                                            "message": "column \"race\" does not exist\nLINE 1: ...kpzyu52mm5xvdumtzdyj0afe4qemacaf3cfsnxpe4 = (NOT (race IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -81741,7 +81825,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"race\" does not exist\nLINE 1: ...f78fuadia98aa5cbyi2rs1rxtmcouza1gxsn4u0aq = (NOT (race IS NO...\n                                                             ^\n"
+                                            "message": "column \"race\" does not exist\nLINE 1: ...kpzyu52mm5xvdumtzdyj0afe4qemacaf3cfsnxpe4 = (NOT (race IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -82457,7 +82541,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...gf61pxswzzd9zrjxigkfzlftojy = ((CEDY IS NULL OR CEDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...d4ip3mjdb6wj11pskvorrgub1q0 = ((CEDY IS NULL OR CEDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -82472,7 +82556,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vt29jocopllwyrh0bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NU...\n                                                             ^\n"
+                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vs07jwjwidkdirx5boicpw6ooecdnd0ykrxegnfdfiu = ((DMDY IS NU...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -82558,7 +82642,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aedy\" does not exist\nLINE 1: ...SET vb4zlpli5hyej89umrah8xbpgjn8urojjqyrriycs = ((AEDY IS NU...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aestdy\" or the column \"ae.aeendy\".\n"
+                                            "message": "column \"aedy\" does not exist\nLINE 1: ...SET vxqym8eygxzhfiapppsfopadfmyxldjugcanxkqdg = ((AEDY IS NU...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aestdy\" or the column \"ae.aeendy\".\n"
                                         }
                                     ]
                                 ]
@@ -82573,7 +82657,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vt29jocopllwyrh0bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NU...\n                                                             ^\n"
+                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vs07jwjwidkdirx5boicpw6ooecdnd0ykrxegnfdfiu = ((DMDY IS NU...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -82588,7 +82672,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"exdy\" does not exist\nLINE 1: ... vgeirx3erl2qhi0ggyk2r8acv36rzb97s4bissi6xygk = ((EXDY IS NU...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ex.exstdy\" or the column \"ex.exendy\".\n"
+                                            "message": "column \"exdy\" does not exist\nLINE 1: ... vbljdcfgbtid9hxqydsmd04qgxpai1xn9mmxuib10lva = ((EXDY IS NU...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ex.exstdy\" or the column \"ex.exendy\".\n"
                                         }
                                     ]
                                 ]
@@ -82603,7 +82687,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1ue9nme2hd8pscumfnwm1usgxce = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...jq3bjvlg5s6ksh3pnfvbr0uzfhs = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -82722,7 +82806,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...gf61pxswzzd9zrjxigkfzlftojy = ((CEDY IS NULL OR CEDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...d4ip3mjdb6wj11pskvorrgub1q0 = ((CEDY IS NULL OR CEDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -82737,7 +82821,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vt29jocopllwyrh0bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NU...\n                                                             ^\n"
+                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vs07jwjwidkdirx5boicpw6ooecdnd0ykrxegnfdfiu = ((DMDY IS NU...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -82802,7 +82886,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aedy\" does not exist\nLINE 1: ...SET vb4zlpli5hyej89umrah8xbpgjn8urojjqyrriycs = ((AEDY IS NU...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aestdy\" or the column \"ae.aeendy\".\n"
+                                            "message": "column \"aedy\" does not exist\nLINE 1: ...SET vxqym8eygxzhfiapppsfopadfmyxldjugcanxkqdg = ((AEDY IS NU...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ae.aestdy\" or the column \"ae.aeendy\".\n"
                                         }
                                     ]
                                 ]
@@ -82817,7 +82901,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vt29jocopllwyrh0bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NU...\n                                                             ^\n"
+                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vs07jwjwidkdirx5boicpw6ooecdnd0ykrxegnfdfiu = ((DMDY IS NU...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -82832,7 +82916,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"exdy\" does not exist\nLINE 1: ... vgeirx3erl2qhi0ggyk2r8acv36rzb97s4bissi6xygk = ((EXDY IS NU...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ex.exstdy\" or the column \"ex.exendy\".\n"
+                                            "message": "column \"exdy\" does not exist\nLINE 1: ... vbljdcfgbtid9hxqydsmd04qgxpai1xn9mmxuib10lva = ((EXDY IS NU...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ex.exstdy\" or the column \"ex.exendy\".\n"
                                         }
                                     ]
                                 ]
@@ -82847,7 +82931,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1ue9nme2hd8pscumfnwm1usgxce = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...jq3bjvlg5s6ksh3pnfvbr0uzfhs = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -83157,7 +83241,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83172,7 +83256,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83240,7 +83324,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83255,7 +83339,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83270,7 +83354,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83349,7 +83433,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83364,7 +83448,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83422,7 +83506,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83437,7 +83521,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83452,7 +83536,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -83534,7 +83618,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -83549,7 +83633,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -83684,7 +83768,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -83699,7 +83783,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -83757,7 +83841,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -83772,7 +83856,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...mclpn8ifr4 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
+                                            "message": "invalid input syntax for type double precision: \"$tv_visitnum\"\nLINE 1: ...zrjs0h4db0 = (visitnum IS NOT NULL AND visitnum = '$tv_visit...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -85295,7 +85379,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "contains check_operator not implemented"
+                                            "message": "Operation min_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -85310,7 +85394,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "contains check_operator not implemented"
+                                            "message": "Operation min_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -85394,7 +85478,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "contains check_operator not implemented"
+                                            "message": "Operation min_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -85409,7 +85493,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "contains check_operator not implemented"
+                                            "message": "Operation min_date is not implemented"
                                         }
                                     ]
                                 ]
@@ -86283,7 +86367,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...SET vkdxjkzco3e1d9v8dlgxxutvefwwynhhoysyseozpg = ($domain_is...\n                                                             ^\n"
+                                            "message": "Operation domain_is_custom is not implemented"
                                         }
                                     ]
                                 ]
@@ -86298,7 +86382,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...SET vkdxjkzco3e1d9v8dlgxxutvefwwynhhoysyseozpg = ($domain_is...\n                                                             ^\n"
+                                            "message": "Operation domain_is_custom is not implemented"
                                         }
                                     ]
                                 ]
@@ -86373,7 +86457,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...SET vkdxjkzco3e1d9v8dlgxxutvefwwynhhoysyseozpg = ($domain_is...\n                                                             ^\n"
+                                            "message": "Operation domain_is_custom is not implemented"
                                         }
                                     ]
                                 ]
@@ -86388,7 +86472,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...SET vkdxjkzco3e1d9v8dlgxxutvefwwynhhoysyseozpg = ($domain_is...\n                                                             ^\n"
+                                            "message": "Operation domain_is_custom is not implemented"
                                         }
                                     ]
                                 ]
@@ -86561,7 +86645,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ... SET vvqgmbysezdpen3yxk6ldj5a0250feh8gnheaygio = (variable_n...\n                                                             ^\n"
+                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vzxibnc5spbeebl7ek8rimvkofeuoxzsynem33wqjgcm = (variable_n...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -86576,7 +86660,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ... SET vvqgmbysezdpen3yxk6ldj5a0250feh8gnheaygio = (variable_n...\n                                                             ^\n"
+                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vzxibnc5spbeebl7ek8rimvkofeuoxzsynem33wqjgcm = (variable_n...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -86591,7 +86675,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ... SET vvqgmbysezdpen3yxk6ldj5a0250feh8gnheaygio = (variable_n...\n                                                             ^\n"
+                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vzxibnc5spbeebl7ek8rimvkofeuoxzsynem33wqjgcm = (variable_n...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -86681,7 +86765,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ... SET vvqgmbysezdpen3yxk6ldj5a0250feh8gnheaygio = (variable_n...\n                                                             ^\n"
+                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vzxibnc5spbeebl7ek8rimvkofeuoxzsynem33wqjgcm = (variable_n...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -86696,7 +86780,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ... SET vvqgmbysezdpen3yxk6ldj5a0250feh8gnheaygio = (variable_n...\n                                                             ^\n"
+                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vzxibnc5spbeebl7ek8rimvkofeuoxzsynem33wqjgcm = (variable_n...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -86711,7 +86795,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ... SET vvqgmbysezdpen3yxk6ldj5a0250feh8gnheaygio = (variable_n...\n                                                             ^\n"
+                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vzxibnc5spbeebl7ek8rimvkofeuoxzsynem33wqjgcm = (variable_n...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -86814,7 +86898,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -86867,7 +86951,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...hbic12rvdl7ubugnnwr6qyvgx1lru = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...0fuutiyq6zqbcs4vybhi1nxleukq8 = ((AGE IS NULL OR AGE = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -86933,7 +87017,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"agetxt\" does not exist\nLINE 1: ...ET viwqzfclneidtjhnzp0z5xgdjwaqegtvbnznckzamw = ((AGETXT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.age\" or the column \"dm.ageu\".\n"
+                                            "message": "column \"agetxt\" does not exist\nLINE 1: ...T v3syb0cwvpok3fylj0zcjlwmsictbca0wzniinoksbu = ((AGETXT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.age\" or the column \"dm.ageu\".\n"
                                         }
                                     ]
                                 ]
@@ -86986,7 +87070,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"agetxt\" does not exist\nLINE 1: ...ET viwqzfclneidtjhnzp0z5xgdjwaqegtvbnznckzamw = ((AGETXT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.age\" or the column \"dm.ageu\".\n"
+                                            "message": "column \"agetxt\" does not exist\nLINE 1: ...T v3syb0cwvpok3fylj0zcjlwmsictbca0wzniinoksbu = ((AGETXT IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.age\" or the column \"dm.ageu\".\n"
                                         }
                                     ]
                                 ]
@@ -87293,7 +87377,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87343,7 +87427,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87396,7 +87480,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87446,7 +87530,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87512,7 +87596,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87562,7 +87646,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87615,7 +87699,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87665,7 +87749,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87731,7 +87815,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87781,7 +87865,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87834,7 +87918,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87884,7 +87968,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -87950,7 +88034,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -88000,7 +88084,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -88050,7 +88134,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -88103,7 +88187,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -88153,7 +88237,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -88203,7 +88287,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -88570,7 +88654,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -88620,7 +88704,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -88673,7 +88757,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -88723,7 +88807,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($stype_interventional AS NU...\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -89435,7 +89519,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...bdjys3as2uynvnnav5k = ((CMDOSTOT IS NULL OR CMDOSTOT = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...o2nfyjfh2koilm7b8mi = ((CMDOSTOT IS NULL OR CMDOSTOT = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -89450,7 +89534,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...c3mfmpfrmadvmshyqmk = ((EXDOSTOT IS NULL OR EXDOSTOT = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ihdfz0suhfzvc4lusay = ((EXDOSTOT IS NULL OR EXDOSTOT = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -89545,7 +89629,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...bdjys3as2uynvnnav5k = ((CMDOSTOT IS NULL OR CMDOSTOT = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...o2nfyjfh2koilm7b8mi = ((CMDOSTOT IS NULL OR CMDOSTOT = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -89560,7 +89644,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...c3mfmpfrmadvmshyqmk = ((EXDOSTOT IS NULL OR EXDOSTOT = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ihdfz0suhfzvc4lusay = ((EXDOSTOT IS NULL OR EXDOSTOT = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -89634,7 +89718,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...7ijy3djgnqoz17ucxg4xm2m = ((CMVAMT IS NULL OR CMVAMT = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...qiokqsuwd59e7gppdg1an9m = ((CMVAMT IS NULL OR CMVAMT = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -89649,7 +89733,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...bajispji0onyimvkvnx3vu0 = ((EXVAMT IS NULL OR EXVAMT = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...l5e948qe4y6hbgkd9kuab00 = ((EXVAMT IS NULL OR EXVAMT = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -89744,7 +89828,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...7ijy3djgnqoz17ucxg4xm2m = ((CMVAMT IS NULL OR CMVAMT = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...qiokqsuwd59e7gppdg1an9m = ((CMVAMT IS NULL OR CMVAMT = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -89759,7 +89843,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...bajispji0onyimvkvnx3vu0 = ((EXVAMT IS NULL OR EXVAMT = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...l5e948qe4y6hbgkd9kuab00 = ((EXVAMT IS NULL OR EXVAMT = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -89975,7 +90059,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NULL OR DMDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90037,7 +90121,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1ue9nme2hd8pscumfnwm1usgxce = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90052,7 +90136,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vt29jocopllwyrh0bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NU...\n                                                             ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90129,7 +90213,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NULL OR DMDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90144,7 +90228,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...l8dkwrhmexrwso3ck4t9fnncyu4 = ((FADY IS NULL OR FADY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90159,7 +90243,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...gg1rxnb7dzirkjpyfhpgnuuzus0 = ((IEDY IS NULL OR IEDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90174,7 +90258,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1ue9nme2hd8pscumfnwm1usgxce = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90320,7 +90404,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NULL OR DMDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90370,7 +90454,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1ue9nme2hd8pscumfnwm1usgxce = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90385,7 +90469,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmdy\" does not exist\nLINE 1: ...T vt29jocopllwyrh0bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NU...\n                                                             ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90450,7 +90534,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...bhk6hldhfkaowk1mulugnq6guam = ((DMDY IS NULL OR DMDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90465,7 +90549,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...l8dkwrhmexrwso3ck4t9fnncyu4 = ((FADY IS NULL OR FADY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90480,7 +90564,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...gg1rxnb7dzirkjpyfhpgnuuzus0 = ((IEDY IS NULL OR IEDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90495,7 +90579,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1ue9nme2hd8pscumfnwm1usgxce = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -90614,7 +90698,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($addon_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -90664,7 +90748,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($addon_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -90714,7 +90798,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($addon_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -90767,7 +90851,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($addon_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -90817,7 +90901,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($addon_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -90867,7 +90951,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($addon_y AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -91099,7 +91183,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "equals_string_part check_operator not implemented"
+                                            "message": "Operation extract_metadata is not implemented"
                                         }
                                     ]
                                 ]
@@ -91149,7 +91233,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "equals_string_part check_operator not implemented"
+                                            "message": "Operation extract_metadata is not implemented"
                                         }
                                     ]
                                 ]
@@ -91202,7 +91286,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "equals_string_part check_operator not implemented"
+                                            "message": "Operation extract_metadata is not implemented"
                                         }
                                     ]
                                 ]
@@ -91217,7 +91301,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "equals_string_part check_operator not implemented"
+                                            "message": "Operation extract_metadata is not implemented"
                                         }
                                     ]
                                 ]
@@ -91275,7 +91359,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "equals_string_part check_operator not implemented"
+                                            "message": "Operation extract_metadata is not implemented"
                                         }
                                     ]
                                 ]
@@ -91341,7 +91425,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91356,7 +91440,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91371,7 +91455,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91451,7 +91535,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91529,7 +91613,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91544,7 +91628,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91648,7 +91732,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91701,7 +91785,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91716,7 +91800,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91774,7 +91858,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91789,7 +91873,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91804,7 +91888,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91870,7 +91954,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -91885,7 +91969,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "matches_regex check_operator not implemented"
+                                            "message": "Operation dataset_names is not implemented"
                                         }
                                     ]
                                 ]
@@ -92234,7 +92318,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vomtkzuyvtz9lkyel6qxmivzgcilpxspoobv9ihmtxuo = (variable_n...\n                                                             ^\n"
+                                            "message": "Operation get_model_column_order is not implemented"
                                         }
                                     ]
                                 ]
@@ -92249,7 +92333,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vomtkzuyvtz9lkyel6qxmivzgcilpxspoobv9ihmtxuo = (variable_n...\n                                                             ^\n"
+                                            "message": "Operation get_model_column_order is not implemented"
                                         }
                                     ]
                                 ]
@@ -92264,7 +92348,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vomtkzuyvtz9lkyel6qxmivzgcilpxspoobv9ihmtxuo = (variable_n...\n                                                             ^\n"
+                                            "message": "Operation get_model_column_order is not implemented"
                                         }
                                     ]
                                 ]
@@ -92354,7 +92438,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vomtkzuyvtz9lkyel6qxmivzgcilpxspoobv9ihmtxuo = (variable_n...\n                                                             ^\n"
+                                            "message": "Operation get_model_column_order is not implemented"
                                         }
                                     ]
                                 ]
@@ -92369,7 +92453,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"variable_name\" does not exist\nLINE 1: ...T vomtkzuyvtz9lkyel6qxmivzgcilpxspoobv9ihmtxuo = (variable_n...\n                                                             ^\n"
+                                            "message": "Operation get_model_column_order is not implemented"
                                         }
                                     ]
                                 ]
@@ -92456,8 +92540,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "DMSTDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92471,8 +92555,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "CMSTDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92566,8 +92650,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "DMSTDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92581,8 +92665,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "CMSTDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92655,8 +92739,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "AEENDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92670,8 +92754,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "CMENDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92685,8 +92769,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "DMENDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92811,8 +92895,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "AEENDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92826,8 +92910,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "DMENDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92841,8 +92925,8 @@
                                 "errors": [
                                     [
                                         {
-                                            "error": "Column not found in data",
-                                            "message": "CMENDTC"
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation dy is not implemented"
                                         }
                                     ]
                                 ]
@@ -92935,7 +93019,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_n AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -92985,7 +93069,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_n AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93038,7 +93122,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_n AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93088,7 +93172,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_n AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93138,7 +93222,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($hltsubji_n AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93451,7 +93535,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93466,7 +93550,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93534,7 +93618,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93549,7 +93633,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93564,7 +93648,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93643,7 +93727,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93658,7 +93742,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93716,7 +93800,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93731,7 +93815,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -93746,7 +93830,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($variable_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation variable_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -94066,7 +94150,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vefxpmoiayhuyoxpmnkpaoksgusuallus9rfujfjvza = ($records_i...\n                                                             ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -95003,7 +95087,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"qnam\" does not exist\nLINE 1: ...T vigb1dswc893bola1fpvak1muufzswoaxpzyk5rrerqu = (qnam IS NO...\n                                                             ^\n"
+                                            "message": "column \"qnam\" does not exist\nLINE 1: ...ET vyenlb5a2limtdensrol9geh3wi6wpqux88dofijtqu = (qnam IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -95018,7 +95102,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aesmie\" does not exist\nLINE 1: ...jlvrgzbtnw19vxsvxssdecoq3jqwgeefh8jbscipy = (NOT (aesmie IS ...\n                                                             ^\n"
+                                            "message": "column \"aesmie\" does not exist\nLINE 1: ...a1958zwar2wfyl0apamqijdlgh4r5ohqbbl6rbhz8 = (NOT (aesmie IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -95086,7 +95170,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"qnam\" does not exist\nLINE 1: ...T vigb1dswc893bola1fpvak1muufzswoaxpzyk5rrerqu = (qnam IS NO...\n                                                             ^\n"
+                                            "message": "column \"qnam\" does not exist\nLINE 1: ...ET vyenlb5a2limtdensrol9geh3wi6wpqux88dofijtqu = (qnam IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -95101,7 +95185,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aesmie\" does not exist\nLINE 1: ...jlvrgzbtnw19vxsvxssdecoq3jqwgeefh8jbscipy = (NOT (aesmie IS ...\n                                                             ^\n"
+                                            "message": "column \"aesmie\" does not exist\nLINE 1: ...a1958zwar2wfyl0apamqijdlgh4r5ohqbbl6rbhz8 = (NOT (aesmie IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -95903,7 +95987,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...ET vxthwhqxeb4jhz2lfypwdtab5ayouw2l9jh1egkkf0u = (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...SET vabfjxojif0tn3yuh96v4fdht99ppxahmc37laxzfm = (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -95988,7 +96072,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...ET vxthwhqxeb4jhz2lfypwdtab5ayouw2l9jh1egkkf0u = (dthfl IS N...\n                                                             ^\n"
+                                            "message": "column \"dthfl\" does not exist\nLINE 1: ...SET vabfjxojif0tn3yuh96v4fdht99ppxahmc37laxzfm = (dthfl IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -97489,7 +97573,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"epoch\" does not exist\nLINE 1: ...T vlj8v1lgwr01hsf2xdidz5ysuypc1pwflpycgkuadco = ((EPOCH IS N...\n                                                             ^\n"
+                                            "message": "column \"epoch\" does not exist\nLINE 1: ...ET vyifnitmgnllszviairels1f1xn5zau2qzmq5y7pec = ((EPOCH IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -97692,7 +97776,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"epoch\" does not exist\nLINE 1: ...T vlj8v1lgwr01hsf2xdidz5ysuypc1pwflpycgkuadco = ((EPOCH IS N...\n                                                             ^\n"
+                                            "message": "column \"epoch\" does not exist\nLINE 1: ...ET vyifnitmgnllszviairels1f1xn5zau2qzmq5y7pec = ((EPOCH IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -97731,7 +97815,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"epoch\" does not exist\nLINE 1: ...T vlj8v1lgwr01hsf2xdidz5ysuypc1pwflpycgkuadco = ((EPOCH IS N...\n                                                             ^\n"
+                                            "message": "column \"epoch\" does not exist\nLINE 1: ...ET vyifnitmgnllszviairels1f1xn5zau2qzmq5y7pec = ((EPOCH IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -98126,7 +98210,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1ue9nme2hd8pscumfnwm1usgxce = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...jq3bjvlg5s6ksh3pnfvbr0uzfhs = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98198,7 +98282,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...1ue9nme2hd8pscumfnwm1usgxce = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...jq3bjvlg5s6ksh3pnfvbr0uzfhs = ((LBDY IS NULL OR LBDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98264,7 +98348,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...exlbavjwpihrnyu2zjrlk34 = ((SMSTDY IS NULL OR SMSTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...qcl8g8duqoqoqt2maak6zek = ((SMSTDY IS NULL OR SMSTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98279,7 +98363,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...u5sb03ioxhsfhnlr2hvqg2q = ((SESTDY IS NULL OR SESTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ehm89p7xojetkhkvq5jdapu = ((SESTDY IS NULL OR SESTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98294,7 +98378,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...tlujc0vk0enzzrcw86szt08 = ((SVSTDY IS NULL OR SVSTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...d709kvupvguflpavawbqbzq = ((SVSTDY IS NULL OR SVSTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98309,7 +98393,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...b7ldlbnzdp3sqsezteg58ca = ((AESTDY IS NULL OR AESTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...tjeyru5cwmuegpxktatbenk = ((AESTDY IS NULL OR AESTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98324,7 +98408,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...cvqbxfwrgtw4pltvty35jqg = ((CMSTDY IS NULL OR CMSTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ct51dh7kp29kocq8ekemif8 = ((CMSTDY IS NULL OR CMSTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98429,7 +98513,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...exlbavjwpihrnyu2zjrlk34 = ((SMSTDY IS NULL OR SMSTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...qcl8g8duqoqoqt2maak6zek = ((SMSTDY IS NULL OR SMSTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98444,7 +98528,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...u5sb03ioxhsfhnlr2hvqg2q = ((SESTDY IS NULL OR SESTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ehm89p7xojetkhkvq5jdapu = ((SESTDY IS NULL OR SESTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98459,7 +98543,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...tlujc0vk0enzzrcw86szt08 = ((SVSTDY IS NULL OR SVSTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...d709kvupvguflpavawbqbzq = ((SVSTDY IS NULL OR SVSTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98474,7 +98558,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...b7ldlbnzdp3sqsezteg58ca = ((AESTDY IS NULL OR AESTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...tjeyru5cwmuegpxktatbenk = ((AESTDY IS NULL OR AESTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -98489,7 +98573,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...cvqbxfwrgtw4pltvty35jqg = ((CMSTDY IS NULL OR CMSTDY = ''));\n                                                                  ^\n"
+                                            "message": "invalid input syntax for type double precision: \"\"\nLINE 1: ...ct51dh7kp29kocq8ekemif8 = ((CMSTDY IS NULL OR CMSTDY = ''));\n                                                                  ^\n"
                                         }
                                     ]
                                 ]
@@ -99028,7 +99112,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"idvar\" does not exist\nLINE 1: ...T vvlzbaj7j0rpsutrl4531yft84uorzt2hmcf43jivfe = ((IDVAR IS N...\n                                                             ^\n"
+                                            "message": "column \"idvar\" does not exist\nLINE 1: ... vpe4gwez4rwrglrgkubvihacbj0vrpcq9ddhi6fbwd4a = ((IDVAR IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -99170,7 +99254,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"idvar\" does not exist\nLINE 1: ...T vvlzbaj7j0rpsutrl4531yft84uorzt2hmcf43jivfe = ((IDVAR IS N...\n                                                             ^\n"
+                                            "message": "column \"idvar\" does not exist\nLINE 1: ... vpe4gwez4rwrglrgkubvihacbj0vrpcq9ddhi6fbwd4a = ((IDVAR IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -99185,7 +99269,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"idvar\" does not exist\nLINE 1: ...T vvlzbaj7j0rpsutrl4531yft84uorzt2hmcf43jivfe = ((IDVAR IS N...\n                                                             ^\n"
+                                            "message": "column \"idvar\" does not exist\nLINE 1: ... vpe4gwez4rwrglrgkubvihacbj0vrpcq9ddhi6fbwd4a = ((IDVAR IS N...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -99704,7 +99788,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aestdtc\" does not exist\nLINE 1: ...T vyoptqvgmpcsamkbco2qn5ypnqhtnumkqrkbc7bfuuy = ((AESTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ds.dsstdtc\".\n"
+                                            "message": "column \"aestdtc\" does not exist\nLINE 1: ...T vqtjtoksxwft13qkogdgyhq6ehxgnqzxr0iobw1vhg8 = ((AESTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ds.dsstdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -99790,7 +99874,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"aestdtc\" does not exist\nLINE 1: ...T vyoptqvgmpcsamkbco2qn5ypnqhtnumkqrkbc7bfuuy = ((AESTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ds.dsstdtc\".\n"
+                                            "message": "column \"aestdtc\" does not exist\nLINE 1: ...T vqtjtoksxwft13qkogdgyhq6ehxgnqzxr0iobw1vhg8 = ((AESTDTC IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ds.dsstdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -100354,7 +100438,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmdtc\" does not exist\nLINE 1: ...T vnjv5sajzpyivbh1sl5delmynyww8lu0j0gkn5hgtyi = ((DMDTC IS N...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.dthdtc\".\n"
+                                            "message": "column \"dmdtc\" does not exist\nLINE 1: ...ET vb1povxdlq7iaioqsfc5ue8ruduvalyvi0smfpne6q = ((DMDTC IS N...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.dthdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -100369,7 +100453,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfpendtc\" does not exist\nLINE 1: ...T vsjczqsmbnztf1kqnuez6myf0m1jag2vihnhz1gmm8o = ((RFPENDTC I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ce.ceendtc\".\n"
+                                            "message": "column \"rfpendtc\" does not exist\nLINE 1: ...T v0bzjeky2azlmbpy7gjpjzwgha59zldqkrgjkiedh7g = ((RFPENDTC I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ce.ceendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -100384,7 +100468,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfpendtc\" does not exist\nLINE 1: ...T vsjczqsmbnztf1kqnuez6myf0m1jag2vihnhz1gmm8o = ((RFPENDTC I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"lb.lbendtc\".\n"
+                                            "message": "column \"rfpendtc\" does not exist\nLINE 1: ...T v0bzjeky2azlmbpy7gjpjzwgha59zldqkrgjkiedh7g = ((RFPENDTC I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"lb.lbendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -100473,7 +100557,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"dmdtc\" does not exist\nLINE 1: ...T vnjv5sajzpyivbh1sl5delmynyww8lu0j0gkn5hgtyi = ((DMDTC IS N...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.dthdtc\".\n"
+                                            "message": "column \"dmdtc\" does not exist\nLINE 1: ...ET vb1povxdlq7iaioqsfc5ue8ruduvalyvi0smfpne6q = ((DMDTC IS N...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"dm.dthdtc\".\n"
                                         }
                                     ]
                                 ]
@@ -100488,7 +100572,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfpendtc\" does not exist\nLINE 1: ...T vsjczqsmbnztf1kqnuez6myf0m1jag2vihnhz1gmm8o = ((RFPENDTC I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"lb.lbendtc\".\n"
+                                            "message": "column \"rfpendtc\" does not exist\nLINE 1: ...T v0bzjeky2azlmbpy7gjpjzwgha59zldqkrgjkiedh7g = ((RFPENDTC I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"lb.lbendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -100503,7 +100587,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"rfpendtc\" does not exist\nLINE 1: ...T vsjczqsmbnztf1kqnuez6myf0m1jag2vihnhz1gmm8o = ((RFPENDTC I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ce.ceendtc\".\n"
+                                            "message": "column \"rfpendtc\" does not exist\nLINE 1: ...T v0bzjeky2azlmbpy7gjpjzwgha59zldqkrgjkiedh7g = ((RFPENDTC I...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"ce.ceendtc\".\n"
                                         }
                                     ]
                                 ]
@@ -101107,7 +101191,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ethnic\" does not exist\nLINE 1: ...ET vqvmned0s9vkjr839gwof6odvebrjbpyoa5bdzborq = ((ETHNIC IS ...\n                                                             ^\n"
+                                            "message": "column \"ethnic\" does not exist\nLINE 1: ...ET vyu2kxrowmrb0difpoqtft1cukawlgkygkpiwdmy9s = ((ETHNIC IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -101122,7 +101206,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"qnam\" does not exist\nLINE 1: ...ET vna5nvzk85cuzxlac8lrt6qjddcv9iroehja66ep6ek = (qnam IS NO...\n                                                             ^\n"
+                                            "message": "column \"qnam\" does not exist\nLINE 1: ...T vd7ebbvqg5x3ga3e2czoep2u8ttokmxnzvbxdzlpdakw = (qnam IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -101183,7 +101267,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ethnic\" does not exist\nLINE 1: ...ET vqvmned0s9vkjr839gwof6odvebrjbpyoa5bdzborq = ((ETHNIC IS ...\n                                                             ^\n"
+                                            "message": "column \"ethnic\" does not exist\nLINE 1: ...ET vyu2kxrowmrb0difpoqtft1cukawlgkygkpiwdmy9s = ((ETHNIC IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -101198,7 +101282,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"qnam\" does not exist\nLINE 1: ...ET vna5nvzk85cuzxlac8lrt6qjddcv9iroehja66ep6ek = (qnam IS NO...\n                                                             ^\n"
+                                            "message": "column \"qnam\" does not exist\nLINE 1: ...T vd7ebbvqg5x3ga3e2czoep2u8ttokmxnzvbxdzlpdakw = (qnam IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -101741,7 +101825,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vqpe4jgxihkepualtlofertz4u33b7j1spbv9g8eony = ($trt_count...\n                                                             ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -101791,7 +101875,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vqpe4jgxihkepualtlofertz4u33b7j1spbv9g8eony = ($trt_count...\n                                                             ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -101844,7 +101928,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vqpe4jgxihkepualtlofertz4u33b7j1spbv9g8eony = ($trt_count...\n                                                             ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -102167,7 +102251,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($age_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -102220,7 +102304,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($age_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -102455,7 +102539,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($crmdur_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -102508,7 +102592,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 2:                             CAST($crmdur_count AS NUMERIC)\n                                         ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -102739,7 +102823,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "contains_all check_operator not implemented"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -102789,7 +102873,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "contains_all check_operator not implemented"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -102839,7 +102923,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "contains_all check_operator not implemented"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -102907,7 +102991,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...T vmiasi2ijwsc436xrnpj9qvfhihpixgwrjustqvlgski = ($hltsubji ...\n                                                             ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -102960,7 +103044,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...T vmiasi2ijwsc436xrnpj9qvfhihpixgwrjustqvlgski = ($hltsubji ...\n                                                             ^\n"
+                                            "message": "Operation record_count is not implemented"
                                         }
                                     ]
                                 ]
@@ -103281,7 +103365,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ethnic\" does not exist\nLINE 1: ...ET vqvmned0s9vkjr839gwof6odvebrjbpyoa5bdzborq = ((ETHNIC IS ...\n                                                             ^\n"
+                                            "message": "column \"ethnic\" does not exist\nLINE 1: ...ET vyu2kxrowmrb0difpoqtft1cukawlgkygkpiwdmy9s = ((ETHNIC IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -103296,7 +103380,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"qnam\" does not exist\nLINE 1: ...ET vna5nvzk85cuzxlac8lrt6qjddcv9iroehja66ep6ek = (qnam IS NO...\n                                                             ^\n"
+                                            "message": "column \"qnam\" does not exist\nLINE 1: ...T vd7ebbvqg5x3ga3e2czoep2u8ttokmxnzvbxdzlpdakw = (qnam IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -103357,7 +103441,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"ethnic\" does not exist\nLINE 1: ...ET vqvmned0s9vkjr839gwof6odvebrjbpyoa5bdzborq = ((ETHNIC IS ...\n                                                             ^\n"
+                                            "message": "column \"ethnic\" does not exist\nLINE 1: ...ET vyu2kxrowmrb0difpoqtft1cukawlgkygkpiwdmy9s = ((ETHNIC IS ...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -103372,7 +103456,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"qnam\" does not exist\nLINE 1: ...ET vna5nvzk85cuzxlac8lrt6qjddcv9iroehja66ep6ek = (qnam IS NO...\n                                                             ^\n"
+                                            "message": "column \"qnam\" does not exist\nLINE 1: ...T vd7ebbvqg5x3ga3e2czoep2u8ttokmxnzvbxdzlpdakw = (qnam IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -103446,7 +103530,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"race\" does not exist\nLINE 1: ...T vsovqbfjklfupsnsmkqyhevrkwttgubnk1tnjuauiia = ((RACE IS NU...\n                                                             ^\n"
+                                            "message": "column \"race\" does not exist\nLINE 1: ...ET vsph8xn8blgkuqw8yvsdwndgrnugbmcqgfxboazjn0 = ((RACE IS NU...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -103461,7 +103545,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"qnam\" does not exist\nLINE 1: ...ET vdigyajl5l7mjbkauhurgpnopxtpnxwtqjnnbuufuxo = (qnam IS NO...\n                                                             ^\n"
+                                            "message": "column \"qnam\" does not exist\nLINE 1: ...T vlll1espw5qz9vurn1assg7jqfjyf8po5infuvhyjfxg = (qnam IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -103522,7 +103606,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"race\" does not exist\nLINE 1: ...T vsovqbfjklfupsnsmkqyhevrkwttgubnk1tnjuauiia = ((RACE IS NU...\n                                                             ^\n"
+                                            "message": "column \"race\" does not exist\nLINE 1: ...ET vsph8xn8blgkuqw8yvsdwndgrnugbmcqgfxboazjn0 = ((RACE IS NU...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -103537,7 +103621,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"qnam\" does not exist\nLINE 1: ...ET vdigyajl5l7mjbkauhurgpnopxtpnxwtqjnnbuufuxo = (qnam IS NO...\n                                                             ^\n"
+                                            "message": "column \"qnam\" does not exist\nLINE 1: ...T vlll1espw5qz9vurn1assg7jqfjyf8po5infuvhyjfxg = (qnam IS NO...\n                                                             ^\n"
                                         }
                                     ]
                                 ]
@@ -103759,39 +103843,18 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ts.xpt",
                                 "domain": "TS",
-                                "execution_status": "success",
-                                "execution_message": "TSVCDVER is not a valid published version (date)",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "$valid_dates": "Not in dataset",
-                                            "tsvcdref": "CDISC"
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation valid_codelist_dates is not implemented"
                                         }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "$valid_dates": "Not in dataset",
-                                            "tsvcdref": "CDISC"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "$valid_dates": "Not in dataset",
-                                            "tsvcdref": "CDISC"
-                                        }
-                                    }
+                                    ]
                                 ]
                             }
                         ],
@@ -103833,39 +103896,18 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ts.xpt",
                                 "domain": "TS",
-                                "execution_status": "success",
-                                "execution_message": "TSVCDVER is not a valid published version (date)",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "$valid_dates": "Not in dataset",
-                                            "tsvcdref": "CDISC"
+                                    [
+                                        {
+                                            "error": "An unknown exception has occurred",
+                                            "message": "Operation valid_codelist_dates is not implemented"
                                         }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "$valid_dates": "Not in dataset",
-                                            "tsvcdref": "CDISC"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "$valid_dates": "Not in dataset",
-                                            "tsvcdref": "CDISC"
-                                        }
-                                    }
+                                    ]
                                 ]
                             }
                         ],
@@ -104178,7 +104220,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"cmterm\" does not exist\nLINE 1: ...6n2z5umw8b4g0lseoch5uimkryfaslljwzn6l9lbg = (NOT (cmterm IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmtrt\".\n"
+                                            "message": "column \"cmterm\" does not exist\nLINE 1: ...vh8ruy6kc8jywogs9czddyozbnmmwz4gvuaatyh0m = (NOT (cmterm IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmtrt\".\n"
                                         }
                                     ]
                                 ]
@@ -104222,7 +104264,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"fadecod\" does not exist\nLINE 1: ...T vpf7zm7ftq6ohwxuokimrvgkrc8w3vpjkw1tmtbpfvu = ((FADECOD IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"fa.fadtc\".\n"
+                                            "message": "column \"fadecod\" does not exist\nLINE 1: ...a SET vsir231wopcy37e9qyt3wnjmdw284y62o8nglag = ((FADECOD IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"fa.fadtc\".\n"
                                         }
                                     ]
                                 ]
@@ -104237,7 +104279,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at end of input\nLINE 1: ...g6t6izgkxlcdm1ow7cumg = ((--DECOD IS NULL OR --DECOD = ''));\n                                                                       ^\n"
+                                            "message": "syntax error at end of input\nLINE 1: ...h2tiwskd1vqdpvalkqfxm = ((--DECOD IS NULL OR --DECOD = ''));\n                                                                       ^\n"
                                         }
                                     ]
                                 ]
@@ -104335,7 +104377,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"cmterm\" does not exist\nLINE 1: ...6n2z5umw8b4g0lseoch5uimkryfaslljwzn6l9lbg = (NOT (cmterm IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmtrt\".\n"
+                                            "message": "column \"cmterm\" does not exist\nLINE 1: ...vh8ruy6kc8jywogs9czddyozbnmmwz4gvuaatyh0m = (NOT (cmterm IS ...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"cm.cmtrt\".\n"
                                         }
                                     ]
                                 ]
@@ -104358,7 +104400,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "column \"fadecod\" does not exist\nLINE 1: ...T vpf7zm7ftq6ohwxuokimrvgkrc8w3vpjkw1tmtbpfvu = ((FADECOD IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"fa.fadtc\".\n"
+                                            "message": "column \"fadecod\" does not exist\nLINE 1: ...a SET vsir231wopcy37e9qyt3wnjmdw284y62o8nglag = ((FADECOD IS...\n                                                             ^\nHINT:  Perhaps you meant to reference the column \"fa.fadtc\".\n"
                                         }
                                     ]
                                 ]
@@ -104373,7 +104415,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at end of input\nLINE 1: ...g6t6izgkxlcdm1ow7cumg = ((--DECOD IS NULL OR --DECOD = ''));\n                                                                       ^\n"
+                                            "message": "syntax error at end of input\nLINE 1: ...h2tiwskd1vqdpvalkqfxm = ((--DECOD IS NULL OR --DECOD = ''));\n                                                                       ^\n"
                                         }
                                     ]
                                 ]
@@ -104517,7 +104559,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at end of input\nLINE 1: ...g6t6izgkxlcdm1ow7cumg = ((--DECOD IS NULL OR --DECOD = ''));\n                                                                       ^\n"
+                                            "message": "syntax error at end of input\nLINE 1: ...h2tiwskd1vqdpvalkqfxm = ((--DECOD IS NULL OR --DECOD = ''));\n                                                                       ^\n"
                                         }
                                     ]
                                 ]
@@ -104675,7 +104717,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at end of input\nLINE 1: ...g6t6izgkxlcdm1ow7cumg = ((--DECOD IS NULL OR --DECOD = ''));\n                                                                       ^\n"
+                                            "message": "syntax error at end of input\nLINE 1: ...h2tiwskd1vqdpvalkqfxm = ((--DECOD IS NULL OR --DECOD = ''));\n                                                                       ^\n"
                                         }
                                     ]
                                 ]
@@ -105269,7 +105311,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105284,7 +105326,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105299,7 +105341,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105314,7 +105356,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105329,7 +105371,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105344,7 +105386,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105359,7 +105401,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105374,7 +105416,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105389,7 +105431,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105404,7 +105446,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105419,7 +105461,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105434,7 +105476,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105449,7 +105491,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105604,7 +105646,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105619,7 +105661,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105634,7 +105676,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105649,7 +105691,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105664,7 +105706,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105679,7 +105721,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105694,7 +105736,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105709,7 +105751,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105724,7 +105766,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105739,7 +105781,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105754,7 +105796,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105769,7 +105811,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105784,7 +105826,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105939,7 +105981,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105954,7 +105996,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105969,7 +106011,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105984,7 +106026,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -105999,7 +106041,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106014,7 +106056,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106029,7 +106071,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106044,7 +106086,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106059,7 +106101,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106074,7 +106116,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106089,7 +106131,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106104,7 +106146,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106119,7 +106161,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106274,7 +106316,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106289,7 +106331,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106304,7 +106346,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106319,7 +106361,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106334,7 +106376,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106349,7 +106391,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106364,7 +106406,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106379,7 +106421,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106394,7 +106436,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106409,7 +106451,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106424,7 +106466,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106439,7 +106481,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106454,7 +106496,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106622,7 +106664,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106637,7 +106679,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106652,7 +106694,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106667,7 +106709,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106682,7 +106724,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106697,7 +106739,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106712,7 +106754,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106727,7 +106769,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106742,7 +106784,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106757,7 +106799,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106772,7 +106814,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106787,7 +106829,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106802,7 +106844,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106817,7 +106859,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106971,7 +107013,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -106986,7 +107028,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107001,7 +107043,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107016,7 +107058,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107031,7 +107073,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107046,7 +107088,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107061,7 +107103,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107076,7 +107118,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107091,7 +107133,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107106,7 +107148,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107121,7 +107163,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107136,7 +107178,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107151,7 +107193,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107166,7 +107208,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107320,7 +107362,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107335,7 +107377,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107350,7 +107392,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107365,7 +107407,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107380,7 +107422,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107395,7 +107437,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107410,7 +107452,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107425,7 +107467,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107440,7 +107482,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107455,7 +107497,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107470,7 +107512,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107485,7 +107527,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107500,7 +107542,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107515,7 +107557,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107669,7 +107711,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107684,7 +107726,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107699,7 +107741,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107714,7 +107756,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107729,7 +107771,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107744,7 +107786,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107759,7 +107801,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107774,7 +107816,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107789,7 +107831,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107804,7 +107846,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107819,7 +107861,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107834,7 +107876,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107849,7 +107891,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -107864,7 +107906,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108018,7 +108060,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108033,7 +108075,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108048,7 +108090,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108063,7 +108105,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108078,7 +108120,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108093,7 +108135,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108108,7 +108150,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108123,7 +108165,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108138,7 +108180,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108153,7 +108195,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108168,7 +108210,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108183,7 +108225,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108198,7 +108240,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]
@@ -108213,7 +108255,7 @@
                                     [
                                         {
                                             "error": "An unknown exception has occurred",
-                                            "message": "syntax error at or near \"$\"\nLINE 1: ...ET vojedc4zhgzrjtoqcfyns31awytlywk0hthikj2vfre = ($relmids_e...\n                                                             ^\n"
+                                            "message": "Operation variable_exists is not implemented"
                                         }
                                     ]
                                 ]

--- a/tests/rule_regression/conftest.py
+++ b/tests/rule_regression/conftest.py
@@ -1,7 +1,8 @@
-import pytest
 import pickle
 from ast import literal_eval
+
 import pandas as pd
+import pytest
 
 
 @pytest.fixture
@@ -63,15 +64,22 @@ def get_sample_lb_rule() -> dict:
             "all": [
                 {
                     "name": "get_dataset",
-                    "operator": "greater_than",
-                    "value": {"target": "LBSEQ", "comparator": 0},
+                    "operator": "less_than",
+                    "value": {"target": "LBSEQ", "comparator": "$lbseqmax"},
                 }
             ]
         },
+        "operations": [
+            {
+                "id": "$lbseqmax",
+                "name": "LBSEQ",
+                "operator": "max",
+            }
+        ],
         "actions": [
             {
                 "name": "generate_dataset_error_objects",
-                "params": {"message": "LBSEQ greater than 0"},
+                "params": {"message": "LBSEQ less than maximum value"},
             }
         ],
     }


### PR DESCRIPTION
Adds the initial scaffolding for running operations. It's structured in a similar way to the original, but with lots of stuff trimmed out.

I've implemented two example operations, `DISTINCT` which returns a SQL query which is a list and `MAX` which is a SQL query returning a single value

The actual `output_variables` are passed through to the class where the check operators are executed but not used yet. Will come in another PR