### PR TITLE
chore: valid rule structure based rule skipping

### DIFF
--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -289,12 +289,12 @@ class SQLRuleProcessor:
     #         return True
     #     return False
 
-    # def valid_rule_structure(self, rule) -> bool:
-    #     required_keys = ["standards", "core_id"]
-    #     for key in required_keys:
-    #         if key not in rule:
-    #             return False
-    #     return True
+    def valid_rule_structure(self, rule) -> bool:
+        required_keys = ["standards", "core_id"]
+        for key in required_keys:
+            if key not in rule:
+                return False
+        return True
 
     # @staticmethod
     # def _ct_package_type_api_name(ct_package_type: str | None) -> str:
@@ -447,14 +447,14 @@ class SQLRuleProcessor:
         rule_id = rule.get("core_id", "unknown")
         dataset_name = dataset_metadata.dataset_name
 
+        if not self.valid_rule_structure(rule):
+            reason = f"Rule skipped - invalid rule structure for rule id={rule_id}"
+            logger.info(f"is_suitable_for_validation. {reason}, result=False")
+            return False, reason
         if not self.rule_applies_to_domain(dataset_metadata, rule):
             reason = f"Rule skipped - doesn't apply to domain for rule id={rule_id}, dataset={dataset_name}"
             logger.info(f"is_suitable_for_validation. {reason}, result=False")
             return False, reason
-        # if not self.valid_rule_structure(rule):
-        #     reason = f"Rule skipped - invalid rule structure for rule id={rule_id}"
-        #     logger.info(f"is_suitable_for_validation. {reason}, result=False")
-        #     return False, reason
         # if not self.rule_applies_to_use_case(dataset_metadata, rule, standard, standard_substandard):
         #     reason = f"Rule skipped - doesn't apply to use case for " f"rule id={rule_id}, dataset={dataset_name}"
         #     logger.info(f"is_suitable_for_validation. {reason}, result=False")

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -289,13 +289,6 @@ class SQLRuleProcessor:
     #         return True
     #     return False
 
-    def valid_rule_structure(self, rule) -> bool:
-        required_keys = ["standards", "core_id"]
-        for key in required_keys:
-            if key not in rule:
-                return False
-        return True
-
     # @staticmethod
     # def _ct_package_type_api_name(ct_package_type: str | None) -> str:
     #     if ct_package_type is None:
@@ -447,10 +440,6 @@ class SQLRuleProcessor:
         rule_id = rule.get("core_id", "unknown")
         dataset_name = dataset_metadata.dataset_name
 
-        if not self.valid_rule_structure(rule):
-            reason = f"Rule skipped - invalid rule structure for rule id={rule_id}"
-            logger.info(f"is_suitable_for_validation. {reason}, result=False")
-            return False, reason
         if not self.rule_applies_to_domain(dataset_metadata, rule):
             reason = f"Rule skipped - doesn't apply to domain for rule id={rule_id}, dataset={dataset_name}"
             logger.info(f"is_suitable_for_validation. {reason}, result=False")
@@ -459,15 +448,11 @@ class SQLRuleProcessor:
         #     reason = f"Rule skipped - doesn't apply to use case for " f"rule id={rule_id}, dataset={dataset_name}"
         #     logger.info(f"is_suitable_for_validation. {reason}, result=False")
         #     return False, reason
-        # if not self.rule_applies_to_domain(dataset_metadata, rule):
-        #     reason = f"Rule skipped - doesn't apply to domain for " f"rule id={rule_id}, dataset={dataset_name}"
-        #     logger.info(f"is_suitable_for_validation. {reason}, result=False")
-        #     return False, reason
         # if not self.rule_applies_to_class(rule, datasets, dataset_metadata):
         #     reason = f"Rule skipped - doesn't apply to class for " f"rule id={rule_id}, dataset={dataset_name}"
         #     logger.info(f"is_suitable_for_validation. {reason}, result=False")
         #     return False, reason
-        # TODO: uncomment and reimplement above other checks (class, use-case, rule structure)
+        # TODO: uncomment and reimplement above other checks (i.e. class, use-case)
 
         logger.info(f"is_suitable_for_validation. rule id={rule_id}, dataset={dataset_name}, result=True")
         return True, ""
@@ -548,3 +533,11 @@ class SQLRuleProcessor:
     #     """
     #     actions: List[dict] = rule["actions"]
     #     return actions[0]["params"]["message"]
+
+    @staticmethod
+    def valid_rule_structure(rule) -> bool:
+        required_keys = ["standards", "core_id"]
+        for key in required_keys:
+            if key not in rule:
+                return False
+        return True

--- a/scripts/run_sql_validation.py
+++ b/scripts/run_sql_validation.py
@@ -43,6 +43,7 @@ from scripts.script_utils import (
 )
 from cdisc_rules_engine.services.reporting import BaseReport, ReportFactory
 from cdisc_rules_engine.utilities.progress_displayers import get_progress_displayer
+from cdisc_rules_engine.utilities.sql_rule_processor import SQLRuleProcessor
 from warnings import simplefilter
 import os
 
@@ -67,6 +68,10 @@ def sql_validate_single_rule(
     library_metadata: LibraryMetadataContainer,
     rule: dict = None,
 ):
