### PR TITLE
fix: RULE PROCESSOR: missed class matches

### DIFF
--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -11,6 +11,7 @@ from cdisc_rules_engine.constants.classes import (
     RELATIONSHIP,
     TRIAL_DESIGN,
     FINDINGS_ABOUT,
+    ASSOCIATED_PERSONS,
 )
 
 # from cdisc_rules_engine.constants.domains import (
@@ -106,101 +107,6 @@ class SQLRuleProcessor:
                     return True
         return False
 
-    # @classmethod
-    # def _is_domain_name_included(
-    #     cls,
-    #     dataset_metadata: SDTMDatasetMetadata,
-    #     included_domains: List[str],
-    #     include_split_datasets: bool,
-    # ) -> bool:
-    #     """
-    #     If included domains aren't specified
-    #      and include_split_datasets is True,
-    #      and it is not a split dataset
-    #      -> domain is not included
-    #     If included domains are specified,
-    #      and the domain is not in the list of included domains,
-    #      and domain doesn't match with AP / APFA / APRELSUB / SUPP / SQ naming pattern
-    #      -> domain is not included.
-    #     In other cases domain is included
-    #     """
-    #     if not included_domains:
-    #         if include_split_datasets is True and not dataset_metadata.is_split:
-    #             return False
-    #         return True
-
-    #     if (
-    #         dataset_metadata.domain in included_domains
-    #         or dataset_metadata.name in included_domains
-    #         or ALL_KEYWORD in included_domains
-    #     ):
-    #         return True
-    #     if cls._domain_matched_ap_or_supp(dataset_metadata, included_domains):
-    #         return True
-    #     return False
-
-    # @classmethod
-    # def _is_domain_name_excluded(cls, dataset_metadata: SDTMDatasetMetadata, excluded_domains: List[str]) -> bool:
-    #     """
-    #     If excluded domains are specified,
-    #      and the domain is in the list of excluded domains,
-    #      or domain name match with AP / APFA / APRELSUB / SUPP / SQ naming pattern
-    #      domain is excluded.
-
-    #     In other cases domain is not excluded.
-    #     """
-    #     if not excluded_domains:
-    #         return False
-
-    #     if (
-    #         dataset_metadata.domain in excluded_domains
-    #         or dataset_metadata.name in excluded_domains
-    #         or dataset_metadata.unsplit_name in excluded_domains
-    #         or ALL_KEYWORD in excluded_domains
-    #     ):
-    #         return True
-    #     if cls._domain_matched_ap_or_supp(dataset_metadata, excluded_domains):
-    #         return True
-    #     return False
-
-    # @classmethod
-    # def _handle_split_domains(
-    #     cls,
-    #     is_split_domain: bool,
-    #     include_split_datasets: bool,
-    #     is_excluded: bool,
-    #     is_included: bool,
-    # ) -> Tuple[bool, bool]:
-    #     """
-    #     HANDLING SPLIT DOMAINS
-
-    #     If include_split_datasets is True -
-    #     add split domains to the list of included domains.
-    #     If no included domains specified, only validate split domains
-
-    #     If include_split_datasets is False - Exclude split domains
-    #     If include_split_datasets is None - Do nothing
-    #     """
-    #     if include_split_datasets is True and is_split_domain and not is_excluded:
-    #         is_included = True
-    #     if include_split_datasets is False and is_split_domain:
-    #         is_excluded = True
-    #     return is_excluded, is_included
-
-    # @classmethod
-    # def _domain_matched_ap_or_supp(cls, dataset_metadata: SDTMDatasetMetadata, domains_to_check: List[str]) -> bool:
-    #     """
-    #     Check that domain name match with only
-    #     AP / APFA / APRELSUB / SUPP / SQ naming pattern
-    #     """
-    #     supp_ap_domains = {f"{domain}--" for domain in SUPPLEMENTARY_DOMAINS}
-    #     supp_ap_domains.update({f"{AP_DOMAIN}--", f"{APFA_DOMAIN}--"})
-
-    #     return any(set(domains_to_check).intersection(supp_ap_domains)) and (
-    #         dataset_metadata.is_supp
-    #         or is_ap_domain(dataset_metadata.domain or dataset_metadata.rdomain or dataset_metadata.name)
-    #     )
-
     @classmethod
     def rule_applies_to_class(cls, dataset_metadata: SQLDatasetMetadata, rule: dict) -> bool:
         """Check if rule applies to dataset's class"""
