### PR TITLE
fix: `include_split_datasets` in domain skipping

### DIFF
--- a/cdisc_rules_engine/data_service/postgresql_data_service.py
+++ b/cdisc_rules_engine/data_service/postgresql_data_service.py
@@ -43,6 +43,7 @@ class SQLDatasetMetadata:
     is_supp: bool
     rdomain: str
     variables: list[str]
+    is_split: bool = False
 
 
 class PostgresQLDataService:
@@ -143,6 +144,7 @@ class PostgresQLDataService:
             is_supp=tmp.is_supp,
             rdomain=tmp.rdomain,
             variables=[],
+            is_split=tmp.is_split,
         )
 
     def get_dataset_for_rule(self, dataset_metadata: SQLDatasetMetadata, rule: dict) -> str:

--- a/tests/resources/rules/regression_analysis_report.md
+++ b/tests/resources/rules/regression_analysis_report.md
@@ -13,9 +13,9 @@
 - Rules with **operation errors**: 14
 - Rules with **other errors**: 21
 
-## Missing Operators (3 operators, 14 total failures across 3 rule occurrences)
+## Missing Operators (3 operators, 13 total failures across 3 rule occurrences)
 
-1.  **not_prefix_matches_regex**: 9 failures across 1 rules
+1.  **not_prefix_matches_regex**: 8 failures across 1 rules
 2.  **suffix_matches_regex**: 3 failures across 1 rules
 3.  **empty_within_except_last_row**: 2 failures across 1 rules
 
@@ -32,7 +32,7 @@
 9.  **valid_codelist_dates**: 2 failures across 1 rules
 10. **domain_is_custom**: 1 failures across 1 rules
 
-## Execution Errors by Type (15 unique error types, 159 total failures across 39 rule occurrences)
+## Execution Errors by Type (15 unique error types, 158 total failures across 39 rule occurrences)
 
 1.  **An unknown exception has occurred**: 80 failures across 19 rules
 2.  **SQL error in not_equal_to operator**: 18 failures across 3 rules
@@ -41,7 +41,7 @@
 5.  **SQL error in does_not_contain operator**: 4 failures across 2 rules
 6.  **SQL error in less_than_or_equal_to operator**: 4 failures across 2 rules
 7.  **Rule format error**: 15 failures across 1 rules
-8.  **SQL error in not_prefix_matches_regex operator**: 9 failures across 1 rules
+8.  **SQL error in not_prefix_matches_regex operator**: 8 failures across 1 rules
 9.  **SQL error in suffix_matches_regex operator**: 3 failures across 1 rules
 10. **SQL error in empty_within_except_last_row operator**: 2 failures across 1 rules
 11. **SQL error in sqldaydatavalidatoroperation operation**: 2 failures across 1 rules

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -78209,11 +78209,20 @@
                         "results_sql": [
                             {
                                 "dataset": "sqapfamh.xpt",
-                                "domain": "APFAMH",
-                                "execution_status": "skipped",
-                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000293, dataset=SQAPFAMH",
-                                "number_errors": 0,
-                                "errors": []
+                                "domain": "SUPPAPFAMH",
+                                "execution_status": "success",
+                                "execution_message": "Length of dataset name of SUPP dataset is greater than 8.",
+                                "number_errors": 1,
+                                "errors": [
+                                    {
+                                        "row": null,
+                                        "SEQ": null,
+                                        "USUBJID": null,
+                                        "value": {
+                                            "dataset_name": "Not in dataset"
+                                        }
+                                    }
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -78229,12 +78238,12 @@
                             }
                         ],
                         "old_vs_sql": {
-                            "dataset_mismatch": false,
-                            "execution_status_mismatch": true,
+                            "dataset_mismatch": true,
+                            "execution_status_mismatch": false,
                             "number_of_errors_mismatch": false,
                             "diff": {}
                         },
-                        "sql_overall_result": "skipped",
+                        "sql_overall_result": "success",
                         "old_overall_result": "success",
                         "validated_results_folder_exists": false,
                         "validation_file": "",
@@ -95084,19 +95093,10 @@
                             {
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
-                                "execution_status": "success",
-                                "execution_message": "Split dataset name is not 3 or 4 characters in length",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "CDISC01.100008",
-                                        "value": {
-                                            "dataset_name": "Not in dataset"
-                                        }
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000510, dataset=AE",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -95125,7 +95125,7 @@
                             "number_of_errors_mismatch": false,
                             "diff": {}
                         },
-                        "sql_overall_result": "success",
+                        "sql_overall_result": "skipped",
                         "old_overall_result": "success",
                         "validated_results_folder_exists": false,
                         "validation_file": "",
@@ -95162,28 +95162,11 @@
                             },
                             {
                                 "dataset": "relrec.xpt",
-                                "domain": "RELREC",
-                                "execution_status": "success",
-                                "execution_message": "Split dataset name is not 3 or 4 characters in length",
-                                "number_errors": 2,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": null,
-                                        "USUBJID": "CDISC01.100008",
-                                        "value": {
-                                            "dataset_name": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": null,
-                                        "USUBJID": "CDISC01.100008",
-                                        "value": {
-                                            "dataset_name": "Not in dataset"
-                                        }
-                                    }
-                                ]
+                                "domain": "",
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000510, dataset=RELREC",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -95212,7 +95195,7 @@
                             "number_of_errors_mismatch": false,
                             "diff": {}
                         },
-                        "sql_overall_result": "success",
+                        "sql_overall_result": "skipped",
                         "old_overall_result": "success",
                         "validated_results_folder_exists": false,
                         "validation_file": "",
@@ -97924,15 +97907,10 @@
                             {
                                 "dataset": "apmh.xpt",
                                 "domain": "APMHE",
-                                "execution_status": "execution_error",
-                                "execution_message": "SQL operator execution error",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "error": "SQL error in not_prefix_matches_regex operator",
-                                        "message": "not_prefix_matches_regex check_operator not implemented"
-                                    }
-                                ]
+                                "execution_status": "skipped",
+                                "execution_message": "Rule skipped - doesn't apply to domain for rule id=CORE-000539, dataset=APMH",
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",


### PR DESCRIPTION
Adds handling of the `include_split_datasets` flag in domain skipping. Basically just made it do the same logic as the old engine, which looks good