### PR TITLE
refactor: better identify postgres errors

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/postgresql_operators.py
+++ b/cdisc_rules_engine/check_operators/sql/postgresql_operators.py
@@ -180,8 +180,8 @@ class PostgresQLOperators(BaseType):
             operator_factory = self._operator_map[name]
             operator_instance = operator_factory(self.data)
 
-            # Define the method with the necessary decorators
-            @log_operator_execution
+            # Define the method with the necessary decorators, passing the operator name
+            @log_operator_execution(name)
             @type_operator(FIELD_DATAFRAME)
             def operator_method(self, other_value):
                 return operator_instance.execute_operator(other_value)

--- a/cdisc_rules_engine/data_service/sql_interface.py
+++ b/cdisc_rules_engine/data_service/sql_interface.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from psycopg2.errors import ProgrammingError
 
 from cdisc_rules_engine.data_service.database import (
     DatabaseConfigPostgres,
@@ -70,10 +69,6 @@ class PostgresQLInterface:
             except Exception as e:
                 conn.rollback()
                 logger.error(f"Query execution failed: {e}")
-
-                # TODO: Adding this temporarily to make regression deterministic
-                if isinstance(e, ProgrammingError):
-                    raise ProgrammingError("A postgres SQL error occurred") from e
                 raise
 
         return affected_rows
@@ -105,10 +100,6 @@ class PostgresQLInterface:
             except Exception as e:
                 conn.rollback()
                 logger.error(f"Batch execution failed: {e}")
-
-                # TODO: Adding this temporarily to make regression deterministic
-                if isinstance(e, ProgrammingError):
-                    raise ProgrammingError("A postgres SQL error occurred") from e
                 raise
 
         return affected_rows_list

--- a/cdisc_rules_engine/sql_operations/dataset_names.py
+++ b/cdisc_rules_engine/sql_operations/dataset_names.py
@@ -2,7 +2,7 @@ from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
 from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
 
 
-class SqlDatasetNames(SqlBaseOperation):
+class SqlDatasetNamesOperation(SqlBaseOperation):
     def _execute_operation(self):
         all_tables = self.data_service.pgi.schema.get_tables()
         source_tables = [name for name, schema in all_tables if schema.source == "data"]

--- a/cdisc_rules_engine/sql_operations/distinct.py
+++ b/cdisc_rules_engine/sql_operations/distinct.py
@@ -2,7 +2,7 @@ from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
 from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
 
 
-class SqlDistinct(SqlBaseOperation):
+class SqlDistinctOperation(SqlBaseOperation):
     def _execute_operation(self):
         dataset_id = self.data_service.pgi.schema.get_table_hash(self.params.domain)
         column_id = self.data_service.pgi.schema.get_column_hash(self.params.domain, self.params.target)

--- a/cdisc_rules_engine/sql_operations/sql_base_operation.py
+++ b/cdisc_rules_engine/sql_operations/sql_base_operation.py
@@ -76,12 +76,8 @@ class SqlBaseOperation:
                 f"error in operation {self.__class__.__name__}: {str(e)}",
                 exc_info=True,
             )
-            # Convert class name to operation name (e.g., NumericOperation -> numeric)
-            operation_name = self.__class__.__name__.lower()
-            if operation_name.endswith("operation"):
-                operation_name = operation_name[:-9]
 
-            raise SqlOperationError(original_exception=e, operation_name=operation_name) from e
+            raise SqlOperationError(original_exception=e, operation_name=self.__class__.__name__.lower()) from e
 
     def construct_where_clause(self) -> str:
         """

--- a/cdisc_rules_engine/sql_operations/sql_base_operation.py
+++ b/cdisc_rules_engine/sql_operations/sql_base_operation.py
@@ -24,6 +24,15 @@ from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
 from cdisc_rules_engine.services import logger
 
 
+class SqlOperationError(Exception):
+    """Simple exception to identify which SQL operation caused the error."""
+
+    def __init__(self, original_exception, operation_name):
+        self.original_exception = original_exception
+        self.operation_name = operation_name
+        super().__init__(f"{operation_name}: {str(original_exception)}")
+
+
 class SqlBaseOperation:
     def __init__(self, params: SqlOperationParams, data_service: PostgresQLDataService):
         self.params = params
@@ -62,12 +71,17 @@ class SqlBaseOperation:
             logger.debug(f"error in operation {self.__class__.__name__}: {str(e)}")
             raise
         except Exception as e:
-            # Log unexpected errors
+            # Log unexpected errors and wrap with operation context
             logger.error(
                 f"error in operation {self.__class__.__name__}: {str(e)}",
                 exc_info=True,
             )
-            raise
+            # Convert class name to operation name (e.g., NumericOperation -> numeric)
+            operation_name = self.__class__.__name__.lower()
+            if operation_name.endswith("operation"):
+                operation_name = operation_name[:-9]
+
+            raise SqlOperationError(original_exception=e, operation_name=operation_name) from e
 
     def construct_where_clause(self) -> str:
         """

--- a/cdisc_rules_engine/sql_operations/sql_operations_factory.py
+++ b/cdisc_rules_engine/sql_operations/sql_operations_factory.py
@@ -2,22 +2,22 @@ from cdisc_rules_engine.data_service.postgresql_data_service import (
     PostgresQLDataService,
 )
 from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
-from cdisc_rules_engine.sql_operations.dataset_names import SqlDatasetNames
-from cdisc_rules_engine.sql_operations.distinct import SqlDistinct
+from cdisc_rules_engine.sql_operations.dataset_names import SqlDatasetNamesOperation
+from cdisc_rules_engine.sql_operations.distinct import SqlDistinctOperation
 from cdisc_rules_engine.sql_operations.numeric_operation import (
     SqlNumericOperation,
 )
 from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