@@ -215,9 +121,12 @@ class SQLRuleProcessor:
         domain_name = dataset_metadata.dataset_name
         dataset_class = cls.get_dataset_class_from_variables(variables, domain_name)
 
-        if dataset_class is None and included_classes:
-            logger.warning(f"Could not determine class for dataset {domain_name} with include restrictions")
-            return False
+        if dataset_class is None and (included_classes or excluded_classes):
+            logger.debug(
+                f"Could not determine class for {domain_name}, variables: {variables if variables else 'none'}"
+            )
+        else:
+            logger.debug(f"Dataset {domain_name} identified as class: {dataset_class}")
 
         if cls.matches_class_pattern(dataset_class, excluded_classes):
             return False
@@ -242,13 +151,12 @@ class SQLRuleProcessor:
                 return True
         return False
 
-    @staticmethod
-    def get_dataset_class_from_variables(variables: List[str], domain_name: str) -> Optional[str]:
+    def get_dataset_class_from_variables(self, variables: List[str], domain_name: str) -> Optional[str]:
         """Determine dataset class based on variable names and domain"""
-        variables_upper = [v.upper() for v in variables]
+        variables_upper = [v.upper() for v in variables] if variables else []
         domain_upper = domain_name.upper()
 
-        if domain_upper in ["DM", "CO", "SE", "SJ", "SV", "SM"]:
+        if domain_upper in ["DM", "CO", "SE", "SU", "SV", "SM"]:
             return SPECIAL_PURPOSE
 
         if domain_upper in ["TA", "TE", "TI", "TS", "TV"]:
@@ -256,6 +164,9 @@ class SQLRuleProcessor:
 
         if any([domain_upper.startswith(prefix) for prefix in ["REL", "SUPP", "SQ"]]):
             return RELATIONSHIP
+
+        if not variables:
+            return self.get_class_from_empty_variables(domain_upper)
 
         if any(
             v.endswith("TESTCD")
@@ -281,6 +192,45 @@ class SQLRuleProcessor:
         ):
             return EVENTS
 
+        return None
+
+    @staticmethod
+    def get_class_from_empty_variables(domain_upper: str) -> Optional[str]:
+        """Determine dataset class based on domain name when no variables are present."""
+        if domain_upper in ["AE", "CE", "DS", "MH", "HO", "DV", "DD"]:
+            return EVENTS
+        if domain_upper in ["CM", "EX", "PR", "EC", "AG", "ML", "DO"]:
+            return INTERVENTIONS
+        if domain_upper in [
+            "LB",
+            "VS",
+            "EG",
+            "PE",
+            "IE",
+            "QS",
+            "SC",
+            "PC",
+            "PP",
+            "MB",
+            "MS",
+            "MI",
+            "DA",
+            "FT",
+            "GF",
+            "NV",
+            "OE",
+            "PK",
+            "RS",
+            "SS",
+            "TR",
+            "TU",
+            "UR",
+        ]:
+            return FINDINGS
+        if domain_upper == "FA":
+            return FINDINGS_ABOUT
+        if domain_upper.startswith("AP"):
+            return ASSOCIATED_PERSONS
         return None
 
     # def rule_applies_to_use_case(
@@ -479,7 +429,7 @@ class SQLRuleProcessor:
         #     reason = f"Rule skipped - doesn't apply to use case for " f"rule id={rule_id}, dataset={dataset_name}"
         #     logger.info(f"is_suitable_for_validation. {reason}, result=False")
         #     return False, reason
