### PR TITLE
chore: RULE PROCESSOR: use-case based skipping logic

### DIFF
--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -1,17 +1,17 @@
-from typing import List, Optional, Tuple
+from typing import List, Tuple, Optional
 
 from cdisc_rules_engine.config import config as default_config
 
 # import os
 from cdisc_rules_engine.constants.classes import (
-    ASSOCIATED_PERSONS,
-    EVENTS,
     FINDINGS,
-    FINDINGS_ABOUT,
-    INTERVENTIONS,
-    RELATIONSHIP,
     SPECIAL_PURPOSE,
+    INTERVENTIONS,
+    EVENTS,
+    RELATIONSHIP,
     TRIAL_DESIGN,
+    FINDINGS_ABOUT,
+    ASSOCIATED_PERSONS,
 )
 
 # from cdisc_rules_engine.constants.domains import (
@@ -25,7 +25,7 @@ from cdisc_rules_engine.data_service.postgresql_data_service import (
     SQLDatasetMetadata,
 )
 
-# from cdisc_rules_engine.constants.use_cases import USE_CASE_DOMAINS
+from cdisc_rules_engine.constants.use_cases import USE_CASE_DOMAINS
 from cdisc_rules_engine.interfaces import ConditionInterface
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
@@ -38,9 +38,7 @@ from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
 from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
 from cdisc_rules_engine.services import logger
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
-from cdisc_rules_engine.sql_operations.sql_operations_factory import (
-    SqlOperationsFactory,
-)
+from cdisc_rules_engine.sql_operations import sql_operations_factory
 
 # from cdisc_rules_engine.utilities.data_processor import DataProcessor
 # from cdisc_rules_engine.utilities.utils import (
@@ -236,38 +234,78 @@ class SQLRuleProcessor:
             return ASSOCIATED_PERSONS
         return None
 
-    # def rule_applies_to_use_case(
-    #     self,
-    #     dataset_metadata: SDTMDatasetMetadata,
-    #     rule: dict,
-    #     standard: str,
-    #     standard_substandard: str,
-    # ) -> bool:
-    #     if standard.lower() != "tig":
-    #         return True
-    #     use_cases = rule.get("use_case") or []
-    #     if not use_cases:
-    #         return True
-    #     use_cases = [uc.strip() for uc in use_cases.split(",")]
-    #     substandard = standard_substandard.upper()
-    #     if substandard not in USE_CASE_DOMAINS:
-    #         return False
+    def rule_applies_to_use_case(
+        self,
+        dataset_metadata: SQLDatasetMetadata,
+        rule: dict,
+        standard: str,
+        standard_substandard: str,
+    ) -> bool:
+        """Check if rule applies based on use case restrictions (TIG-specific)."""
+        if standard.lower() != "tig":
+            return True
 
-    #     domain_to_check = dataset_metadata.domain
-    #     if dataset_metadata.is_supp and dataset_metadata.rdomain:
-    #         domain_to_check = dataset_metadata.rdomain
+        use_cases = self._get_normalised_use_cases(rule)
+        if not use_cases:
+            return True
 
-    #     # Handle ADaM datasets with AD prefix
-    #     if substandard == "ADAM" and domain_to_check.startswith("AD"):
-    #         return "ANALYSIS" in use_cases
+        substandard = (standard_substandard or "").upper()
+        if substandard not in USE_CASE_DOMAINS:
+            logger.warning(f"Unknown substandard '{substandard}' for use case checking")
+            return False
 