-from cdisc_rules_engine.sql_operations.variable_exists import SqlVariableExists
+from cdisc_rules_engine.sql_operations.variable_exists import SqlVariableExistsOperation
 
 
 class SqlOperationsFactory:
     _operations_map = {
         "codelist_extensible": None,
         "codelist_terms": None,
-        "dataset_names": SqlDatasetNames,
+        "dataset_names": SqlDatasetNamesOperation,
         "define_extensible_codelists": None,
-        "distinct": SqlDistinct,
+        "distinct": SqlDistinctOperation,
         "dy": None,
         "extract_metadata": None,
         "get_column_order_from_dataset": None,
@@ -38,7 +38,7 @@ class SqlOperationsFactory:
         "whodrug_code_hierarchy": None,
         "valid_meddra_term_references": None,
         "valid_meddra_code_term_pairs": None,
-        "variable_exists": SqlVariableExists,
+        "variable_exists": SqlVariableExistsOperation,
         "variable_names": None,
         "variable_library_metadata": None,
         "variable_value_count": None,

--- a/cdisc_rules_engine/sql_operations/variable_exists.py
+++ b/cdisc_rules_engine/sql_operations/variable_exists.py
@@ -2,7 +2,7 @@ from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
 from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
 
 
-class SqlVariableExists(SqlBaseOperation):
+class SqlVariableExistsOperation(SqlBaseOperation):
     def _execute_operation(self):
         column_exists = self.data_service.pgi.schema.column_exists(self.params.domain, self.params.target)
 

--- a/tests/resources/rules/regression_analysis_report.md
+++ b/tests/resources/rules/regression_analysis_report.md
@@ -44,29 +44,23 @@
 10. **min_date**: 3 failures across 2 rules
 11. **valid_codelist_dates**: 2 failures across 1 rules
 
-## Other Execution Errors (21 unique messages, 76 total failures across 30 rule occurrences)
+## Execution Errors by Type (25 unique error types, 384 total failures across 101 rule occurrences)
 
-1.  **Rule contains invalid operator**: 15 failures across 1 rules
-2.  **Cannot join a table to itself (currently). Use a different n...**: 14 failures across 6 rules
-3.  **'NoneType' object has no attribute 'name'**: 12 failures across 2 rules
-4.  **A postgres SQL error occurred**: 7 failures across 2 rules
-5.  **invalid input syntax for type double precision: "TV.VISITDY"...**: 4 failures across 1 rules
-6.  **$ds_dsdecod**: 4 failures across 2 rules
-7.  **invalid input syntax for type timestamp: "2018-04"
-    **: 3 failures across 2 rules
-8.  **invalid input syntax for type numeric: "redacted"
-    **: 2 failures across 1 rules
-9.  **invalid input syntax for type timestamp: "2019-03"
-    **: 2 failures across 1 rules
-10. **invalid input syntax for type double precision: "SE.TAETORD"...**: 2 failures across 1 rules
-11. **invalid input syntax for type double precision: "TV.VISITDY"...**: 1 failures across 1 rules
-12. **Column visitnum or visitnum not found in the respective sche...**: 1 failures across 1 rules
-13. **invalid input syntax for type timestamp: "cmdtc"
-    LINE 4: ......**: 1 failures across 1 rules
-14. **invalid input syntax for type timestamp: "2012-08"
-    **: 1 failures across 1 rules
-15. **invalid input syntax for type timestamp: "cmdtc"
-    LINE 4: ......**: 1 failures across 1 rules
+1.  **An unknown exception has occurred**: 104 failures across 25 rules
+2.  **SQL error in longer_than operator**: 66 failures across 12 rules
+3.  **SQL error in is_not_unique_set operator**: 47 failures across 13 rules
+4.  **SQL error in matches_regex operator**: 43 failures across 8 rules
+5.  **SQL error in not_matches_regex operator**: 32 failures across 13 rules
+6.  **Rule format error**: 15 failures across 1 rules
+7.  **SQL error in date_greater_than operator**: 10 failures across 6 rules
+8.  **SQL error in shorter_than operator**: 9 failures across 1 rules
+9.  **SQL error in is_inconsistent_across_dataset operator**: 8 failures across 2 rules
+10. **SQL error in not_equal_to operator**: 7 failures across 2 rules
+11. **PostgreSQL Error**: 6 failures across 1 rules
+12. **SQL error in does_not_contain operator**: 4 failures across 2 rules
+13. **SQL error in invalid_duration operator**: 4 failures across 1 rules
+14. **SQL error in is_incomplete_date operator**: 4 failures across 1 rules
+15. **SQL error in invalid_date operator**: 4 failures across 2 rules
 
 ## SQL vs Old Engine Discrepancies
 
@@ -80,9 +74,10 @@ _Indicates SQL engine running rules it shouldn't_
 - [15] invalid input syntax
 - [9] matches_regex check_operator not implemented
 - [5] Operation max_date is not implemented
-- [4] $ds_dsdecod
+- [4] '$ds_dsdecod'
 - [4] Cannot join a table to itself (currently). Use a different n...
 - [4] invalid_duration check_operator not implemented
+- [4] longer_than_or_equal_to check_operator not implemented
 
 ### SQL Success where Old Engine Skipped (299 cases)
 
@@ -109,9 +104,8 @@ _Indicates actual regressions in SQL implementation_
 - [13] longer_than check_operator not implemented
 - [12] matches_regex check_operator not implemented
 - [8] is_inconsistent_across_dataset check_operator not implemente...
-- [8] SQL syntax error
 - [8] Operation variable_count is not implemented
-- [6] column or relation does not exist
 - [6] Operation dy is not implemented
-- [5] Cannot join a table to itself (currently). Use a different n...
+- [4] Cannot join a table to itself (currently). Use a different n...
 - [3] longer_than_or_equal_to check_operator not implemented
+- [2] invalid input syntax

--- a/tests/resources/rules/regression_analysis_report.md
+++ b/tests/resources/rules/regression_analysis_report.md
@@ -1,4 +1,5 @@
 # CDISC Rules Engine Regression Analysis
+
 =============================================
 
 ## Rule Error Summary (out of 762 total rules)
@@ -7,21 +8,22 @@
 - **Clean rules**: 662 (86.9%)
 
 **Error Breakdown by Category:**
+
 - Rules with **operator errors**: 58
 - Rules with **operation errors**: 17
 - Rules with **other errors**: 25
 
 ## Missing Operators (14 operators, 227 total failures across 58 rule occurrences)
 
- 1. **longer_than**: 66 failures across 12 rules
- 2. **is_unique_set**: 47 failures across 13 rules
- 3. **matches_regex**: 43 failures across 8 rules
- 4. **not_matches_regex**: 32 failures across 13 rules
- 5. **longer_than_or_equal_to**: 9 failures across 1 rules
- 6. **is_inconsistent_across_dataset**: 8 failures across 2 rules
- 7. **invalid_duration**: 4 failures across 1 rules
- 8. **invalid_date**: 4 failures across 2 rules
- 9. **has_equal_length**: 3 failures across 1 rules
+1.  **longer_than**: 66 failures across 12 rules
+2.  **is_unique_set**: 47 failures across 13 rules
+3.  **matches_regex**: 43 failures across 8 rules
+4.  **not_matches_regex**: 32 failures across 13 rules
+5.  **longer_than_or_equal_to**: 9 failures across 1 rules
+6.  **is_inconsistent_across_dataset**: 8 failures across 2 rules
+7.  **invalid_duration**: 4 failures across 1 rules
+8.  **invalid_date**: 4 failures across 2 rules
+9.  **has_equal_length**: 3 failures across 1 rules
 10. **starts_with**: 3 failures across 1 rules
 11. **ends_with**: 2 failures across 1 rules
 12. **has_next_corresponding_record**: 2 failures across 1 rules
@@ -30,63 +32,69 @@
 
 ## Missing Operations (11 operations, 77 total failures across 17 rule occurrences)
 
- 1. **variable_count**: 20 failures across 2 rules
- 2. **dy**: 16 failures across 3 rules
- 3. **domain_label**: 8 failures across 2 rules
- 4. **get_column_order_from_dataset**: 6 failures across 1 rules
- 5. **max_date**: 5 failures across 2 rules
- 6. **get_model_column_order**: 5 failures across 1 rules
- 7. **domain_is_custom**: 4 failures across 1 rules
- 8. **extract_metadata**: 4 failures across 1 rules
- 9. **get_parent_model_column_order**: 4 failures across 1 rules
+1.  **variable_count**: 20 failures across 2 rules
+2.  **dy**: 16 failures across 3 rules
+3.  **domain_label**: 8 failures across 2 rules
+4.  **get_column_order_from_dataset**: 6 failures across 1 rules
+5.  **max_date**: 5 failures across 2 rules
+6.  **get_model_column_order**: 5 failures across 1 rules
+7.  **domain_is_custom**: 4 failures across 1 rules
+8.  **extract_metadata**: 4 failures across 1 rules
+9.  **get_parent_model_column_order**: 4 failures across 1 rules
 10. **min_date**: 3 failures across 2 rules
 11. **valid_codelist_dates**: 2 failures across 1 rules
+
 ## Other Execution Errors (21 unique messages, 76 total failures across 30 rule occurrences)
 
- 1. **Rule contains invalid operator**: 15 failures across 1 rules
- 2. **Cannot join a table to itself (currently). Use a different n...**: 14 failures across 6 rules
- 3. **'NoneType' object has no attribute 'name'**: 12 failures across 2 rules
- 4. **A postgres SQL error occurred**: 7 failures across 2 rules
- 5. **invalid input syntax for type double precision: "TV.VISITDY"...**: 4 failures across 1 rules
- 6. **$ds_dsdecod**: 4 failures across 2 rules
- 7. **invalid input syntax for type timestamp: "2018-04"
-**: 3 failures across 2 rules
- 8. **invalid input syntax for type numeric: "redacted"
-**: 2 failures across 1 rules
- 9. **invalid input syntax for type timestamp: "2019-03"
-**: 2 failures across 1 rules
+1.  **Rule contains invalid operator**: 15 failures across 1 rules
+2.  **Cannot join a table to itself (currently). Use a different n...**: 14 failures across 6 rules
+3.  **'NoneType' object has no attribute 'name'**: 12 failures across 2 rules
+4.  **A postgres SQL error occurred**: 7 failures across 2 rules
+5.  **invalid input syntax for type double precision: "TV.VISITDY"...**: 4 failures across 1 rules
+6.  **$ds_dsdecod**: 4 failures across 2 rules
+7.  **invalid input syntax for type timestamp: "2018-04"
+    **: 3 failures across 2 rules
+8.  **invalid input syntax for type numeric: "redacted"
+    **: 2 failures across 1 rules
+9.  **invalid input syntax for type timestamp: "2019-03"
+    **: 2 failures across 1 rules
 10. **invalid input syntax for type double precision: "SE.TAETORD"...**: 2 failures across 1 rules
 11. **invalid input syntax for type double precision: "TV.VISITDY"...**: 1 failures across 1 rules
 12. **Column visitnum or visitnum not found in the respective sche...**: 1 failures across 1 rules
 13. **invalid input syntax for type timestamp: "cmdtc"
-LINE 4: ......**: 1 failures across 1 rules
+    LINE 4: ......**: 1 failures across 1 rules
 14. **invalid input syntax for type timestamp: "2012-08"
-**: 1 failures across 1 rules
+    **: 1 failures across 1 rules
 15. **invalid input syntax for type timestamp: "cmdtc"
-LINE 4: ......**: 1 failures across 1 rules
+    LINE 4: ......**: 1 failures across 1 rules
 
 ## SQL vs Old Engine Discrepancies
 
 ### SQL Errors where Old Engine Skipped (141 cases)
-*Indicates SQL engine running rules it shouldn't*
+
+_Indicates SQL engine running rules it shouldn't_
+
 - [22] is_unique_set check_operator not implemented
 - [18] longer_than check_operator not implemented
+- [16] column or relation does not exist
 - [15] not_matches_regex check_operator not implemented
+- [11] invalid input syntax
 - [9] matches_regex check_operator not implemented
 - [5] Operation max_date is not implemented
 - [4] $ds_dsdecod
 - [4] Cannot join a table to itself (currently). Use a different n...
 - [4] invalid_duration check_operator not implemented
-- [4] longer_than_or_equal_to check_operator not implemented
-- [4] Operation extract_metadata is not implemented
 
 ### SQL Success where Old Engine Skipped (299 cases)
-*Indicates SQL engine not respecting rule applicability*
+
+_Indicates SQL engine not respecting rule applicability_
 **Skip Types:**
+
 - Class Not Applicable: 220
 - Domain Not Applicable: 79
 
 **Examples:**
+
 - [6] Rule skipped - doesn't apply to class for rule id=CORE-00047...
 - [6] Rule skipped - doesn't apply to class for rule id=CORE-00053...
 - [5] Rule skipped - doesn't apply to class for rule id=CORE-00056...
@@ -94,14 +102,17 @@ LINE 4: ......**: 1 failures across 1 rules
 - [4] Rule skipped - doesn't apply to class for rule id=CORE-00033...
 
 ### SQL Errors where Old Engine Succeeded (96 cases)
-*Indicates actual regressions in SQL implementation*
+
+_Indicates actual regressions in SQL implementation_
+
 - [17] is_unique_set check_operator not implemented
 - [17] not_matches_regex check_operator not implemented
 - [13] longer_than check_operator not implemented
 - [12] matches_regex check_operator not implemented
+- [8] column or relation does not exist
 - [8] is_inconsistent_across_dataset check_operator not implemente...
+- [8] SQL syntax error
 - [8] Operation variable_count is not implemented
 - [6] Operation dy is not implemented
 - [5] Cannot join a table to itself (currently). Use a different n...
 - [3] longer_than_or_equal_to check_operator not implemented
-- [2] prefix_equal_to check_operator not implemented

--- a/tests/resources/rules/regression_analysis_report.md
+++ b/tests/resources/rules/regression_analysis_report.md
@@ -15,14 +15,14 @@
 
 ## Missing Operators (14 operators, 227 total failures across 58 rule occurrences)
 
-1.  **longer_than**: 66 failures across 12 rules
-2.  **is_unique_set**: 47 failures across 13 rules
-3.  **matches_regex**: 43 failures across 8 rules
-4.  **not_matches_regex**: 32 failures across 13 rules
-5.  **longer_than_or_equal_to**: 9 failures across 1 rules
-6.  **is_inconsistent_across_dataset**: 8 failures across 2 rules
-7.  **invalid_duration**: 4 failures across 1 rules
-8.  **invalid_date**: 4 failures across 2 rules
+1.  **is_unique_set**: 47 failures across 13 rules
+2.  **not_matches_regex**: 32 failures across 13 rules
+3.  **longer_than**: 66 failures across 12 rules
+4.  **matches_regex**: 43 failures across 8 rules
+5.  **is_inconsistent_across_dataset**: 8 failures across 2 rules
+6.  **invalid_date**: 4 failures across 2 rules
+7.  **longer_than_or_equal_to**: 9 failures across 1 rules
+8.  **invalid_duration**: 4 failures across 1 rules
 9.  **has_equal_length**: 3 failures across 1 rules
 10. **starts_with**: 3 failures across 1 rules
 11. **ends_with**: 2 failures across 1 rules
@@ -32,35 +32,35 @@
 
 ## Missing Operations (11 operations, 77 total failures across 17 rule occurrences)
 
-1.  **variable_count**: 20 failures across 2 rules
-2.  **dy**: 16 failures across 3 rules
+1.  **dy**: 16 failures across 3 rules
+2.  **variable_count**: 20 failures across 2 rules
 3.  **domain_label**: 8 failures across 2 rules
-4.  **get_column_order_from_dataset**: 6 failures across 1 rules
-5.  **max_date**: 5 failures across 2 rules
-6.  **get_model_column_order**: 5 failures across 1 rules
-7.  **domain_is_custom**: 4 failures across 1 rules
-8.  **extract_metadata**: 4 failures across 1 rules
-9.  **get_parent_model_column_order**: 4 failures across 1 rules
-10. **min_date**: 3 failures across 2 rules
+4.  **max_date**: 5 failures across 2 rules
+5.  **min_date**: 3 failures across 2 rules
+6.  **get_column_order_from_dataset**: 6 failures across 1 rules
+7.  **get_model_column_order**: 5 failures across 1 rules
+8.  **domain_is_custom**: 4 failures across 1 rules
+9.  **extract_metadata**: 4 failures across 1 rules
+10. **get_parent_model_column_order**: 4 failures across 1 rules
 11. **valid_codelist_dates**: 2 failures across 1 rules
 
 ## Execution Errors by Type (25 unique error types, 384 total failures across 101 rule occurrences)
 
 1.  **An unknown exception has occurred**: 104 failures across 25 rules
-2.  **SQL error in longer_than operator**: 66 failures across 12 rules
-3.  **SQL error in is_not_unique_set operator**: 47 failures across 13 rules
-4.  **SQL error in matches_regex operator**: 43 failures across 8 rules
-5.  **SQL error in not_matches_regex operator**: 32 failures across 13 rules
-6.  **Rule format error**: 15 failures across 1 rules
-7.  **SQL error in date_greater_than operator**: 10 failures across 6 rules
-8.  **SQL error in shorter_than operator**: 9 failures across 1 rules
-9.  **SQL error in is_inconsistent_across_dataset operator**: 8 failures across 2 rules
-10. **SQL error in not_equal_to operator**: 7 failures across 2 rules
-11. **PostgreSQL Error**: 6 failures across 1 rules
-12. **SQL error in does_not_contain operator**: 4 failures across 2 rules
-13. **SQL error in invalid_duration operator**: 4 failures across 1 rules
-14. **SQL error in is_incomplete_date operator**: 4 failures across 1 rules
-15. **SQL error in invalid_date operator**: 4 failures across 2 rules
+2.  **SQL error in is_not_unique_set operator**: 47 failures across 13 rules
+3.  **SQL error in not_matches_regex operator**: 32 failures across 13 rules
+4.  **SQL error in longer_than operator**: 66 failures across 12 rules
+5.  **SQL error in matches_regex operator**: 43 failures across 8 rules
+6.  **SQL error in date_greater_than operator**: 10 failures across 6 rules
+7.  **SQL error in is_inconsistent_across_dataset operator**: 8 failures across 2 rules
+8.  **SQL error in not_equal_to operator**: 7 failures across 2 rules
+9.  **SQL error in does_not_contain operator**: 4 failures across 2 rules
+10. **SQL error in invalid_date operator**: 4 failures across 2 rules
+11. **SQL error in less_than_or_equal_to operator**: 3 failures across 2 rules
+12. **Rule format error**: 15 failures across 1 rules
+13. **SQL error in shorter_than operator**: 9 failures across 1 rules
+14. **PostgreSQL Error**: 6 failures across 1 rules
+15. **SQL error in invalid_duration operator**: 4 failures across 1 rules
 
 ## SQL vs Old Engine Discrepancies
 

--- a/tests/resources/rules/regression_analysis_report.md
+++ b/tests/resources/rules/regression_analysis_report.md
@@ -76,9 +76,8 @@ _Indicates SQL engine running rules it shouldn't_
 
 - [22] is_unique_set check_operator not implemented
 - [18] longer_than check_operator not implemented
-- [16] column or relation does not exist
 - [15] not_matches_regex check_operator not implemented
-- [11] invalid input syntax
+- [15] invalid input syntax
 - [9] matches_regex check_operator not implemented
 - [5] Operation max_date is not implemented
 - [4] $ds_dsdecod
@@ -109,10 +108,10 @@ _Indicates actual regressions in SQL implementation_
 - [17] not_matches_regex check_operator not implemented
 - [13] longer_than check_operator not implemented
 - [12] matches_regex check_operator not implemented
-- [8] column or relation does not exist
 - [8] is_inconsistent_across_dataset check_operator not implemente...
 - [8] SQL syntax error
 - [8] Operation variable_count is not implemented
+- [6] column or relation does not exist
 - [6] Operation dy is not implemented
 - [5] Cannot join a table to itself (currently). Use a different n...
 - [3] longer_than_or_equal_to check_operator not implemented

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -3940,11 +3940,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -3953,11 +3953,11 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -4014,11 +4014,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -4027,11 +4027,11 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -11829,11 +11829,11 @@
                                 "dataset": "ag.xpt",
                                 "domain": "AG",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11842,11 +11842,11 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11855,11 +11855,11 @@
                                 "dataset": "ec.xpt",
                                 "domain": "EC",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11868,11 +11868,11 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11881,11 +11881,11 @@
                                 "dataset": "ml.xpt",
                                 "domain": "ML",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11894,11 +11894,11 @@
                                 "dataset": "pr.xpt",
                                 "domain": "PR",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11907,11 +11907,11 @@
                                 "dataset": "su.xpt",
                                 "domain": "SU",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11920,11 +11920,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11933,11 +11933,11 @@
                                 "dataset": "be.xpt",
                                 "domain": "BE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11946,11 +11946,11 @@
                                 "dataset": "ce.xpt",
                                 "domain": "CE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11959,11 +11959,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11972,11 +11972,11 @@
                                 "dataset": "dv.xpt",
                                 "domain": "DV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11985,11 +11985,11 @@
                                 "dataset": "ho.xpt",
                                 "domain": "HO",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -11998,11 +11998,11 @@
                                 "dataset": "mh.xpt",
                                 "domain": "MH",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12191,11 +12191,11 @@
                                 "dataset": "ag.xpt",
                                 "domain": "AG",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12204,11 +12204,11 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12217,11 +12217,11 @@
                                 "dataset": "ec.xpt",
                                 "domain": "EC",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12230,11 +12230,11 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12243,11 +12243,11 @@
                                 "dataset": "ml.xpt",
                                 "domain": "ML",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12256,11 +12256,11 @@
                                 "dataset": "pr.xpt",
                                 "domain": "PR",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12269,11 +12269,11 @@
                                 "dataset": "su.xpt",
                                 "domain": "SU",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12282,11 +12282,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12295,11 +12295,11 @@
                                 "dataset": "be.xpt",
                                 "domain": "BE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12308,11 +12308,11 @@
                                 "dataset": "ce.xpt",
                                 "domain": "CE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12321,11 +12321,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12334,11 +12334,11 @@
                                 "dataset": "dv.xpt",
                                 "domain": "DV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12347,11 +12347,11 @@
                                 "dataset": "ho.xpt",
                                 "domain": "HO",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -12360,11 +12360,11 @@
                                 "dataset": "mh.xpt",
                                 "domain": "MH",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -16360,11 +16360,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -16413,11 +16413,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -23088,11 +23088,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -23157,11 +23157,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24523,11 +24523,11 @@
                                 "dataset": "ag.xpt",
                                 "domain": "AG",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24536,11 +24536,11 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24549,11 +24549,11 @@
                                 "dataset": "ec.xpt",
                                 "domain": "EC",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24562,11 +24562,11 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24575,11 +24575,11 @@
                                 "dataset": "ml.xpt",
                                 "domain": "ML",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24588,11 +24588,11 @@
                                 "dataset": "pr.xpt",
                                 "domain": "PR",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24732,11 +24732,11 @@
                                 "dataset": "ag.xpt",
                                 "domain": "AG",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24745,11 +24745,11 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24758,11 +24758,11 @@
                                 "dataset": "ec.xpt",
                                 "domain": "EC",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24771,11 +24771,11 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24784,11 +24784,11 @@
                                 "dataset": "ml.xpt",
                                 "domain": "ML",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -24797,11 +24797,11 @@
                                 "dataset": "pr.xpt",
                                 "domain": "PR",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -37127,11 +37127,11 @@
                                 "dataset": "relrec.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in ends_with operator",
                                         "message": "ends_with check_operator not implemented"
                                     }
                                 ]