+    if not SQLRuleProcessor.valid_rule_structure(rule):
+        engine_logger.error(f"Invalid rule structure: {rule}")
+        return RuleValidationResult(rule, [])
+
     rule["conditions"] = ConditionCompositeFactory.get_condition_composite(rule["conditions"])
     max_dataset_size = max(datasets, key=lambda x: x.file_size).file_size
     # call rule engine

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -4904,470 +4904,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
-                                "domain": "AG",
-                                "execution_status": "success",
-                                "execution_message": "AGOCCUR should only be provided when AGPRESP is equal to \"Y\".",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "agoccur": "Y",
-                                            "agpresp": null,
-                                            "agstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "agoccur": "N",
-                                            "agpresp": null,
-                                            "agstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "agoccur": "Y",
-                                            "agpresp": null,
-                                            "agstat": "NOT DONE"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "CM",
-                                "execution_status": "success",
-                                "execution_message": "CMOCCUR should only be provided when CMPRESP is equal to \"Y\".",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "cmoccur": "Y",
-                                            "cmpresp": null,
-                                            "cmstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "cmoccur": "N",
-                                            "cmpresp": null,
-                                            "cmstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "cmoccur": "Y",
-                                            "cmpresp": null,
-                                            "cmstat": "NOT DONE"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "ec.xpt",
-                                "domain": "EC",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ecstat does not exist in the table ec."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column expresp does not exist in the table ex."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "ML",
-                                "execution_status": "success",
-                                "execution_message": "MLOCCUR should only be provided when MLPRESP is equal to \"Y\".",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mloccur": "Y",
-                                            "mlpresp": null,
-                                            "mlstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mloccur": "N",
-                                            "mlpresp": null,
-                                            "mlstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mloccur": "Y",
-                                            "mlpresp": null,
-                                            "mlstat": "NOT DONE"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "PR",
-                                "execution_status": "success",
-                                "execution_message": "PROCCUR should only be provided when PRPRESP is equal to \"Y\".",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "proccur": "Y",
-                                            "prpresp": null,
-                                            "prstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "proccur": "N",
-                                            "prpresp": null,
-                                            "prstat": "NOT DONE"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "proccur": "Y",
-                                            "prpresp": null,
-                                            "prstat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUOCCUR should only be provided when SUPRESP is equal to \"Y\".",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "suoccur": "Y",
-                                            "supresp": null,
-                                            "sustat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "suoccur": "N",
-                                            "supresp": null,
-                                            "sustat": "NOT DONE"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "suoccur": "Y",
-                                            "supresp": null,
-                                            "sustat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AEOCCUR does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "BE",
-                                "execution_status": "success",
-                                "execution_message": "BEOCCUR should only be provided when BEPRESP is equal to \"Y\".",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": "Y",
-                                            "bepresp": null,
-                                            "bestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": "N",
-                                            "bepresp": null,
-                                            "bestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": "Y",
-                                            "bepresp": null,
-                                            "bestat": "NOT DONE"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": "N",
-                                            "bepresp": null,
-                                            "bestat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "CE",
-                                "execution_status": "success",
-                                "execution_message": "CEOCCUR should only be provided when CEPRESP is equal to \"Y\".",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": "Y",
-                                            "cepresp": null,
-                                            "cestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": "N",
-                                            "cepresp": null,
-                                            "cestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": "Y",
-                                            "cepresp": null,
-                                            "cestat": "NOT DONE"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": "N",
-                                            "cepresp": null,
-                                            "cestat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "ds.xpt",
-                                "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dspresp does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dv.xpt",
-                                "domain": "DV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dvpresp does not exist in the table dv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "HO",
-                                "execution_status": "success",
-                                "execution_message": "HOOCCUR should only be provided when HOPRESP is equal to \"Y\".",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": "Y",
-                                            "hopresp": null,
-                                            "hostat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": "N",
-                                            "hopresp": null,
-                                            "hostat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": "Y",
-                                            "hopresp": null,
-                                            "hostat": "NOT DONE"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": "N",
-                                            "hopresp": null,
-                                            "hostat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "MH",
-                                "execution_status": "success",
-                                "execution_message": "MHOCCUR should only be provided when MHPRESP is equal to \"Y\".",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": "Y",
-                                            "mhpresp": null,
-                                            "mhstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": "N",
-                                            "mhpresp": null,
-                                            "mhstat": "NOT DONE"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": "Y",
-                                            "mhpresp": null,
-                                            "mhstat": "NOT DONE"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": "N",
-                                            "mhpresp": null,
-                                            "mhstat": null
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000014, dataset=ex",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -6009,149 +5551,10 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ag.xpt",
-                                "domain": "AG",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "cm.xpt",
-                                "domain": "CM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ec.xpt",
-                                "domain": "EC",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ecstat does not exist in the table ec."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column expresp does not exist in the table ex."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ml.xpt",
-                                "domain": "ML",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "pr.xpt",
-                                "domain": "PR",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "su.xpt",
-                                "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AEOCCUR does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "be.xpt",
-                                "domain": "BE",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ce.xpt",
-                                "domain": "CE",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ds.xpt",
-                                "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dspresp does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dv.xpt",
-                                "domain": "DV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dvpresp does not exist in the table dv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ho.xpt",
-                                "domain": "HO",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "mh.xpt",
-                                "domain": "MH",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000014, dataset=ex",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -7114,350 +6517,10 @@
                             {
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column EXOCCUR does not exist in the table ex."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "ML",
-                                "execution_status": "success",
-                                "execution_message": "MLPRESP should be populated as \"Y\" when MLOCCUR is provided.",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mloccur": "Y",
-                                            "mlpresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mloccur": "N",
-                                            "mlpresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mloccur": "Y",
-                                            "mlpresp": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "PR",
-                                "execution_status": "success",
-                                "execution_message": "PRPRESP should be populated as \"Y\" when PROCCUR is provided.",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "proccur": "Y",
-                                            "prpresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "proccur": "N",
-                                            "prpresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "proccur": "Y",
-                                            "prpresp": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUPRESP should be populated as \"Y\" when SUOCCUR is provided.",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "suoccur": "Y",
-                                            "supresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "suoccur": "N",
-                                            "supresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "suoccur": "N",
-                                            "supresp": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AEOCCUR does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "BE",
-                                "execution_status": "success",
-                                "execution_message": "BEPRESP should be populated as \"Y\" when BEOCCUR is provided.",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": "Y",
-                                            "bepresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": "N",
-                                            "bepresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": "Y",
-                                            "bepresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": "N",
-                                            "bepresp": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "CE",
-                                "execution_status": "success",
-                                "execution_message": "CEPRESP should be populated as \"Y\" when CEOCCUR is provided.",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": "Y",
-                                            "cepresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": "Y",
-                                            "cepresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": "Y",
-                                            "cepresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": "N",
-                                            "cepresp": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "ds.xpt",
-                                "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DSOCCUR does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dv.xpt",
-                                "domain": "DV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DVOCCUR does not exist in the table dv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "HO",
-                                "execution_status": "success",
-                                "execution_message": "HOPRESP should be populated as \"Y\" when HOOCCUR is provided.",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": "Y",
-                                            "hopresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": "Y",
-                                            "hopresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": "Y",
-                                            "hopresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": "N",
-                                            "hopresp": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "MH",
-                                "execution_status": "success",
-                                "execution_message": "MHPRESP should be populated as \"Y\" when MHOCCUR is provided.",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": "Y",
-                                            "mhpresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": "Y",
-                                            "mhpresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": "Y",
-                                            "mhpresp": null
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": "N",
-                                            "mhpresp": null
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000016, dataset=ex",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -8067,116 +7130,8 @@
                             {
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column EXOCCUR does not exist in the table ex."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ml.xpt",
-                                "domain": "ML",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "pr.xpt",
-                                "domain": "PR",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "su.xpt",
-                                "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AEOCCUR does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "be.xpt",
-                                "domain": "BE",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ce.xpt",
-                                "domain": "CE",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ds.xpt",
-                                "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DSOCCUR does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dv.xpt",
-                                "domain": "DV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DVOCCUR does not exist in the table dv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ho.xpt",
-                                "domain": "HO",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "mh.xpt",
-                                "domain": "MH",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000016, dataset=ex",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -8867,431 +7822,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
-                                "domain": "AG",
-                                "execution_status": "success",
-                                "execution_message": "AGOCCUR is blank when AGPRESP is equal to \"Y\" and AGSTAT is not provided.",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "agoccur": null,
-                                            "agpresp": "Y",
-                                            "agstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "agoccur": null,
-                                            "agpresp": "Y",
-                                            "agstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "agoccur": null,
-                                            "agpresp": "Y",
-                                            "agstat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "ec.xpt",
-                                "domain": "EC",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ECSTAT does not exist in the table ec."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column expresp does not exist in the table ex."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "ML",
-                                "execution_status": "success",
-                                "execution_message": "MLOCCUR is blank when MLPRESP is equal to \"Y\" and MLSTAT is not provided.",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mloccur": null,
-                                            "mlpresp": "Y",
-                                            "mlstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mloccur": null,
-                                            "mlpresp": "Y",
-                                            "mlstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mloccur": null,
-                                            "mlpresp": "Y",
-                                            "mlstat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "PR",
-                                "execution_status": "success",
-                                "execution_message": "PROCCUR is blank when PRPRESP is equal to \"Y\" and PRSTAT is not provided.",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "proccur": null,
-                                            "prpresp": "Y",
-                                            "prstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "proccur": null,
-                                            "prpresp": "Y",
-                                            "prstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "proccur": null,
-                                            "prpresp": "Y",
-                                            "prstat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUOCCUR is blank when SUPRESP is equal to \"Y\" and SUSTAT is not provided.",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "suoccur": null,
-                                            "supresp": "Y",
-                                            "sustat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "suoccur": null,
-                                            "supresp": "Y",
-                                            "sustat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "suoccur": null,
-                                            "supresp": "Y",
-                                            "sustat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AESTAT does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "BE",
-                                "execution_status": "success",
-                                "execution_message": "BEOCCUR is blank when BEPRESP is equal to \"Y\" and BESTAT is not provided.",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": null,
-                                            "bepresp": "Y",
-                                            "bestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": null,
-                                            "bepresp": "Y",
-                                            "bestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": null,
-                                            "bepresp": "Y",
-                                            "bestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "beoccur": null,
-                                            "bepresp": "Y",
-                                            "bestat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "CE",
-                                "execution_status": "success",
-                                "execution_message": "CEOCCUR is blank when CEPRESP is equal to \"Y\" and CESTAT is not provided.",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": null,
-                                            "cepresp": "Y",
-                                            "cestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": null,
-                                            "cepresp": "Y",
-                                            "cestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": null,
-                                            "cepresp": "Y",
-                                            "cestat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "ceoccur": null,
-                                            "cepresp": "Y",
-                                            "cestat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "ds.xpt",
-                                "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dspresp does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dv.xpt",
-                                "domain": "DV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dvpresp does not exist in the table dv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "HO",
-                                "execution_status": "success",
-                                "execution_message": "HOOCCUR is blank when HOPRESP is equal to \"Y\" and HOSTAT is not provided.",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": null,
-                                            "hopresp": "Y",
-                                            "hostat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": null,
-                                            "hopresp": "Y",
-                                            "hostat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": null,
-                                            "hopresp": "Y",
-                                            "hostat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "hooccur": null,
-                                            "hopresp": "Y",
-                                            "hostat": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "MH",
-                                "execution_status": "success",
-                                "execution_message": "MHOCCUR is blank when MHPRESP is equal to \"Y\" and MHSTAT is not provided.",
-                                "number_errors": 4,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": null,
-                                            "mhpresp": "Y",
-                                            "mhstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": null,
-                                            "mhpresp": "Y",
-                                            "mhstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": null,
-                                            "mhpresp": "Y",
-                                            "mhstat": null
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "mhoccur": null,
-                                            "mhpresp": "Y",
-                                            "mhstat": null
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000018, dataset=ex",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -9868,149 +8404,10 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ag.xpt",
-                                "domain": "AG",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "cm.xpt",
-                                "domain": "CM",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ec.xpt",
-                                "domain": "EC",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ECSTAT does not exist in the table ec."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column expresp does not exist in the table ex."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ml.xpt",
-                                "domain": "ML",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "pr.xpt",
-                                "domain": "PR",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "su.xpt",
-                                "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AESTAT does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "be.xpt",
-                                "domain": "BE",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ce.xpt",
-                                "domain": "CE",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "ds.xpt",
-                                "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dspresp does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dv.xpt",
-                                "domain": "DV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dvpresp does not exist in the table dv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ho.xpt",
-                                "domain": "HO",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "mh.xpt",
-                                "domain": "MH",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000018, dataset=ex",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -10993,12 +9390,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column iedrvfl does not exist in the table ie."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column iedrvfl does not exist in the table ie."
+                                    }
                                 ]
                             },
                             {
@@ -12432,12 +10827,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column TEENRL does not exist in the table te."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column TEENRL does not exist in the table te."
+                                    }
                                 ]
                             }
                         ],