-    #     allowed_domains = set()
-    #     for use_case in use_cases:
-    #         if use_case in USE_CASE_DOMAINS[substandard]:
-    #             allowed_domains.update(USE_CASE_DOMAINS[substandard][use_case])
-    #     if domain_to_check in allowed_domains:
-    #         return True
-    #     return False
+        domain_to_check = self._get_domain_for_use_case(dataset_metadata)
+
+        if substandard == "ADAM" and domain_to_check.startswith("AD"):
+            return "ANALYSIS" in use_cases
+
+        allowed_domains = self._get_allowed_domains_for_use_cases(use_cases, substandard)
+
+        if domain_to_check in allowed_domains:
+            return True
+
+        logger.debug(
+            f"Domain {domain_to_check} not in allowed domains {allowed_domains} "
+            f"for use cases {use_cases} in {substandard}"
+        )
+        return False
+
+    @staticmethod
+    def _get_normalised_use_cases(rule: dict) -> List[str]:
+        """Extract and normalise use cases from rule."""
+        use_cases = rule.get("use_case") or rule.get("Use_Case") or ""
+
+        if not use_cases:
+            return []
+
+        if isinstance(use_cases, str):
+            return [uc.strip().upper() for uc in use_cases.split(",")]
+        elif isinstance(use_cases, list):
+            return [uc.upper() for uc in use_cases]
+
+        return []
+
+    @staticmethod
+    def _get_domain_for_use_case(dataset_metadata: SQLDatasetMetadata) -> str:
+        """Get the appropriate domain name for use-case checking."""
+        domain = dataset_metadata.dataset_name.upper()
+
+        if domain.startswith("SUPP") and len(domain) > 4:
+            return domain[4:]
+
+        return domain
+
+    @staticmethod
+    def _get_allowed_domains_for_use_cases(use_cases: List[str], substandard: str) -> set:
+        """Get all allowed domains for the specified use cases."""
+        allowed_domains = set()
+        substandard_domains = USE_CASE_DOMAINS.get(substandard, {})
+
+        for use_case in use_cases:
+            if use_case in substandard_domains:
+                allowed_domains.update(substandard_domains[use_case])
+
+        return allowed_domains
 
     # @staticmethod
     # def _ct_package_type_api_name(ct_package_type: str | None) -> str:
@@ -315,7 +353,7 @@ class SQLRuleProcessor:
                 standard_version=data_service.ig_specs.get("standard_version"),
             )
 
-            operation = SqlOperationsFactory.get_service(rule_name, params=params, data_service=data_service)
+            operation = sql_operations_factory.get_service(rule_name, params=params, data_service=data_service)
             query = operation.execute()
             output_variables[output_variable] = query
 
@@ -428,11 +466,10 @@ class SQLRuleProcessor:
             reason = f"Rule skipped - doesn't apply to domain for rule id={rule_id}, dataset={dataset_name}"
             logger.info(f"is_suitable_for_validation. {reason}, result=False")
             return False, reason
-        # if not self.rule_applies_to_use_case(dataset_metadata, rule, standard, standard_substandard):
-        #     reason = f"Rule skipped - doesn't apply to use case for " f"rule id={rule_id}, dataset={dataset_name}"
-        #     logger.info(f"is_suitable_for_validation. {reason}, result=False")
-        #     return False, reason
-        # TODO: uncomment and reimplement above other checks (i.e. use-case)
+        if not self.rule_applies_to_use_case(dataset_metadata, rule, standard, standard_substandard):
+            reason = f"Rule skipped - doesn't apply to use case for " f"rule id={rule_id}, dataset={dataset_name}"
+            logger.info(f"is_suitable_for_validation. {reason}, result=False")
+            return False, reason
 
         logger.info(f"is_suitable_for_validation. rule id={rule_id}, dataset={dataset_name}, result=True")
         return True, ""

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -1,17 +1,17 @@
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 
 from cdisc_rules_engine.config import config as default_config
 
 # import os
 from cdisc_rules_engine.constants.classes import (
-    FINDINGS,
-    SPECIAL_PURPOSE,
-    INTERVENTIONS,
-    EVENTS,
-    RELATIONSHIP,
-    TRIAL_DESIGN,
-    FINDINGS_ABOUT,
     ASSOCIATED_PERSONS,
+    EVENTS,
+    FINDINGS,
+    FINDINGS_ABOUT,
+    INTERVENTIONS,
+    RELATIONSHIP,
+    SPECIAL_PURPOSE,
+    TRIAL_DESIGN,
 )
 
 # from cdisc_rules_engine.constants.domains import (
@@ -37,7 +37,9 @@ from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
 from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
 from cdisc_rules_engine.services import logger
 from cdisc_rules_engine.services.cache.cache_service_factory import CacheServiceFactory
-from cdisc_rules_engine.sql_operations import sql_operations_factory
+from cdisc_rules_engine.sql_operations.sql_operations_factory import (
+    SqlOperationsFactory,
+)
 
 # from cdisc_rules_engine.utilities.data_processor import DataProcessor
 # from cdisc_rules_engine.utilities.utils import (
@@ -279,7 +281,7 @@ class SQLRuleProcessor:
                 standard_version=data_service.ig_specs.get("standard_version"),
             )
 
-            operation = sql_operations_factory.get_service(rule_name, params=params, data_service=data_service)
+            operation = SqlOperationsFactory.get_service(rule_name, params=params, data_service=data_service)
             query = operation.execute()
             output_variables[output_variable] = query
 

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -25,7 +25,6 @@ from cdisc_rules_engine.data_service.postgresql_data_service import (
     SQLDatasetMetadata,
 )
 