-        # TODO: uncomment and reimplement above other checks (i.e. class, use-case)
+        # TODO: uncomment and reimplement above other checks (i.e. use-case)
 
         logger.info(f"is_suitable_for_validation. rule id={rule_id}, dataset={dataset_name}, result=True")
         return True, ""

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -151,7 +151,8 @@ class SQLRuleProcessor:
                 return True
         return False
 
-    def get_dataset_class_from_variables(self, variables: List[str], domain_name: str) -> Optional[str]:
+    @classmethod
+    def get_dataset_class_from_variables(cls, variables: List[str], domain_name: str) -> Optional[str]:
         """Determine dataset class based on variable names and domain"""
         variables_upper = [v.upper() for v in variables] if variables else []
         domain_upper = domain_name.upper()
@@ -166,7 +167,7 @@ class SQLRuleProcessor:
             return RELATIONSHIP
 
         if not variables:
-            return self.get_class_from_empty_variables(domain_upper)
+            return cls.get_class_from_empty_variables(domain_upper)
 
         if any(
             v.endswith("TESTCD")

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -4731,33 +4731,12 @@
                                 ]
                             },
                             {
-                                "dataset": "su",
+                                "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUOCCUR should only be provided when SUPRESP is equal to \"Y\".",
-                                "number_errors": 2,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "Y",
-                                            "SUPRESP": null,
-                                            "SUSTAT": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "Y",
-                                            "SUPRESP": null,
-                                            "SUSTAT": "NOT DONE"
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000014, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "ae.xpt",
@@ -5518,43 +5497,12 @@
                                 ]
                             },
                             {
-                                "dataset": "su",
+                                "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUOCCUR should only be provided when SUPRESP is equal to \"Y\".",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "Y",
-                                            "SUPRESP": null,
-                                            "SUSTAT": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "N",
-                                            "SUPRESP": null,
-                                            "SUSTAT": "NOT DONE"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": 3,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "Y",
-                                            "SUPRESP": null,
-                                            "SUSTAT": null
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000014, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "ae.xpt",
@@ -6321,8 +6269,8 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000014, dataset=su",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -6579,8 +6527,8 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000014, dataset=su",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -6896,22 +6844,12 @@
                                 ]
                             },
                             {
-                                "dataset": "su",
+                                "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUPRESP is missing in dataset when SUOCCUR is present.",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": null,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "SUOCCUR": null,
-                                            "SUPRESP": "Not in dataset"
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000015, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "ae.xpt",
@@ -7313,8 +7251,8 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000015, dataset=su",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -7690,31 +7628,12 @@
                                 ]
                             },
                             {
-                                "dataset": "su",
+                                "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUPRESP should be populated as \"Y\" when SUOCCUR is provided.",
-                                "number_errors": 2,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "Y",
-                                            "SUPRESP": "y"
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "N",
-                                            "SUPRESP": "y"
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000016, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "ae.xpt",
@@ -8449,40 +8368,12 @@
                                 ]
                             },
                             {
-                                "dataset": "su",
+                                "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUPRESP should be populated as \"Y\" when SUOCCUR is provided.",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "Y",
-                                            "SUPRESP": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "N",
-                                            "SUPRESP": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": 3,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": "N",
-                                            "SUPRESP": null
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000016, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "ae.xpt",
@@ -9199,8 +9090,8 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000016, dataset=su",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -9452,8 +9343,8 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000016, dataset=su",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -9960,33 +9851,12 @@
                                 ]
                             },
                             {
-                                "dataset": "su",
+                                "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUOCCUR is blank when SUPRESP is equal to \"Y\" and SUSTAT is not provided.",
-                                "number_errors": 2,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": null,
-                                            "SUPRESP": "Y",
-                                            "SUSTAT": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": null,
-                                            "SUPRESP": "Y",
-                                            "SUSTAT": null
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000018, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "ae.xpt",
@@ -10708,43 +10578,12 @@
                                 ]
                             },
                             {
-                                "dataset": "su",
+                                "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "SUOCCUR is blank when SUPRESP is equal to \"Y\" and SUSTAT is not provided.",
-                                "number_errors": 3,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": null,
-                                            "SUPRESP": "Y",
-                                            "SUSTAT": null
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": null,
-                                            "SUPRESP": "Y",
-                                            "SUSTAT": null
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": 3,
-                                        "USUBJID": "CDISC001",
-                                        "value": {
-                                            "SUOCCUR": null,
-                                            "SUPRESP": "Y",
-                                            "SUSTAT": null
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000018, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "ae.xpt",
@@ -11446,8 +11285,8 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000018, dataset=su",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -11704,8 +11543,8 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000018, dataset=su",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -16554,7 +16393,7 @@
                                 "dataset": "sj.xpt",
                                 "domain": "SJ",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000042, dataset=sj",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000042, dataset=sj",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -16707,7 +16546,7 @@
                                 "dataset": "sj.xpt",
                                 "domain": "SJ",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000042, dataset=sj",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000042, dataset=sj",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -16892,8 +16731,8 @@
                             {
                                 "dataset": "sj.xpt",
                                 "domain": "SJ",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000044, dataset=sj",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -16988,7 +16827,7 @@
                             "number_of_errors_match": false,
                             "deep_diff": []
                         },
-                        "sql_overall_result": "success",
+                        "sql_overall_result": "skipped",
                         "old_overall_result": "success",
                         "validated_results_folder_exists": false,
                         "validation_file": "",
@@ -23644,22 +23483,12 @@
                                 ]
                             },
                             {
-                                "dataset": "su",
+                                "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "Both SUDOSE and SUDOSTXT values are populated",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "1234005",
-                                        "value": {
-                                            "SUDOSE": 3.0,
-                                            "SUDOSTXT": "3"
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000092, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -23793,8 +23622,8 @@
                             }
                         ],
                         "old_vs_sql": {
-                            "execution_status_match": true,
-                            "number_of_errors_match": true,
+                            "execution_status_match": false,
+                            "number_of_errors_match": false,
                             "deep_diff": []
                         },
                         "sql_overall_result": "success",