@@ -12716,12 +11109,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column PCTPTREF does not exist in the table pc."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column PCTPTREF does not exist in the table pc."
+                                    }
                                 ]
                             }
                         ],
@@ -13621,76 +12012,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dsdecod does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "DS",
-                                "execution_status": "success",
-                                "execution_message": "DSSTDTC does not equal DM.DTHDTC, when DSDECOD equals \"DEATH\".",
-                                "number_errors": 5,
-                                "errors": [
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": "2022-02-20",
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": "2018-09-04",
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": null,
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": "2019-01-10",
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": "2021-01-10",
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000034, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -13772,76 +12097,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dsdecod does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "DS",
-                                "execution_status": "success",
-                                "execution_message": "DSSTDTC does not equal DM.DTHDTC, when DSDECOD equals \"DEATH\".",
-                                "number_errors": 5,
-                                "errors": [
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": "2022-02-20",
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": "2018-09-04",
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": null,
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": "2019-01-10",
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "dsdecod": "DEATH",
-                                            "dsstdtc": "2021-02-16",
-                                            "dthdtc": "Not in dataset"
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000034, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -14072,34 +12331,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visit is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000036, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -14160,34 +12397,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visit is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000036, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -14345,34 +12560,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000039, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -14418,34 +12611,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table sv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000039, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -14506,34 +12677,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000039, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -14607,34 +12756,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column SVPRESP does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000040, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -14695,34 +12822,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column SVPRESP does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000040, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -15580,34 +13685,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_arm is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ACTARM does not exist in the table ta."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000047, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -15656,34 +13739,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_arm is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ACTARM does not exist in the table ta."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000047, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -19816,12 +17877,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column vsdrvfl does not exist in the table vs."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column vsdrvfl does not exist in the table vs."
+                                    }
                                 ]
                             }
                         ],