-from cdisc_rules_engine.constants.use_cases import USE_CASE_DOMAINS
 from cdisc_rules_engine.interfaces import ConditionInterface
 from cdisc_rules_engine.models.library_metadata_container import (
     LibraryMetadataContainer,
@@ -234,79 +233,6 @@ class SQLRuleProcessor:
             return ASSOCIATED_PERSONS
         return None
 
-    def rule_applies_to_use_case(
-        self,
-        dataset_metadata: SQLDatasetMetadata,
-        rule: dict,
-        standard: str,
-        standard_substandard: str,
-    ) -> bool:
-        """Check if rule applies based on use case restrictions (TIG-specific)."""
-        if standard.lower() != "tig":
-            return True
-
-        use_cases = self._get_normalised_use_cases(rule)
-        if not use_cases:
-            return True
-
-        substandard = (standard_substandard or "").upper()
-        if substandard not in USE_CASE_DOMAINS:
-            logger.warning(f"Unknown substandard '{substandard}' for use case checking")
-            return False
-
-        domain_to_check = self._get_domain_for_use_case(dataset_metadata)
-
-        if substandard == "ADAM" and domain_to_check.startswith("AD"):
-            return "ANALYSIS" in use_cases
-
-        allowed_domains = self._get_allowed_domains_for_use_cases(use_cases, substandard)
-
-        if domain_to_check in allowed_domains:
-            return True
-
-        logger.debug(
-            f"Domain {domain_to_check} not in allowed domains {allowed_domains} "
-            f"for use cases {use_cases} in {substandard}"
-        )
-        return False
-
-    @staticmethod
-    def _get_normalised_use_cases(rule: dict) -> List[str]:
-        """Extract and normalise use cases from rule."""
-        use_cases = rule.get("use_case") or rule.get("Use_Case") or ""
-
-        if not use_cases:
-            return []
-
-        if isinstance(use_cases, str):
-            return [uc.strip().upper() for uc in use_cases.split(",")]
-        elif isinstance(use_cases, list):
-            return [uc.upper() for uc in use_cases]
-
-        return []
-
-    @staticmethod
-    def _get_domain_for_use_case(dataset_metadata: SQLDatasetMetadata) -> str:
-        """Get the appropriate domain name for use-case checking."""
-        domain = dataset_metadata.dataset_name.upper()
-
-        if domain.startswith("SUPP") and len(domain) > 4:
-            return domain[4:]
-
-        return domain
-
-    @staticmethod
-    def _get_allowed_domains_for_use_cases(use_cases: List[str], substandard: str) -> set:
-        """Get all allowed domains for the specified use cases."""
-        allowed_domains = set()
-        substandard_domains = USE_CASE_DOMAINS.get(substandard, {})
-
-        for use_case in use_cases:
-            if use_case in substandard_domains:
-                allowed_domains.update(substandard_domains[use_case])
-
-        return allowed_domains
-
     # @staticmethod
     # def _ct_package_type_api_name(ct_package_type: str | None) -> str:
     #     if ct_package_type is None:
@@ -464,10 +390,6 @@ class SQLRuleProcessor:
             return False, reason
         if not self.rule_applies_to_domain(dataset_metadata, rule):
             reason = f"Rule skipped - doesn't apply to domain for rule id={rule_id}, dataset={dataset_name}"
-            logger.info(f"is_suitable_for_validation. {reason}, result=False")
-            return False, reason
-        if not self.rule_applies_to_use_case(dataset_metadata, rule, standard, standard_substandard):
-            reason = f"Rule skipped - doesn't apply to use case for " f"rule id={rule_id}, dataset={dataset_name}"
             logger.info(f"is_suitable_for_validation. {reason}, result=False")
             return False, reason
 


### PR DESCRIPTION
A while ago, when we were refactoring during the end-step of PostgresQL Data Service development, a large portion of the sql_rule_processor.py was commented out. This removed some of the skipping functionality that detects and verifies rules which either shouldn't be run on certain data, or doesn't need to be run at all. The reason this functionality existed beforehand was to effectively minimise the run time of running all rules on all data (e.g. regression tests, real study sweep tests).

This branch and associated PRs aim to bring that functionality back.

This PR is dedicated to use-case based skipping logic. This is the final LOGIC PR on this branch.

I have removed use-case skipping logic because it is TIG specific. We are working with SDTMIG and ADaM rules, not TIG. This was an old feature in CORE even though they never had TIG. Perhaps we reimplement once we have a complete CORE but for now, it serves no purpose to us.