@@ -37180,11 +37180,11 @@
                                 "dataset": "relrec.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in ends_with operator",
                                         "message": "ends_with check_operator not implemented"
                                     }
                                 ]
@@ -37482,7 +37482,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -37577,7 +37577,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -39044,11 +39044,11 @@
                                 "dataset": "vs.xpt",
                                 "domain": "VS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_inconsistent_across_dataset operator",
                                         "message": "is_inconsistent_across_dataset check_operator not implemented"
                                     }
                                 ]
@@ -39143,11 +39143,11 @@
                                 "dataset": "ft.xpt",
                                 "domain": "FT",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_inconsistent_across_dataset operator",
                                         "message": "is_inconsistent_across_dataset check_operator not implemented"
                                     }
                                 ]
@@ -39245,11 +39245,11 @@
                                 "dataset": "vs.xpt",
                                 "domain": "VS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_inconsistent_across_dataset operator",
                                         "message": "is_inconsistent_across_dataset check_operator not implemented"
                                     }
                                 ]
@@ -39295,11 +39295,11 @@
                                 "dataset": "ft.xpt",
                                 "domain": "FT",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_inconsistent_across_dataset operator",
                                         "message": "is_inconsistent_across_dataset check_operator not implemented"
                                     }
                                 ]
@@ -39386,11 +39386,11 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -39436,11 +39436,11 @@
                                 "dataset": "se.xpt",
                                 "domain": "SE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -39486,11 +39486,11 @@
                                 "dataset": "te.xpt",
                                 "domain": "TE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -39539,11 +39539,11 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -39589,11 +39589,11 @@
                                 "dataset": "se.xpt",
                                 "domain": "SE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -39639,11 +39639,11 @@
                                 "dataset": "te.xpt",
                                 "domain": "TE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -39705,11 +39705,11 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -39758,11 +39758,11 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -39824,11 +39824,11 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -39874,11 +39874,11 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -39927,11 +39927,11 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -39977,11 +39977,11 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -40027,11 +40027,11 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -40093,11 +40093,11 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -40146,11 +40146,11 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -40196,11 +40196,11 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -40262,11 +40262,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -40344,11 +40344,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -40925,11 +40925,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -40978,11 +40978,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -43831,11 +43831,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -46344,11 +46344,11 @@
                                 "dataset": "ae1.xpt",
                                 "domain": "AE1",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -46357,11 +46357,11 @@
                                 "dataset": "dmx.xpt",
                                 "domain": "DMX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -46436,11 +46436,11 @@
                                 "dataset": "tr.xpt",
                                 "domain": "TR",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -46486,11 +46486,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -46499,11 +46499,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -46581,11 +46581,11 @@
                                 "dataset": "apmhe.xpt",
                                 "domain": "APMHE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in has_not_equal_length operator",
                                         "message": "has_equal_length check_operator not implemented"
                                     }
                                 ]