@@ -20015,12 +18074,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column vsdrvfl does not exist in the table vs."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column vsdrvfl does not exist in the table vs."
+                                    }
                                 ]
                             }
                         ],
@@ -21867,12 +19924,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AGDOSTOT does not exist in the table ag."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column AGDOSTOT does not exist in the table ag."
+                                    }
                                 ]
                             },
                             {
@@ -21902,12 +19957,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ECDOSTOT does not exist in the table ec."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column ECDOSTOT does not exist in the table ec."
+                                    }
                                 ]
                             },
                             {
@@ -21917,12 +19970,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column EXDOSTOT does not exist in the table ex."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column EXDOSTOT does not exist in the table ex."
+                                    }
                                 ]
                             },
                             {
@@ -21932,12 +19983,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column MLDOSTOT does not exist in the table ml."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column MLDOSTOT does not exist in the table ml."
+                                    }
                                 ]
                             },
                             {
@@ -21947,12 +19996,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column PRDOSTOT does not exist in the table pr."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column PRDOSTOT does not exist in the table pr."
+                                    }
                                 ]
                             },
                             {
@@ -22152,12 +20199,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AGDOSTOT does not exist in the table ag."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column AGDOSTOT does not exist in the table ag."
+                                    }
                                 ]
                             },
                             {
@@ -22175,12 +20220,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ECDOSTOT does not exist in the table ec."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column ECDOSTOT does not exist in the table ec."
+                                    }
                                 ]
                             },
                             {
@@ -22190,12 +20233,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column EXDOSTOT does not exist in the table ex."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column EXDOSTOT does not exist in the table ex."
+                                    }
                                 ]
                             },
                             {
@@ -22205,12 +20246,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column MLDOSTOT does not exist in the table ml."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column MLDOSTOT does not exist in the table ml."
+                                    }
                                 ]
                             },
                             {
@@ -22220,12 +20259,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column PRDOSTOT does not exist in the table pr."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column PRDOSTOT does not exist in the table pr."
+                                    }
                                 ]
                             },
                             {
@@ -22843,12 +20880,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column SEUPDES does not exist in the table se."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column SEUPDES does not exist in the table se."
+                                    }
                                 ]
                             }
                         ],
@@ -25675,34 +23710,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $usubjids_in_dd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "dd.xpt",
                                 "domain": "DD",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table dd."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000108, dataset=dd",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -25751,34 +23764,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $usubjids_in_dd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "dd.xpt",
                                 "domain": "DD",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table dd."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000108, dataset=dd",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -26891,12 +24882,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column lbspcufl does not exist in the table lb."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column lbspcufl does not exist in the table lb."
+                                    }
                                 ]
                             }
                         ],
@@ -27599,12 +25588,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AGETXT does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column AGETXT does not exist in the table dm."
+                                    }
                                 ]
                             }
                         ],
@@ -27706,12 +25693,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AGETXT does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column AGETXT does not exist in the table dm."
+                                    }
                                 ]
                             }
                         ],
@@ -29983,12 +27968,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -29998,12 +27981,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],
@@ -30085,12 +28066,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -30100,12 +28079,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],
@@ -30175,32 +28152,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ex.xpt",
-                                "domain": "EX",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000139, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -30337,34 +28292,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "cm.xpt",
-                                "domain": "CM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000139, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -30436,32 +28369,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ex.xpt",
-                                "domain": "EX",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000139, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -30507,34 +28418,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "cm.xpt",
-                                "domain": "CM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000139, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -30602,12 +28491,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             },
                             {
@@ -30617,12 +28504,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             }
                         ],
@@ -30829,12 +28714,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             },
                             {
@@ -30844,12 +28727,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             }
                         ],
@@ -30915,12 +28796,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             },
                             {
@@ -30930,12 +28809,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             }
                         ],
@@ -30988,12 +28865,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             },
                             {
@@ -31003,12 +28878,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             }
                         ],
@@ -31403,12 +29276,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "is_unique_set check_operator not implemented"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "is_unique_set check_operator not implemented"
+                                    }
                                 ]
                             }
                         ],
@@ -31467,12 +29338,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "is_unique_set check_operator not implemented"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "is_unique_set check_operator not implemented"
+                                    }
                                 ]
                             }
                         ],
@@ -31517,12 +29386,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "is_unique_set check_operator not implemented"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "is_unique_set check_operator not implemented"
+                                    }
                                 ]
                             }
                         ],
