### PR TITLE
feat: RULE PROCESSOR: skip expensive class spec

### DIFF
--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -241,6 +241,57 @@ class SQLRuleProcessor:
     #         return None
     #     return f"{ct_package_type.lower()}ct"
 
+    @classmethod
+    def should_skip_class_logic(cls, dataset_metadata: SQLDatasetMetadata, rule: dict) -> bool:
+        """
+        Check if we can skip class logic because of expensive class determination and use only domain logic.
+        """
+        domains = rule.get("domains") or {}
+        classes = rule.get("classes") or {}
+
+        included_domains = domains.get("Include", [])
+        excluded_domains = domains.get("Exclude", [])
+        included_classes = classes.get("Include", [])
+        excluded_classes = classes.get("Exclude", [])
+
+        total_classes = len(included_classes) + len(excluded_classes)
+        if total_classes != 1:
+            return False
+
+        explicit_domains = []
+        for domain_list in [included_domains, excluded_domains]:
+            explicit_domains.extend(
+                [d for d in domain_list if d != ALL_KEYWORD and not d.endswith("--") and not d.startswith("--")]
+            )
+
+        if len(explicit_domains) != 1:
+            return False
+
+        single_class = (included_classes + excluded_classes)[0]
+        single_domain = explicit_domains[0]
+
+        if single_class == ALL_KEYWORD:
+            return False
+
+        variables = dataset_metadata.variables if hasattr(dataset_metadata, "variables") else []
+        domain_class = cls.get_dataset_class_from_variables(variables, single_domain)
+
+        if domain_class == single_class:
+            logger.debug(
+                f"Optimization: Skipping class logic for rule. "
+                f"Domain {single_domain} belongs to class {single_class}"
+            )
+            return True
+
+        if domain_class == FINDINGS_ABOUT and single_class == FINDINGS:  # FINDINGS_ABOUT is considered part of FINDINGS
+            logger.debug(
+                f"Optimization: Skipping class logic for rule. "
+                f"Domain {single_domain} (FINDINGS_ABOUT) belongs to class {single_class} (FINDINGS)"
+            )
+            return True
+
+        return False
+
     def perform_rule_operations(
         self,
         rule: dict,
@@ -385,6 +436,19 @@ class SQLRuleProcessor:
         """Check if rule is suitable and return reason if not"""
         rule_id = rule.get("core_id", "unknown")
         dataset_name = dataset_metadata.dataset_name
+
+        if self.should_skip_class_logic(dataset_metadata, rule):
+            logger.debug(f"Using domain-only validation for rule {rule_id}, dataset {dataset_name}")
+
+            if not self.rule_applies_to_domain(dataset_metadata, rule):
+                reason = f"Rule skipped - doesn't apply to domain for rule id={rule_id}, dataset={dataset_name}"
+                logger.info(f"is_suitable_for_validation. {reason}, result=False")
+                return False, reason
+
+            logger.info(
+                f"is_suitable_for_validation. rule id={rule_id}, dataset={dataset_name}, result=True (domain-only)"
+            )
+            return True, ""
 
         if not self.rule_applies_to_class(dataset_metadata, rule):
             reason = f"Rule skipped - doesn't apply to class for " f"rule id={rule_id}, dataset={dataset_name}"

--- a/tests/resources/rules/regression_analysis_report.md
+++ b/tests/resources/rules/regression_analysis_report.md
@@ -4,14 +4,14 @@
 
 ## Rule Error Summary (out of 762 total rules)
 
-- **Rules with any errors**: 61 (8.0%)
-- **Clean rules**: 701 (92.0%)
+- **Rules with any errors**: 62 (8.1%)
+- **Clean rules**: 700 (91.9%)
 
 **Error Breakdown by Category:**
 
 - Rules with **operator errors**: 29
 - Rules with **operation errors**: 17
-- Rules with **other errors**: 15
+- Rules with **other errors**: 16
 
 ## Missing Operators (9 operators, 94 total failures across 29 rule occurrences)
 
@@ -39,7 +39,7 @@
 10. **get_parent_model_column_order**: 4 failures across 1 rules
 11. **valid_codelist_dates**: 2 failures across 1 rules
 
-## Execution Errors by Type (18 unique error types, 227 total failures across 61 rule occurrences)
+## Execution Errors by Type (19 unique error types, 228 total failures across 62 rule occurrences)
 
 1.  **An unknown exception has occurred**: 96 failures across 21 rules
 2.  **SQL error in not_matches_regex operator**: 32 failures across 13 rules
@@ -90,7 +90,7 @@ _Indicates SQL engine not respecting rule applicability_
 - [5] Rule skipped - doesn't apply to class for rule id=CORE-00014...
 - [5] Rule skipped - doesn't apply to class for rule id=CORE-00056...
 
-### SQL Errors where Old Engine Succeeded (55 cases)
+### SQL Errors where Old Engine Succeeded (56 cases)
 
 _Indicates actual regressions in SQL implementation_
 
@@ -102,4 +102,5 @@ _Indicates actual regressions in SQL implementation_
 - [2] invalid input syntax
 - [2] prefix_equal_to check_operator not implemented
 - [2] Joins with relationship domains are not supported yet
+- [1] No valid columns found for uniqueness check.
 - [1] 'NoneType' object has no attribute 'get_column_hash'

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -15517,7 +15517,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000036, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000036, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -15593,7 +15593,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000036, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000036, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -15839,7 +15839,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000039, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000039, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -15900,7 +15900,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000039, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000039, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -15976,7 +15976,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000039, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000039, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -16075,7 +16075,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000040, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000040, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -16151,7 +16151,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000040, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000040, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -17297,7 +17297,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000047, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000047, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -17361,7 +17361,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000047, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000047, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -27877,7 +27877,7 @@
                                 "dataset": "dd.xpt",
                                 "domain": "DD",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000108, dataset=dd",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000108, dataset=dd",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -27941,7 +27941,7 @@
                                 "dataset": "dd.xpt",
                                 "domain": "DD",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000108, dataset=dd",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000108, dataset=dd",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -52268,7 +52268,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000208, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000208, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -52344,7 +52344,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000208, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000208, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -52450,7 +52450,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000209, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000209, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -52526,7 +52526,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000209, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000209, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -52632,7 +52632,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000210, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000210, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -52708,7 +52708,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000210, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000210, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -53783,7 +53783,7 @@
                                 "dataset": "tm.xpt",
                                 "domain": "TM",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000216, dataset=tm",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000216, dataset=tm",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -53859,7 +53859,7 @@
                                 "dataset": "tm.xpt",
                                 "domain": "TM",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000216, dataset=tm",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000216, dataset=tm",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -55874,7 +55874,7 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000228, dataset=ti",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000228, dataset=ti",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -55955,7 +55955,7 @@
                                 "dataset": "ti.xpt",
                                 "domain": "TI",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000228, dataset=ti",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000228, dataset=ti",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -57266,7 +57266,7 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000238, dataset=ex",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000238, dataset=ex",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -57348,7 +57348,7 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000238, dataset=ex",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000238, dataset=ex",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -57414,7 +57414,7 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000238, dataset=ex",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000238, dataset=ex",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -57496,7 +57496,7 @@
                                 "dataset": "ex.xpt",
                                 "domain": "EX",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000239, dataset=ex",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000239, dataset=ex",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -63163,7 +63163,7 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000252, dataset=ds",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000252, dataset=ds",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -63237,7 +63237,7 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000252, dataset=ds",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000252, dataset=ds",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -63253,7 +63253,7 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000252, dataset=ae",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000252, dataset=ae",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -63348,7 +63348,7 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000253, dataset=ae",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000253, dataset=ae",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -63412,7 +63412,7 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000253, dataset=ae",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000253, dataset=ae",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -63499,7 +63499,7 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000254, dataset=ae",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000254, dataset=ae",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -63563,7 +63563,7 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000254, dataset=ae",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000254, dataset=ae",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -82981,7 +82981,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000333, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000333, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -83061,7 +83061,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000333, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000333, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -83125,7 +83125,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000333, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000333, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -83186,7 +83186,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000333, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000333, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -86744,7 +86744,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000367, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000367, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -114309,7 +114309,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000791, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000791, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -114317,7 +114317,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000791, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000791, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -114389,7 +114389,7 @@
                                 "dataset": "ta.xpt",
                                 "domain": "TA",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000791, dataset=ta",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000791, dataset=ta",
                                 "number_errors": 0,
                                 "errors": []
                             },
@@ -114397,7 +114397,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000791, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000791, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -114747,7 +114747,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000842, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000842, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -114827,7 +114827,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000842, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000842, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -114891,7 +114891,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000842, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000842, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }
@@ -114952,7 +114952,7 @@
                                 "dataset": "tv.xpt",
                                 "domain": "TV",
                                 "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to class for rule id=CORE-000842, dataset=tv",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000842, dataset=tv",
                                 "number_errors": 0,
                                 "errors": []
                             }


### PR DESCRIPTION
This PR is to check if we can avoid running and determining class skipping logic because of expensive class determination and use only domain skipping logic instead.

Example:
{""Classes"":{""Include"":[""SPECIAL PURPOSE""]},""Domains"":{""Include"":[""DM""]}}"

We don't need to process the skip on class because the only domain within it is DM. So we only really need to process the skip on DM.

This doesn't change regression much at all, just renaming a few class skipping errors that should have been domain skipping errors to begin with.