@@ -46699,11 +46699,11 @@
                                 "dataset": "apmh.xpt",
                                 "domain": "APMH",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in has_not_equal_length operator",
                                         "message": "has_equal_length check_operator not implemented"
                                     }
                                 ]
@@ -46797,11 +46797,11 @@
                                 "dataset": "apmh.xpt",
                                 "domain": "APMH",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in has_not_equal_length operator",
                                         "message": "has_equal_length check_operator not implemented"
                                     }
                                 ]
@@ -46887,11 +46887,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -46900,11 +46900,11 @@
                                 "dataset": "apmhe.xpt",
                                 "domain": "APMHE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -46913,11 +46913,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -47000,11 +47000,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -47013,11 +47013,11 @@
                                 "dataset": "apmh.xpt",
                                 "domain": "APMH",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -47026,11 +47026,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -47092,11 +47092,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -47105,11 +47105,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -48785,11 +48785,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -48838,11 +48838,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -48904,11 +48904,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -48957,11 +48957,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -55017,11 +55017,11 @@
                                 "dataset": "vs.xpt",
                                 "domain": "VS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -55140,11 +55140,11 @@
                                 "dataset": "oe.xpt",
                                 "domain": "OE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -55282,11 +55282,11 @@
                                 "dataset": "vs.xpt",
                                 "domain": "VS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -55332,11 +55332,11 @@
                                 "dataset": "oe.xpt",
                                 "domain": "OE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -57357,11 +57357,11 @@
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -57422,11 +57422,11 @@
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -57500,11 +57500,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -57596,11 +57596,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -57665,11 +57665,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -57715,11 +57715,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -57793,11 +57793,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -57843,11 +57843,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -57909,7 +57909,7 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -57985,7 +57985,7 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -58051,7 +58051,7 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -58165,7 +58165,7 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -58243,11 +58243,11 @@
                                 "dataset": "sm.xpt",
                                 "domain": "SM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -58324,11 +58324,11 @@
                                 "dataset": "sm.xpt",
                                 "domain": "SM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -58906,11 +58906,11 @@
                                 "dataset": "vs.xpt",
                                 "domain": "VS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -59069,11 +59069,11 @@
                                 "dataset": "vs.xpt",
                                 "domain": "VS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -59119,11 +59119,11 @@
                                 "dataset": "vs.xpt",
                                 "domain": "VS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -59185,11 +59185,11 @@
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -59235,11 +59235,11 @@
                                 "dataset": "suppae.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -59288,11 +59288,11 @@
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -59338,11 +59338,11 @@
                                 "dataset": "suppae.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -59404,11 +59404,11 @@
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -59454,11 +59454,11 @@
                                 "dataset": "suppae.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -59507,11 +59507,11 @@
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -59557,11 +59557,11 @@
                                 "dataset": "suppae.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -63265,12 +63265,12 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type double precision: \"TV.VISITDY\"\nLINE 6:                         ELSE visitdy != 'TV.VISITDY'\n                                                ^\n"