@@ -33191,32 +31058,10 @@
                             {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "tv.xpt",
-                                "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000155, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -33267,32 +31112,10 @@
                             {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "tv.xpt",
-                                "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000155, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -33356,32 +31179,10 @@
                             {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_arm is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "tv.xpt",
-                                "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_arm is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000156, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -33432,32 +31233,10 @@
                             {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_arm is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "tv.xpt",
-                                "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_arm is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000156, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -35176,79 +32955,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $sv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "oe.xpt",
-                                "domain": "OE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $sv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $sv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "tv.xpt",
-                                "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $sv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "vs.xpt",
-                                "domain": "VS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $sv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000168, dataset=sv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -36101,32 +33813,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "cm.xpt",
                                 "domain": "CM",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             }
@@ -36183,64 +33891,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "se.xpt",
                                 "domain": "SE",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
-                                "number_errors": 4,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
-                                "number_errors": 2,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT11"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             }
@@ -36321,32 +33993,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ft.xpt",
                                 "domain": "FT",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             }
@@ -36403,64 +34071,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT03"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             }
@@ -36536,48 +34168,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ec.xpt",
                                 "domain": "EC",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             }
@@ -36625,96 +34237,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
-                                "number_errors": 8,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
-                                "number_errors": 2,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "studyid": "CDISCPILOT01"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             }
@@ -36762,32 +34306,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ie.xpt",
                                 "domain": "IE",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             }
@@ -36835,32 +34375,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dv.xpt",
                                 "domain": "DV",
-                                "execution_status": "success",
-                                "execution_message": "STUDYID is not equal to DM.STUDYID",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_studyid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_studyid is not a constant."
                                     }
                                 ]
                             }
@@ -36924,34 +34460,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ta.xpt",
-                                "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $te_etcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "te.xpt",
                                 "domain": "TE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $te_etcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000173, dataset=te",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -36997,34 +34511,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "se.xpt",
-                                "domain": "SE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $te_etcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "te.xpt",
                                 "domain": "TE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $te_etcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000173, dataset=te",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -37073,34 +34565,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ta.xpt",
-                                "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $te_etcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "te.xpt",
                                 "domain": "TE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $te_etcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000173, dataset=te",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -37146,34 +34616,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "se.xpt",
-                                "domain": "SE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $te_etcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "te.xpt",
                                 "domain": "TE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $te_etcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000173, dataset=te",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -37573,32 +35021,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMENRF does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFENDTC does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000177, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -37687,32 +35113,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMENRF does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "cm.xpt",
-                                "domain": "CM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFENDTC does not exist in the table cm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000177, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -37796,32 +35200,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMENRF does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFENDTC does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000177, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -37869,32 +35251,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMENRF does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "cm.xpt",
-                                "domain": "CM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFENDTC does not exist in the table cm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000177, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -47137,12 +44497,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column lbdrvfl does not exist in the table lb."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column lbdrvfl does not exist in the table lb."
+                                    }
                                 ]
                             }
                         ],
@@ -47208,12 +44566,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column LBSTAT does not exist in the table lb."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column LBSTAT does not exist in the table lb."
+                                    }
                                 ]
                             }
                         ],
@@ -47374,56 +44730,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
-                                "domain": "relrec",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 2,
+                                "dataset": "relrec.xpt",
+                                "domain": "",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "S02"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-003"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-004"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             }
@@ -47488,95 +44816,41 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 2,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "003"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 4,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-002"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-003"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-004"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
-                                "domain": "relrec",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 3,
+                                "dataset": "relrec.xpt",
+                                "domain": "",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "006"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "007"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             }
@@ -47674,72 +44948,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "002"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "003"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 4,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-002"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-003"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-004"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             }
@@ -47813,56 +45043,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
-                                "domain": "relrec",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
+                                "dataset": "relrec.xpt",
+                                "domain": "",
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 4,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-002"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-003"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-004"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             }
@@ -47910,72 +45112,28 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-002"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-003"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "success",
-                                "execution_message": "USUBJID is not found in DM.USUBJID",
-                                "number_errors": 4,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-002"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-003"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "usubjid": "CDISC-TEST-004"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $dm_usubjid is not a constant."
                                     }
                                 ]
                             }
@@ -48091,32 +45249,10 @@
                             {
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000206, dataset=ae",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -48189,94 +45325,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "co.xpt",
-                                "domain": "CO",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table co."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "relrec.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "Rule format error",
-                                            "message": "Rule contains invalid operator"
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "supplb.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVARVAL does not exist in the table supplb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "suppdm.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000206, dataset=lb",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -48356,62 +45410,10 @@
                             {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "suppdm.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "Rule format error",
-                                            "message": "Rule contains invalid operator"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000206, dataset=lb",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -48648,34 +45650,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ACTARMCD does not exist in the table ta."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000208, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -48736,34 +45716,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ACTARMCD does not exist in the table ta."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000208, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -48837,34 +45795,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_arm is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ACTARM does not exist in the table ta."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000209, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -48925,34 +45861,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_arm is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ACTARM does not exist in the table ta."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000209, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -49026,34 +45940,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000210, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -49114,34 +46006,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_armcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000210, dataset=ta",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -50077,34 +46947,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sm.xpt",
-                                "domain": "SM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tm_midstype is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tm.xpt",
                                 "domain": "TM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tm_midstype is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000216, dataset=tm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -50165,34 +47013,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sm.xpt",
-                                "domain": "SM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tm_midstype is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tm.xpt",
                                 "domain": "TM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tm_midstype is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000216, dataset=tm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -52011,34 +48837,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ie.xpt",
-                                "domain": "IE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ti_ietestcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ti_ietestcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000228, dataset=ti",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -52104,34 +48908,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ie.xpt",
-                                "domain": "IE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ti_ietestcd is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ti_ietestcd is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000228, dataset=ti",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -52804,34 +49586,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "apdm.xpt",
-                                "domain": "APDM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $dm_usubjid is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RSUBJID does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000235, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -52906,17 +49666,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column MHSTDTC does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000236, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -52995,17 +49748,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column MHSTDTC does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000236, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -53244,12 +49990,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column LBSCAT does not exist in the table lb."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column LBSCAT does not exist in the table lb."
+                                    }
                                 ]
                             }
                         ],