@@ -23870,8 +23699,8 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000092, dataset=su",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -24062,24 +23891,12 @@
                                 ]
                             },
                             {
-                                "dataset": "su",
+                                "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": "Missing value for SUDOSU, when SUDOSE, SUDOSTXT or SUDOSTOT is provided",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "1234005",
-                                        "value": {
-                                            "SUDOSE": null,
-                                            "SUDOSTOT": 3.0,
-                                            "SUDOSTXT": null,
-                                            "SUDOSU": null
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000093, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -24227,8 +24044,8 @@
                             }
                         ],
                         "old_vs_sql": {
-                            "execution_status_match": true,
-                            "number_of_errors_match": true,
+                            "execution_status_match": false,
+                            "number_of_errors_match": false,
                             "deep_diff": []
                         },
                         "sql_overall_result": "execution_error",
@@ -24329,8 +24146,8 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "success",
-                                "execution_message": null,
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000093, dataset=su",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -24516,15 +24333,10 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "matches_regex check_operator not implemented"
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000094, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -24730,15 +24542,10 @@
                             {
                                 "dataset": "su.xpt",
                                 "domain": "SU",
-                                "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "matches_regex check_operator not implemented"
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000094, dataset=su",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",


### PR DESCRIPTION
Filling the gaps in missed classes and domains within the rules.json.

Multiple domains and classes were not recognised in the rule skipping logic and therefore the rules.json was showing mismatches between skipping in the old engine and the new sql engine.

Also removes some now-redundant commented-out domain skipping code.