+                                        "error": "SQL error in not_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -63341,12 +63341,12 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type double precision: \"TV.VISITDY\"\nLINE 6: ...E vevkh9xijrjum2si7bwa2fbgobgxfb3ilplq5vwpn5wc != 'TV.VISITD...\n                                                             ^\n"
+                                        "error": "SQL error in not_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -63362,12 +63362,12 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type double precision: \"TV.VISITDY\"\nLINE 6:                         ELSE visitdy != 'TV.VISITDY'\n                                                ^\n"
+                                        "error": "SQL error in not_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -63375,12 +63375,12 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type double precision: \"TV.VISITDY\"\nLINE 6:                         ELSE visitdy != 'TV.VISITDY'\n                                                ^\n"
+                                        "error": "SQL error in not_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -65256,12 +65256,12 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type double precision: \"TV.VISITDY\"\nLINE 6:                         ELSE visitdy != 'TV.VISITDY'\n                                                ^\n"
+                                        "error": "SQL error in not_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -65571,7 +65571,7 @@
                                 "dataset": "ss.xpt",
                                 "domain": "SS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -65658,7 +65658,7 @@
                                 "dataset": "ss.xpt",
                                 "domain": "SS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -71826,7 +71826,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -72692,7 +72692,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -73968,7 +73968,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -75234,7 +75234,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -77846,11 +77846,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -77918,11 +77918,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -77984,11 +77984,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -78056,11 +78056,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -78106,11 +78106,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -78180,7 +78180,7 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -78258,7 +78258,7 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -78482,11 +78482,11 @@
                                 "dataset": "suppdmmmm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -78532,11 +78532,11 @@
                                 "dataset": "suppapfamh.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -78652,11 +78652,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in invalid_duration operator",
                                         "message": "invalid_duration check_operator not implemented"
                                     }
                                 ]
@@ -78702,11 +78702,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in invalid_duration operator",
                                         "message": "invalid_duration check_operator not implemented"
                                     }
                                 ]
@@ -78755,11 +78755,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in invalid_duration operator",
                                         "message": "invalid_duration check_operator not implemented"
                                     }
                                 ]
@@ -78805,11 +78805,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in invalid_duration operator",
                                         "message": "invalid_duration check_operator not implemented"
                                     }
                                 ]
@@ -81266,11 +81266,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -81335,11 +81335,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -81398,11 +81398,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -81448,11 +81448,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -81514,11 +81514,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -81583,11 +81583,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -81646,11 +81646,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -81696,11 +81696,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -84288,7 +84288,7 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -85779,11 +85779,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -85832,11 +85832,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -85898,11 +85898,11 @@
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in starts_with operator",
                                         "message": "starts_with check_operator not implemented"
                                     }
                                 ]
@@ -85967,11 +85967,11 @@
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in starts_with operator",
                                         "message": "starts_with check_operator not implemented"
                                     }
                                 ]
@@ -86033,11 +86033,11 @@
                                 "dataset": "suppdm.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in starts_with operator",
                                         "message": "starts_with check_operator not implemented"
                                     }
                                 ]
@@ -86115,11 +86115,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -86168,11 +86168,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -86405,11 +86405,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -86458,11 +86458,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -86625,11 +86625,11 @@
                                 "dataset": "se.xpt",
                                 "domain": "SE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in does_not_have_next_corresponding_record operator",
                                         "message": "has_next_corresponding_record check_operator not implemented"
                                     }
                                 ]
@@ -86678,11 +86678,11 @@
                                 "dataset": "se.xpt",
                                 "domain": "SE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in does_not_have_next_corresponding_record operator",
                                         "message": "has_next_corresponding_record check_operator not implemented"
                                     }
                                 ]
@@ -86773,7 +86773,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -86865,7 +86865,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -87070,7 +87070,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -87152,7 +87152,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -87328,11 +87328,11 @@
                                 "dataset": "suppqscqi.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -87341,11 +87341,11 @@
                                 "dataset": "suppqsswls.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -87402,11 +87402,11 @@
                                 "dataset": "suppqscq.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -87415,11 +87415,11 @@
                                 "dataset": "suppqssw.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -89765,11 +89765,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -89836,11 +89836,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -89907,11 +89907,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -89981,11 +89981,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -90037,11 +90037,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -93092,11 +93092,11 @@
                                 "dataset": "qscgi2.xpt",
                                 "domain": "QS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in shorter_than operator",
                                         "message": "longer_than_or_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -93175,11 +93175,11 @@
                                 "dataset": "qscgi2.xpt",
                                 "domain": "QS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in shorter_than operator",
                                         "message": "longer_than_or_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -93245,11 +93245,11 @@
                                 "dataset": "qspg.xpt",
                                 "domain": "QS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in shorter_than operator",
                                         "message": "longer_than_or_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -93258,11 +93258,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in shorter_than operator",
                                         "message": "longer_than_or_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -93325,11 +93325,11 @@
                                 "dataset": "qspg.xpt",
                                 "domain": "QS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in shorter_than operator",
                                         "message": "longer_than_or_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -93338,11 +93338,11 @@
                                 "dataset": "relrec.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in shorter_than operator",
                                         "message": "longer_than_or_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -93396,11 +93396,11 @@
                                 "dataset": "qspg.xpt",
                                 "domain": "QS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in shorter_than operator",
                                         "message": "longer_than_or_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -93462,11 +93462,11 @@
                                 "dataset": "qspg.xpt",
                                 "domain": "QS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in shorter_than operator",
                                         "message": "longer_than_or_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -93528,11 +93528,11 @@
                                 "dataset": "qspg.xpt",
                                 "domain": "QS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in shorter_than operator",
                                         "message": "longer_than_or_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -94063,11 +94063,11 @@
                                 "dataset": "se.xpt",
                                 "domain": "SE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in empty_within_except_last_row operator",
                                         "message": "empty_within_except_last_row check_operator not implemented"
                                     }
                                 ]