@@ -54905,34 +51649,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000249, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -54988,64 +51710,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ds.xpt",
-                                "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000249, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -56914,34 +53584,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000249, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57015,17 +53663,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column MHENDTC does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000250, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57113,17 +53754,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column MHENDTC does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000250, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57187,32 +53821,10 @@
                             {
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ssstresc does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ss.xpt",
-                                "domain": "SS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "contains check_operator not implemented"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000251, dataset=ds",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57281,32 +53893,10 @@
                             {
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ssstresc does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ss.xpt",
-                                "domain": "SS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "contains check_operator not implemented"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000251, dataset=ds",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57370,32 +53960,10 @@
                             {
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dsdecod does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000252, dataset=ds",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57446,47 +54014,10 @@
                             {
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dsdecod does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dsdecod does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000252, dataset=ds",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57556,34 +54087,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column aesdth does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000253, dataset=ae",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57632,34 +54141,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column aesdth does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000253, dataset=ae",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57721,34 +54208,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column aeout does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000254, dataset=ae",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -57797,34 +54262,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column aeout does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000254, dataset=ae",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -58738,32 +55181,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ssstresc does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ss.xpt",
-                                "domain": "SS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000259, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -58859,32 +55280,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ssstresc does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ss.xpt",
-                                "domain": "SS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000259, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -59765,32 +56164,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMSTRF does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFSTDTC does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000262, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -59871,32 +56248,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMSTRF does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "cm.xpt",
-                                "domain": "CM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFSTDTC does not exist in the table cm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000262, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -59980,32 +56335,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMSTRF does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFSTDTC does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000262, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -60053,32 +56386,10 @@
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMSTRF does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "cm.xpt",
-                                "domain": "CM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFSTDTC does not exist in the table cm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000262, dataset=dm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -63099,79 +59410,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "oe.xpt",
-                                "domain": "OE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table oe."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visit is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "vs.xpt",
-                                "domain": "VS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table vs."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000269, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -63657,94 +59901,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "oe.xpt",
-                                "domain": "OE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table oe."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $TV_VISITNUM is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "vs.xpt",
-                                "domain": "VS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table vs."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000270, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -64063,79 +60225,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "oe.xpt",
-                                "domain": "OE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table oe."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $TV_VISITNUM is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "vs.xpt",
-                                "domain": "VS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table vs."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000270, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -64715,79 +60810,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "oe.xpt",
-                                "domain": "OE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table oe."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $TV_VISITNUM is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "vs.xpt",
-                                "domain": "VS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column svpresp does not exist in the table vs."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000270, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -64873,910 +60901,54 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 55,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 15,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 17,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 18,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 19,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 20,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 22,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 23,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 24,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 25,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 27,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 28,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 29,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 30,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 31,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 32,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 33,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 34,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 35,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 36,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 37,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 38,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 39,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 40,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 41,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 42,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 43,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 44,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 45,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 46,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 47,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 48,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 49,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 50,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 51,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 52,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 53,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 54,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 55,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 46,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 15,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 17,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 18,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 19,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 20,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 22,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 23,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 24,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 25,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 27,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 28,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 29,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 30,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 31,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 32,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 33,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 34,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 35,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 36,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 37,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 38,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 39,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 40,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 41,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 42,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 43,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 44,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 45,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 46,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 6,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             }
@@ -66307,854 +61479,54 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 2,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 52,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 15,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 17,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 18,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 19,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 20,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 22,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 23,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 24,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 25,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 27,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 28,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 29,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 30,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 31,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 32,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 33,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 34,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 35,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 36,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 37,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 38,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 39,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 40,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 41,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 42,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 43,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 44,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 45,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 46,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 47,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 48,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 49,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 50,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 51,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 52,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 53,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 54,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 55,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 43,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 15,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 17,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 18,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 19,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 20,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 22,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 23,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 24,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 25,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 27,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 28,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 29,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 30,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 31,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 32,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 33,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 34,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 35,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 36,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 37,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 38,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 39,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 40,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 41,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 42,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 43,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 44,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 45,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT I"
-                                        }
-                                    },
-                                    {
-                                        "row": 46,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 6,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             }
@@ -67688,910 +62060,54 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 3,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 55,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 15,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 17,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 18,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 19,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 20,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 22,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 23,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 24,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 25,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 27,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 28,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 29,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 30,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 31,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 32,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 33,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 34,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 35,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 36,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 37,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 38,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 39,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 40,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 41,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 42,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 43,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 44,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 45,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 46,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 47,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 48,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 49,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 50,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 51,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 52,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 53,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 54,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 55,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 46,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 15,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 17,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 18,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 19,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 20,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 22,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 23,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 24,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 25,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 27,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 28,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 29,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 30,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 31,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 32,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 33,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 34,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 35,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 36,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 37,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 38,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 39,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 40,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 41,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 42,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 43,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 44,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 45,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 46,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 6,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             }
@@ -68655,862 +62171,54 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "",
+                                "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 2,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 53,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 15,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 17,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 18,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 19,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 20,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 22,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 23,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 24,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 25,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 27,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 28,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 29,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 30,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 31,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 32,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 33,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 34,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 35,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 36,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 37,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 38,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 39,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 40,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 41,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 42,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 43,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 44,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 45,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 46,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 47,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 48,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 49,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 50,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 51,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 52,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 53,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 54,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 55,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 43,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 15,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 16,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 17,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 18,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 19,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 20,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 21,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 22,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 23,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 24,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 25,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 26,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 27,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 28,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 29,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 30,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 31,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 32,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 33,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 34,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 35,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 36,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 37,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 38,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 39,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 40,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 41,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 42,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 43,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 44,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 45,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 46,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             },
                             {
-                                "dataset": "",
+                                "dataset": "ta.xpt",
                                 "domain": "TA",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is not in TA.EPOCH",
-                                "number_errors": 6,
+                                "execution_status": "execution_error",
+                                "execution_message": "rule execution error",
+                                "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ta_epoch is not a constant."
-                                        }
-                                    },
                                     {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "SCREENING"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "TREATMENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": "FOLLOW-UP"
-                                        }
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $ta_epoch is not a constant."
                                     }
                                 ]
                             }
@@ -75928,12 +68636,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -76597,34 +69303,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column SVUPDES does not exist in the table sv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column SVUPDES does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000333, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -76670,34 +69354,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $vis_list is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column SVUPDES does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000333, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -76746,34 +69408,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column SVUPDES does not exist in the table sv."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column SVUPDES does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000333, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -76819,34 +69459,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "sv.xpt",
-                                "domain": "SV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $vis_list is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column SVUPDES does not exist in the table tv."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000333, dataset=tv",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -77040,21 +69658,6 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "suppdm.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column race does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "skipped",
@@ -77109,21 +69712,6 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "suppdm.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column race does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "skipped",
@@ -77174,21 +69762,6 @@
                         "datasets_import_sql": "SUCCESS",
                         "results_present_sql": true,
                         "results_sql": [
-                            {
-                                "dataset": "suppdm.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column race does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
-                            },
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
@@ -77878,12 +70451,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -77893,12 +70464,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMDY does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column DMDY does not exist in the table dm."
+                                    }
                                 ]
                             }
                         ],