@@ -94122,11 +94122,11 @@
                                 "dataset": "se.xpt",
                                 "domain": "SE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in empty_within_except_last_row operator",
                                         "message": "empty_within_except_last_row check_operator not implemented"
                                     }
                                 ]
@@ -95147,11 +95147,11 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95200,11 +95200,11 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95518,11 +95518,11 @@
                                 "dataset": "mhlb.xpt",
                                 "domain": "MH",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95531,11 +95531,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95544,11 +95544,11 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95624,11 +95624,11 @@
                                 "dataset": "qs1.xpt",
                                 "domain": "QS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95702,11 +95702,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95715,11 +95715,11 @@
                                 "dataset": "apmh.xpt",
                                 "domain": "APMHE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95773,11 +95773,11 @@
                                 "dataset": "mhLB.xpt",
                                 "domain": "MH",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95786,11 +95786,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95799,11 +95799,11 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95865,11 +95865,11 @@
                                 "dataset": "qs1.xpt",
                                 "domain": "QS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95878,11 +95878,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -95952,11 +95952,11 @@
                                 "dataset": "fa1.xpt",
                                 "domain": "FA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96002,11 +96002,11 @@
                                 "dataset": "facm.xpt",
                                 "domain": "FA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96055,11 +96055,11 @@
                                 "dataset": "fa.xpt",
                                 "domain": "FA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96068,11 +96068,11 @@
                                 "dataset": "apmh.xpt",
                                 "domain": "APMHE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96126,11 +96126,11 @@
                                 "dataset": "famh.xpt",
                                 "domain": "FA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96139,11 +96139,11 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96152,11 +96152,11 @@
                                 "dataset": "mh.xpt",
                                 "domain": "MH",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96218,11 +96218,11 @@
                                 "dataset": "facm.xpt",
                                 "domain": "FA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96231,11 +96231,11 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96350,11 +96350,11 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -96526,11 +96526,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -96539,11 +96539,11 @@
                                 "dataset": "ss1.xpt",
                                 "domain": "SS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -96552,11 +96552,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -96565,11 +96565,11 @@
                                 "dataset": "lbae.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -96916,11 +96916,11 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -96929,11 +96929,11 @@
                                 "dataset": "ss1.xpt",
                                 "domain": "SS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -96942,11 +96942,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -96955,11 +96955,11 @@
                                 "dataset": "lbae.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -96968,11 +96968,11 @@
                                 "dataset": "suppec.xpt",
                                 "domain": "",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -96981,11 +96981,11 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -98660,12 +98660,12 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2012-08\"\n"
+                                        "error": "SQL error in date_less_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -98792,7 +98792,7 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -99202,11 +99202,11 @@
                                 "dataset": "te.xpt",
                                 "domain": "TE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -99252,11 +99252,11 @@
                                 "dataset": "te.xpt",
                                 "domain": "TE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -99302,11 +99302,11 @@
                                 "dataset": "te.xpt",
                                 "domain": "TE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -99355,11 +99355,11 @@
                                 "dataset": "te.xpt",
                                 "domain": "TE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -99405,11 +99405,11 @@
                                 "dataset": "te.xpt",
                                 "domain": "TE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -99455,11 +99455,11 @@
                                 "dataset": "te.xpt",
                                 "domain": "TE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -99712,12 +99712,12 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type numeric: \"redacted\"\n"
+                                        "error": "SQL error in less_than_or_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -99762,12 +99762,12 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type numeric: \"redacted\"\n"
+                                        "error": "SQL error in less_than_or_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -99919,11 +99919,11 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in not_matches_regex operator",
                                         "message": "not_matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -100282,11 +100282,11 @@
                                 "dataset": "alb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in prefix_not_equal_to operator",
                                         "message": "prefix_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -100363,11 +100363,11 @@
                                 "dataset": "lb.xpt",
                                 "domain": "LB",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in prefix_not_equal_to operator",
                                         "message": "prefix_equal_to check_operator not implemented"
                                     }
                                 ]
@@ -101013,7 +101013,7 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -101091,7 +101091,7 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -101173,11 +101173,11 @@
                                 "dataset": "ft.xpt",
                                 "domain": "FT",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_inconsistent_across_dataset operator",
                                         "message": "is_inconsistent_across_dataset check_operator not implemented"
                                     }
                                 ]
@@ -101524,11 +101524,11 @@
                                 "dataset": "ft.xpt",
                                 "domain": "FT",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_inconsistent_across_dataset operator",
                                         "message": "is_inconsistent_across_dataset check_operator not implemented"
                                     }
                                 ]
@@ -101898,11 +101898,11 @@
                                 "dataset": "ft.xpt",
                                 "domain": "FT",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_inconsistent_across_dataset operator",
                                         "message": "is_inconsistent_across_dataset check_operator not implemented"
                                     }
                                 ]
@@ -101948,11 +101948,11 @@
                                 "dataset": "ft.xpt",
                                 "domain": "FT",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_inconsistent_across_dataset operator",
                                         "message": "is_inconsistent_across_dataset check_operator not implemented"
                                     }
                                 ]
@@ -104055,12 +104055,12 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2006-03\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -104731,12 +104731,12 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2018-05\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -104845,12 +104845,12 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2018-04\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -105186,7 +105186,7 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -105265,7 +105265,7 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -105339,12 +105339,12 @@
                                 "dataset": "sm.xpt",
                                 "domain": "SM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2018-04-17T09\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -105388,12 +105388,12 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2019-03\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -105401,12 +105401,12 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"\t2018-07\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -105530,12 +105530,12 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2019-03\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -105855,7 +105855,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -105980,7 +105980,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -107136,11 +107136,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in invalid_date operator",
                                         "message": "invalid_date check_operator not implemented"
                                     }
                                 ]
@@ -107189,11 +107189,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in invalid_date operator",
                                         "message": "invalid_date check_operator not implemented"
                                     }
                                 ]
@@ -107255,11 +107255,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in invalid_date operator",
                                         "message": "invalid_date check_operator not implemented"
                                     }
                                 ]
@@ -107308,11 +107308,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in invalid_date operator",
                                         "message": "invalid_date check_operator not implemented"
                                     }
                                 ]
@@ -109959,12 +109959,12 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2019\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -110715,12 +110715,12 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "A postgres SQL error occurred"
+                                        "error": "PostgreSQL Error",
+                                        "message": "SQL syntax error"
                                     }
                                 ]
                             },
@@ -110728,12 +110728,12 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "A postgres SQL error occurred"
+                                        "error": "PostgreSQL Error",
+                                        "message": "SQL syntax error"
                                     }
                                 ]
                             },
@@ -110741,12 +110741,12 @@
                                 "dataset": "fa.xpt",
                                 "domain": "FA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "A postgres SQL error occurred"
+                                        "error": "PostgreSQL Error",
+                                        "message": "SQL syntax error"
                                     }
                                 ]
                             },
@@ -110861,12 +110861,12 @@
                                 "dataset": "cm.xpt",
                                 "domain": "CM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "A postgres SQL error occurred"
+                                        "error": "PostgreSQL Error",
+                                        "message": "SQL syntax error"
                                     }
                                 ]
                             },
@@ -110874,12 +110874,12 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "A postgres SQL error occurred"
+                                        "error": "PostgreSQL Error",
+                                        "message": "SQL syntax error"
                                     }
                                 ]
                             },
@@ -110887,12 +110887,12 @@
                                 "dataset": "fa.xpt",
                                 "domain": "FA",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "A postgres SQL error occurred"
+                                        "error": "PostgreSQL Error",
+                                        "message": "SQL syntax error"
                                     }
                                 ]
                             },
@@ -113870,11 +113870,11 @@
                                 "dataset": "apdrug1ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in longer_than operator",
                                         "message": "longer_than check_operator not implemented"
                                     }
                                 ]
@@ -114363,7 +114363,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -114432,7 +114432,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -114662,11 +114662,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -114715,11 +114715,11 @@
                                 "dataset": "ts.xpt",
                                 "domain": "TS",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in matches_regex operator",
                                         "message": "matches_regex check_operator not implemented"
                                     }
                                 ]
@@ -116099,11 +116099,11 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operation execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in sqldistinct operation",
                                         "message": "'NoneType' object has no attribute 'type'"
                                     }
                                 ]
@@ -116377,12 +116377,12 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "rule execution error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "A postgres SQL error occurred"
+                                        "error": "SQL error in less_than_or_equal_to operator",
+                                        "message": "SQL syntax error"
                                     }
                                 ]
                             }

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -84292,8 +84292,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"cmdtc\"\nLINE 4: ...            AND CAST(cmentpt AS TIMESTAMP) = CAST('cmdtc' AS...\n                                                             ^\n"
+                                        "error": "SQL error in date_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -98796,8 +98796,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"cmdtc\"\nLINE 4: ...            AND CAST(cmentpt AS TIMESTAMP) < CAST('cmdtc' AS...\n                                                             ^\n"
+                                        "error": "SQL error in date_less_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             },
@@ -105190,8 +105190,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2018-04\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -105269,8 +105269,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type timestamp: \"2018-04\"\n"
+                                        "error": "SQL error in date_greater_than operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -114367,8 +114367,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type double precision: \"SE.TAETORD\"\nLINE 6:                         ELSE taetord != 'SE.TAETORD'\n                                                ^\n"
+                                        "error": "SQL error in not_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }
@@ -114436,8 +114436,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
-                                        "message": "invalid input syntax for type double precision: \"SE.TAETORD\"\nLINE 6:                         ELSE taetord != 'SE.TAETORD'\n                                                ^\n"
+                                        "error": "SQL error in not_equal_to operator",
+                                        "message": "invalid input syntax"
                                     }
                                 ]
                             }

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -37482,7 +37482,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -37577,7 +37577,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -57913,7 +57913,7 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -57989,7 +57989,7 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -58055,7 +58055,7 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -58169,7 +58169,7 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "An unknown exception has occurred",
+                                        "error": "SQL error in is_not_unique_set operator",
                                         "message": "is_unique_set check_operator not implemented"
                                     }
                                 ]
@@ -65575,8 +65575,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "Column not found in data",
-                                        "message": "$ds_dsdecod"
+                                        "error": "SQL error in does_not_contain operator",
+                                        "message": "'$ds_dsdecod'"
                                     }
                                 ]
                             }
@@ -65662,8 +65662,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "Column not found in data",
-                                        "message": "$ds_dsdecod"
+                                        "error": "SQL error in does_not_contain operator",
+                                        "message": "'$ds_dsdecod'"
                                     }
                                 ]
                             }
@@ -71826,7 +71826,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -72692,7 +72692,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -73968,7 +73968,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -75234,7 +75234,7 @@
                                 "dataset": "sv.xpt",
                                 "domain": "SV",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -78180,7 +78180,7 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -78258,7 +78258,7 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -86773,7 +86773,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -86856,16 +86856,21 @@
                             {
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "SQL operator execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    {
+                                        "error": "SQL error in is_incomplete_date operator",
+                                        "message": "'AEDTC'"
+                                    }
+                                ]
                             },
                             {
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -86877,10 +86882,15 @@
                             {
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "SQL operator execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    {
+                                        "error": "SQL error in is_incomplete_date operator",
+                                        "message": "'EXDTC'"
+                                    }
+                                ]
                             },
                             {
                                 "dataset": "lb",
@@ -87070,7 +87080,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -87130,21 +87140,15 @@
                         "results_present_sql": true,
                         "results_sql": [
                             {
-                                "dataset": "ae",
+                                "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "The date portion of AEDTC is not complete date or the date portion of DM.RFSTDTC is not complete date, but AEDY is not empty",
+                                "execution_status": "execution_error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "row": 4,
-                                        "SEQ": 1,
-                                        "USUBJID": "123102",
-                                        "value": {
-                                            "AEDTC": "Not in dataset",
-                                            "AEDY": "Not in dataset",
-                                            "RFSTDTC": "2005-10"
-                                        }
+                                        "error": "SQL error in is_incomplete_date operator",
+                                        "message": "'AEDTC'"
                                     }
                                 ]
                             },
@@ -87152,7 +87156,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -87162,31 +87166,15 @@
                                 ]
                             },
                             {
-                                "dataset": "ex",
+                                "dataset": "ex.xpt",
                                 "domain": "EX",
-                                "execution_status": "success",
-                                "execution_message": "The date portion of EXDTC is not complete date or the date portion of DM.RFSTDTC is not complete date, but EXDY is not empty",
-                                "number_errors": 2,
+                                "execution_status": "execution_error",
+                                "execution_message": "SQL operator execution error",
+                                "number_errors": 1,
                                 "errors": [
                                     {
-                                        "row": 54,
-                                        "SEQ": 54,
-                                        "USUBJID": "123102",
-                                        "value": {
-                                            "EXDTC": "Not in dataset",
-                                            "EXDY": "Not in dataset",
-                                            "RFSTDTC": "2005-10"
-                                        }
-                                    },
-                                    {
-                                        "row": 55,
-                                        "SEQ": 55,
-                                        "USUBJID": "123103",
-                                        "value": {
-                                            "EXDTC": "Not in dataset",
-                                            "EXDY": "Not in dataset",
-                                            "RFSTDTC": null
-                                        }
+                                        "error": "SQL error in is_incomplete_date operator",
+                                        "message": "'EXDTC'"
                                     }
                                 ]
                             },
@@ -101017,8 +101005,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "Column not found in data",
-                                        "message": "$ds_dsdecod"
+                                        "error": "SQL error in does_not_contain operator",
+                                        "message": "'$ds_dsdecod'"
                                     }
                                 ]
                             },
@@ -101095,8 +101083,8 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "Column not found in data",
-                                        "message": "$ds_dsdecod"
+                                        "error": "SQL error in does_not_contain operator",
+                                        "message": "'$ds_dsdecod'"
                                     }
                                 ]
                             },
@@ -105855,7 +105843,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -105980,7 +105968,7 @@
                                 "dataset": "dm.xpt",
                                 "domain": "DM",
                                 "execution_status": "execution_error",
-                                "execution_message": "SQL execution error",
+                                "execution_message": "rule execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
@@ -116103,7 +116091,7 @@
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "error": "SQL error in sqldistinct operation",
+                                        "error": "SQL error in sqldistinctoperation operation",
                                         "message": "'NoneType' object has no attribute 'type'"
                                     }
                                 ]
@@ -116382,7 +116370,7 @@
                                 "errors": [
                                     {
                                         "error": "SQL error in less_than_or_equal_to operator",
-                                        "message": "SQL syntax error"
+                                        "message": "column or relation does not exist"
                                     }
                                 ]
                             }

--- a/tests/rule_regression/analyze_regression.py
+++ b/tests/rule_regression/analyze_regression.py
@@ -341,7 +341,10 @@ def _generate_operators_section(operator_failures: Dict[str, int], operator_rule
         )
         section.append("")
 