@@ -77977,12 +70546,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AEDY does not exist in the table ae."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column AEDY does not exist in the table ae."
+                                    }
                                 ]
                             },
                             {
@@ -77992,12 +70559,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMDY does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column DMDY does not exist in the table dm."
+                                    }
                                 ]
                             },
                             {
@@ -78007,12 +70572,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column EXDY does not exist in the table ex."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column EXDY does not exist in the table ex."
+                                    }
                                 ]
                             },
                             {
@@ -78022,12 +70585,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],
@@ -78135,12 +70696,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -78150,12 +70709,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMDY does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column DMDY does not exist in the table dm."
+                                    }
                                 ]
                             }
                         ],
@@ -78213,12 +70770,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AEDY does not exist in the table ae."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column AEDY does not exist in the table ae."
+                                    }
                                 ]
                             },
                             {
@@ -78228,12 +70783,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMDY does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column DMDY does not exist in the table dm."
+                                    }
                                 ]
                             },
                             {
@@ -78243,12 +70796,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column EXDY does not exist in the table ex."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column EXDY does not exist in the table ex."
+                                    }
                                 ]
                             },
                             {
@@ -78258,12 +70809,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],
@@ -78911,12 +71460,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             },
                             {
@@ -78926,12 +71473,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             }
                         ],
@@ -79061,12 +71606,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             },
                             {
@@ -79076,12 +71619,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             }
                         ],
@@ -79134,12 +71675,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             },
                             {
@@ -79149,12 +71688,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $tv_visitnum is not a constant."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Variable $tv_visitnum is not a constant."
+                                    }
                                 ]
                             }
                         ],
@@ -80086,21 +72623,6 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $usubjids_in_ex is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "skipped",
@@ -80154,21 +72676,6 @@
                         "datasets_import_sql": "SUCCESS",
                         "results_present_sql": true,
                         "results_sql": [
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $usubjids_in_ex is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
                             {
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
@@ -80236,21 +72743,6 @@
                         "datasets_import_sql": "SUCCESS",
                         "results_present_sql": true,
                         "results_sql": [
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Variable $ARMS_IN_TA is not a constant."
-                                        }
-                                    ]
-                                ]
-                            },
                             {
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
@@ -81557,12 +74049,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column variable_name does not exist in the table ae."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column variable_name does not exist in the table ae."
+                                    }
                                 ]
                             },
                             {
@@ -81572,12 +74062,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column variable_name does not exist in the table lb."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column variable_name does not exist in the table lb."
+                                    }
                                 ]
                             },
                             {
@@ -81587,12 +74075,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column variable_name does not exist in the table ec."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column variable_name does not exist in the table ec."
+                                    }
                                 ]
                             }
                         ],
@@ -81671,12 +74157,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column variable_name does not exist in the table ae."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column variable_name does not exist in the table ae."
+                                    }
                                 ]
                             },
                             {
@@ -81686,12 +74170,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column variable_name does not exist in the table lb."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column variable_name does not exist in the table lb."
+                                    }
                                 ]
                             },
                             {
@@ -81701,12 +74183,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column variable_name does not exist in the table ec."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column variable_name does not exist in the table ec."
+                                    }
                                 ]
                             }
                         ],
@@ -81924,12 +74404,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AGETXT does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column AGETXT does not exist in the table dm."
+                                    }
                                 ]
                             }
                         ],
@@ -81977,12 +74455,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AGETXT does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column AGETXT does not exist in the table dm."
+                                    }
                                 ]
                             }
                         ],
@@ -87163,12 +79639,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column USUBJID does not exist in the table ae."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column USUBJID does not exist in the table ae."
+                                    }
                                 ]
                             },
                             {
@@ -87178,12 +79652,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column USUBJID does not exist in the table lbae."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column USUBJID does not exist in the table lbae."
+                                    }
                                 ]
                             }
                         ],