-        sorted_operators = sorted(operator_failures.items(), key=lambda x: x[1], reverse=True)
+        # Sort by rule count first, then by failure count
+        sorted_operators = sorted(
+            operator_failures.items(), key=lambda x: (operator_rule_counts.get(x[0], 0), x[1]), reverse=True
+        )
         for i, (operator, count) in enumerate(sorted_operators, 1):
             rule_count = operator_rule_counts.get(operator, 0)
             section.append(f"{i:2d}. **{operator}**: {count} failures across {rule_count} rules")
@@ -365,7 +368,10 @@ def _generate_operations_section(
         )
         section.append("")
 
-        sorted_operations = sorted(operation_failures.items(), key=lambda x: x[1], reverse=True)
+        # Sort by rule count first, then by failure count
+        sorted_operations = sorted(
+            operation_failures.items(), key=lambda x: (operation_rule_counts.get(x[0], 0), x[1]), reverse=True
+        )
         for i, (operation, count) in enumerate(sorted_operations, 1):
             rule_count = operation_rule_counts.get(operation, 0)
             section.append(f"{i:2d}. **{operation}**: {count} failures across {rule_count} rules")
@@ -443,7 +449,11 @@ def _generate_execution_errors_section(
         )
         section.append("")
 
-        for i, (error_type, count) in enumerate(execution_errors.most_common(15), 1):
+        # Sort by rule count first, then by failure count
+        sorted_errors = sorted(
+            execution_errors.items(), key=lambda x: (execution_error_rule_counts.get(x[0], 0), x[1]), reverse=True
+        )
+        for i, (error_type, count) in enumerate(sorted_errors[:15], 1):
             rule_count = execution_error_rule_counts.get(error_type, 0)
             section.append(f"{i:2d}. **{error_type}**: {count} failures across {rule_count} rules")
         section.append("")

--- a/tests/rule_regression/analyze_regression.py
+++ b/tests/rule_regression/analyze_regression.py
@@ -276,6 +276,18 @@ def _is_other_error(message: str) -> bool:
     )
 
 
+def _extract_error_types_from_results(results_sql: List[Dict]) -> List[str]:
+    """Helper: Extract error types from SQL results using the 'error' field"""
+    error_types = []
+    for result in results_sql:
+        if result.get("execution_status") == "execution_error":
+            errors = result.get("errors", [])
+            for error in errors:
+                error_type = error.get("error", "Unknown error type")
+                error_types.append(error_type)
+    return error_types
+
+
 def _extract_other_errors_from_results(results_sql: List[Dict]) -> List[str]:
     """Helper: Extract other error messages from SQL results"""
     messages = []
@@ -289,9 +301,9 @@ def _extract_other_errors_from_results(results_sql: List[Dict]) -> List[str]:
     return messages
 
 
-def categorize_other_errors(rules_data: List[Dict]) -> tuple[Counter, Dict[str, int]]:
-    """Count other execution errors (excluding operators and operations)"""
-    error_messages = []
+def categorize_execution_errors(rules_data: List[Dict]) -> tuple[Counter, Dict[str, int]]:
+    """Categorize execution errors by error type (using our improved error field)"""
+    error_types = []
     error_rules = defaultdict(set)
 
     for rule in rules_data:
@@ -306,15 +318,15 @@ def categorize_other_errors(rules_data: List[Dict]) -> tuple[Counter, Dict[str, 
                         continue
 
                     results_sql = engine_regression.get("results_sql", [])
-                    messages = _extract_other_errors_from_results(results_sql)
-                    error_messages.extend(messages)
-                    for message in messages:
-                        error_rules[message].add(core_id)
+                    error_type_list = _extract_error_types_from_results(results_sql)
+                    error_types.extend(error_type_list)
+                    for error_type in error_type_list:
+                        error_rules[error_type].add(core_id)
 
     # Convert sets to counts
-    error_rule_counts = {msg: len(rules) for msg, rules in error_rules.items()}
+    error_rule_counts = {error_type: len(rules) for error_type, rules in error_rules.items()}
 
-    return Counter(error_messages), error_rule_counts
+    return Counter(error_types), error_rule_counts
 
 
 def _generate_operators_section(operator_failures: Dict[str, int], operator_rule_counts: Dict[str, int]) -> List[str]:
@@ -417,22 +429,24 @@ def _generate_discrepancies_section(discrepancies: Dict[str, List[Dict]]) -> Lis
     return section
 
 
-def _generate_other_errors_section(other_errors: Counter, other_error_rule_counts: Dict[str, int]) -> List[str]:
-    """Helper: Generate other errors section"""
+def _generate_execution_errors_section(
+    execution_errors: Counter, execution_error_rule_counts: Dict[str, int]
+) -> List[str]:
+    """Helper: Generate execution errors section by error type"""
     section = []
-    if other_errors:
-        total_failures = sum(other_errors.values())
-        total_rules_affected = sum(other_error_rule_counts.values())
+    if execution_errors:
+        total_failures = sum(execution_errors.values())
+        total_rules_affected = sum(execution_error_rule_counts.values())
         section.append(
-            f"## Other Execution Errors ({len(other_errors)} unique messages, {total_failures} total failures "
+            f"## Execution Errors by Type ({len(execution_errors)} unique error types, {total_failures} total failures "
             f"across {total_rules_affected} rule occurrences)"
         )
         section.append("")
 
-        for i, (error_msg, count) in enumerate(other_errors.most_common(15), 1):
-            rule_count = other_error_rule_counts.get(error_msg, 0)
-            short_msg = error_msg[:60] + "..." if len(error_msg) > 60 else error_msg
-            section.append(f"{i:2d}. **{short_msg}**: {count} failures across {rule_count} rules")
+        for i, (error_type, count) in enumerate(execution_errors.most_common(15), 1):
+            rule_count = execution_error_rule_counts.get(error_type, 0)
+            section.append(f"{i:2d}. **{error_type}**: {count} failures across {rule_count} rules")
+        section.append("")
     return section
 
 
@@ -476,7 +490,7 @@ def generate_report(rules_data: List[Dict]) -> str:
     operation_failures, operation_rule_counts = extract_missing_operations(rules_data)
     rules_by_error_type = analyze_rules_by_error_type(rules_data)
     discrepancies = analyze_meaningful_discrepancies(rules_data)
-    other_errors, other_error_rule_counts = categorize_other_errors(rules_data)
+    execution_errors, execution_error_rule_counts = categorize_execution_errors(rules_data)
 
     # Add rule summary at the top
     report.extend(_generate_rule_summary_section(rules_by_error_type, len(rules_data)))
@@ -484,7 +498,7 @@ def generate_report(rules_data: List[Dict]) -> str:
 
     report.extend(_generate_operators_section(operator_failures, operator_rule_counts))
     report.extend(_generate_operations_section(operation_failures, operation_rule_counts))
-    report.extend(_generate_other_errors_section(other_errors, other_error_rule_counts))
+    report.extend(_generate_execution_errors_section(execution_errors, execution_error_rule_counts))
     report.extend(_generate_discrepancies_section(discrepancies))
 
     return "\n".join(report)
@@ -492,7 +506,11 @@ def generate_report(rules_data: List[Dict]) -> str:
 
 def main():
     """Main analysis function"""
-    rules_file = "../resources/rules/rules.json"
+    import os
+
+    # Use os.path.join for cross-platform compatibility
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    rules_file = os.path.join(script_dir, "..", "resources", "rules", "rules.json")
 
     print("Loading rules data...")
     try:
@@ -507,7 +525,7 @@ def main():
     report = generate_report(rules_data)
 
     # Save report to file
-    output_file = "../resources/rules/regression_analysis_report.md"
+    output_file = os.path.join(script_dir, "..", "resources", "rules", "regression_analysis_report.md")
     with open(output_file, "w", encoding="utf-8") as f:
         f.write(report)
 


### PR DESCRIPTION
Groups postgres errors and better identifies them into 
- operator error 
- operation error
- others

Cleanup postgres errors into 3 categories 
- column/relation does not exist
- sql syntax error
- invalid input syntax

Updates report analysis to look at the new error types. 
Update report analysis to work regardless of OS 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211301185095051