@@ -87555,12 +80027,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column USUBJID does not exist in the table ae."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column USUBJID does not exist in the table ae."
+                                    }
                                 ]
                             },
                             {
@@ -87570,12 +80040,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column USUBJID does not exist in the table lbae."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column USUBJID does not exist in the table lbae."
+                                    }
                                 ]
                             },
                             {
@@ -89270,12 +81738,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "invalid input syntax for type timestamp: \"2012-08\"\n"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "invalid input syntax for type timestamp: \"2012-08\"\n"
+                                    }
                                 ]
                             },
                             {
@@ -89402,12 +81868,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -90422,34 +82886,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column qnam does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "suppae.xpt",
                                 "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column aesmie does not exist in the table suppae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000597, dataset=suppae",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -90503,34 +82945,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column qnam does not exist in the table ae."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "suppae.xpt",
                                 "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column aesmie does not exist in the table suppae."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000597, dataset=suppae",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -91314,21 +83734,6 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ds.xpt",
-                                "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "skipped",
@@ -91391,21 +83796,6 @@
                         "datasets_import_sql": "SUCCESS",
                         "results_present_sql": true,
                         "results_sql": [
-                            {
-                                "dataset": "ds.xpt",
-                                "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column dthfl does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
@@ -92829,102 +85219,10 @@
                             {
                                 "dataset": "mh.xpt",
                                 "domain": "MH",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is missing for clinical subject-level observations",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "CE",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is missing for clinical subject-level observations",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "eg.xpt",
-                                "domain": "EG",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column EPOCH does not exist in the table eg."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is missing for clinical subject-level observations",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "PC",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is missing for clinical subject-level observations",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": null
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "dataset": "",
-                                "domain": "PP",
-                                "execution_status": "success",
-                                "execution_message": "EPOCH is missing for clinical subject-level observations",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "epoch": null
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000701, dataset=mh",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -93056,56 +85354,10 @@
                             {
                                 "dataset": "mh.xpt",
                                 "domain": "MH",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column EPOCH does not exist in the table mh."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ce.xpt",
-                                "domain": "CE",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000701, dataset=mh",
                                 "number_errors": 0,
                                 "errors": []
-                            },
-                            {
-                                "dataset": "lb.xpt",
-                                "domain": "LB",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "pc.xpt",
-                                "domain": "PC",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
-                            },
-                            {
-                                "dataset": "pp.xpt",
-                                "domain": "PP",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column EPOCH does not exist in the table pp."
-                                        }
-                                    ]
-                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -93517,12 +85769,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],
@@ -93589,12 +85839,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],
@@ -93655,12 +85903,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -93670,12 +85916,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -93685,12 +85929,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -93700,12 +85942,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -93715,12 +85955,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],
@@ -93820,12 +86058,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -93835,12 +86071,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -93850,12 +86084,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -93865,12 +86097,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             },
                             {
@@ -93880,12 +86110,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],
@@ -94442,17 +86670,10 @@
                             {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000712, dataset=lb",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -94519,47 +86740,10 @@
                             {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "suppdm.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "Rule format error",
-                                            "message": "Rule contains invalid operator"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000712, dataset=lb",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -94637,94 +86821,12 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "co.xpt",
-                                "domain": "CO",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table co."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "relrec.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "Rule format error",
-                                            "message": "Rule contains invalid operator"
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "supplb.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "Rule format error",
-                                            "message": "Rule contains invalid operator"
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "suppdm.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000712, dataset=lb",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -94804,47 +86906,10 @@
                             {
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table lb."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column IDVAR does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "suppdm.xpt",
-                                "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "Rule format error",
-                                            "message": "Rule contains invalid operator"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000712, dataset=lb",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -95375,32 +87440,10 @@
                             {
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AESTDTC does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000717, dataset=ds",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -95461,32 +87504,10 @@
                             {
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column AESTDTC does not exist in the table ds."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "ae.xpt",
-                                "domain": "AE",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000717, dataset=ds",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -96062,12 +88083,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMDTC does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column DMDTC does not exist in the table dm."
+                                    }
                                 ]
                             },
                             {
@@ -96077,12 +88096,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFPENDTC does not exist in the table ce."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column RFPENDTC does not exist in the table ce."
+                                    }
                                 ]
                             },
                             {
@@ -96092,12 +88109,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFPENDTC does not exist in the table lb."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column RFPENDTC does not exist in the table lb."
+                                    }
                                 ]
                             }
                         ],
@@ -96181,12 +88196,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column DMDTC does not exist in the table dm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column DMDTC does not exist in the table dm."
+                                    }
                                 ]
                             },
                             {
@@ -96196,12 +88209,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFPENDTC does not exist in the table lb."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column RFPENDTC does not exist in the table lb."
+                                    }
                                 ]
                             },
                             {
@@ -96211,12 +88222,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RFPENDTC does not exist in the table ce."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column RFPENDTC does not exist in the table ce."
+                                    }
                                 ]
                             }
                         ],
@@ -96934,32 +88943,10 @@
                             {
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ETHNIC does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column qnam does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000726, dataset=suppdm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -97010,32 +88997,10 @@
                             {
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ETHNIC does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column qnam does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000726, dataset=suppdm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -99169,32 +91134,10 @@
                             {
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ETHNIC does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column qnam does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000746, dataset=suppdm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -99245,32 +91188,10 @@
                             {
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column ETHNIC does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column qnam does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000746, dataset=suppdm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -99334,32 +91255,10 @@
                             {
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RACE does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column qnam does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000747, dataset=suppdm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -99410,32 +91309,10 @@
                             {
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column RACE does not exist in the table suppdm."
-                                        }
-                                    ]
-                                ]
-                            },
-                            {
-                                "dataset": "dm.xpt",
-                                "domain": "DM",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column qnam does not exist in the table dm."
-                                        }
-                                    ]
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000747, dataset=suppdm",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -100066,12 +91943,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column cmterm does not exist in the table cm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column cmterm does not exist in the table cm."
+                                    }
                                 ]
                             },
                             {
@@ -100110,12 +91985,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column FADECOD does not exist in the table fa."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column FADECOD does not exist in the table fa."
+                                    }
                                 ]
                             },
                             {
@@ -100125,12 +91998,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column --DECOD does not exist in the table relrec."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column --DECOD does not exist in the table relrec."
+                                    }
                                 ]
                             }
                         ],
@@ -100223,12 +92094,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column cmterm does not exist in the table cm."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column cmterm does not exist in the table cm."
+                                    }
                                 ]
                             },
                             {
@@ -100246,12 +92115,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column FADECOD does not exist in the table fa."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column FADECOD does not exist in the table fa."
+                                    }
                                 ]
                             },
                             {
@@ -100261,12 +92128,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column --DECOD does not exist in the table relrec."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column --DECOD does not exist in the table relrec."
+                                    }
                                 ]
                             }
                         ],
@@ -100405,12 +92270,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column --DECOD does not exist in the table relrec."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column --DECOD does not exist in the table relrec."
+                                    }
                                 ]
                             }
                         ],
@@ -100561,12 +92424,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "Column --DECOD does not exist in the table relrec."
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "Column --DECOD does not exist in the table relrec."
+                                    }
                                 ]
                             }
                         ],
@@ -104192,12 +96053,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],
@@ -104245,12 +96104,10 @@
                                 "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
-                                    [
-                                        {
-                                            "error": "An unknown exception has occurred",
-                                            "message": "A postgres SQL error occurred"
-                                        }
-                                    ]
+                                    {
+                                        "error": "An unknown exception has occurred",
+                                        "message": "A postgres SQL error occurred"
+                                    }
                                 ]
                             }
                         ],


### PR DESCRIPTION
A while ago, when we were refactoring during the end-step of PostgresQL Data Service development, a large portion of the sql_rule_processor.py was commented out. This removed some of the skipping functionality that detects and verifies rules which either shouldn't be run on certain data, or doesn't need to be run at all. The reason this functionality existed beforehand was to effectively minimise the run time of running all rules on all data (e.g. regression tests, real study sweep tests).

This branch and associated PRs aims to bring that functionality back.

This PR is dedicated to uncommenting and also restoring the valid rule structure based skipping logic. The logic for class-based and use-case-based skipping will be implemented in future PRs on this branch.