### PR TITLE
fix: Empty CO return True when column not present

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/empty_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/empty_operator.py
@@ -8,6 +8,9 @@ class EmptyOperator(BaseSqlOperator):
         column = self.replace_prefix(other_value.get("target"))
 
         def sql():
+            if self.sql_data_service.pgi.schema.get_column(self.table_id, column) is None:
+                return "TRUE"
+
             return self._is_empty_sql(column)
 
         return self._do_check_operator(f"{column}_empty", sql)

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -10091,9 +10091,50 @@
                                 "dataset": "ec.xpt",
                                 "domain": "EC",
                                 "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_message": "ECOCCUR is blank when ECPRESP is equal to \"Y\" and ECSTAT is not provided.",
+                                "number_errors": 4,
+                                "errors": [
+                                    {
+                                        "row": 1,
+                                        "SEQ": 1,
+                                        "USUBJID": "CDISC001",
+                                        "value": {
+                                            "ECOCCUR": null,
+                                            "ECPRESP": "Y",
+                                            "ECSTAT": "Not in dataset"
+                                        }
+                                    },
+                                    {
+                                        "row": 2,
+                                        "SEQ": 2,
+                                        "USUBJID": "CDISC001",
+                                        "value": {
+                                            "ECOCCUR": null,
+                                            "ECPRESP": "Y",
+                                            "ECSTAT": "Not in dataset"
+                                        }
+                                    },
+                                    {
+                                        "row": 3,
+                                        "SEQ": 3,
+                                        "USUBJID": "CDISC001",
+                                        "value": {
+                                            "ECOCCUR": null,
+                                            "ECPRESP": "Y",
+                                            "ECSTAT": "Not in dataset"
+                                        }
+                                    },
+                                    {
+                                        "row": 4,
+                                        "SEQ": 4,
+                                        "USUBJID": "CDISC001",
+                                        "value": {
+                                            "ECOCCUR": null,
+                                            "ECPRESP": "Y",
+                                            "ECSTAT": "Not in dataset"
+                                        }
+                                    }
+                                ]
                             },
                             {
                                 "dataset": "ex.xpt",
@@ -24968,21 +25009,9 @@
                                 "dataset": "ml.xpt",
                                 "domain": "ML",
                                 "execution_status": "success",
-                                "execution_message": "Missing value for MLDOSU, when MLDOSE, MLDOSTXT or MLDOSTOT is provided",
-                                "number_errors": 1,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "XYZ-001-001",
-                                        "value": {
-                                            "MLDOSE": null,
-                                            "MLDOSTOT": "Not in dataset",
-                                            "MLDOSTXT": null,
-                                            "MLDOSU": null
-                                        }
-                                    }
-                                ]
+                                "execution_message": null,
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "pr.xpt",
@@ -25063,8 +25092,8 @@
                         ],
                         "old_vs_sql": {
                             "dataset_mismatch": false,
-                            "execution_status_mismatch": false,
-                            "number_of_errors_mismatch": true,
+                            "execution_status_mismatch": true,
+                            "number_of_errors_mismatch": false,
                             "diff": {}
                         },
                         "sql_overall_result": "success",
@@ -25536,82 +25565,9 @@
                                 "dataset": "se.xpt",
                                 "domain": "SE",
                                 "execution_status": "success",
-                                "execution_message": "ETCD is not 'UNPLAN', when SEUPDES is not empty",
-                                "number_errors": 8,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "1201001",
-                                        "value": {
-                                            "ETCD": "SCRN",
-                                            "SEUPDES": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "1201001",
-                                        "value": {
-                                            "ETCD": "TRTZ",
-                                            "SEUPDES": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": 3,
-                                        "USUBJID": "1201001",
-                                        "value": {
-                                            "ETCD": "FU",
-                                            "SEUPDES": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": 1,
-                                        "USUBJID": "1201002",
-                                        "value": {
-                                            "ETCD": "SCRN",
-                                            "SEUPDES": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": 2,
-                                        "USUBJID": "1201002",
-                                        "value": {
-                                            "ETCD": "TRTZ",
-                                            "SEUPDES": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": 1,
-                                        "USUBJID": "1201003",
-                                        "value": {
-                                            "ETCD": "SCRN",
-                                            "SEUPDES": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": 2,
-                                        "USUBJID": "1201003",
-                                        "value": {
-                                            "ETCD": "TRTZ",
-                                            "SEUPDES": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": 3,
-                                        "USUBJID": "1201003",
-                                        "value": {
-                                            "ETCD": "FU",
-                                            "SEUPDES": "Not in dataset"
-                                        }
-                                    }
-                                ]
+                                "execution_message": null,
+                                "number_errors": 0,
+                                "errors": []
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -98757,48 +98713,8 @@
                                 "domain": "DS",
                                 "execution_status": "success",
                                 "execution_message": "DSSEQ is not a unique number per USUBJID per domain, nor a unique number per POOLID per domain, including when the domain is split into multiple files",
-                                "number_errors": 13,
+                                "number_errors": 2,
                                 "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 1.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 2.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": 3,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 3.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": 4,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 4.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
                                     {
                                         "row": 5,
                                         "SEQ": 5,
@@ -98817,76 +98733,6 @@
                                             "DSSEQ": 5.0,
                                             "POOLID": "Not in dataset",
                                             "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": 7,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 7.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": 1,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 1.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": 2,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 2.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": 3,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 3.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": 4,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 4.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": 5,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 5.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": 7,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 7.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
                                         }
                                     }
                                 ]
@@ -98912,18 +98758,8 @@
                                 "domain": "AE",
                                 "execution_status": "success",
                                 "execution_message": "AESEQ is not a unique number per USUBJID per domain, nor a unique number per POOLID per domain, including when the domain is split into multiple files",
-                                "number_errors": 8,
+                                "number_errors": 7,
                                 "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 1.0,
-                                            "POOLID": "0001",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
                                     {
                                         "row": 8,
                                         "SEQ": 1,
@@ -99324,9 +99160,9 @@
                             }
                         ],
                         "old_vs_sql": {
-                            "dataset_mismatch": false,
+                            "dataset_mismatch": true,
                             "execution_status_mismatch": false,
-                            "number_of_errors_mismatch": true,
+                            "number_of_errors_mismatch": false,
                             "diff": {}
                         },
                         "sql_overall_result": "success",
@@ -99355,150 +99191,9 @@
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
                                 "execution_status": "success",
-                                "execution_message": "DSSEQ is not a unique number per USUBJID per domain, nor a unique number per POOLID per domain, including when the domain is split into multiple files",
-                                "number_errors": 14,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 1.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 2.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": 3,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 3.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": 4,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 4.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": 5,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 5.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": 6,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 6.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": 7,
-                                        "USUBJID": "0001",
-                                        "value": {
-                                            "DSSEQ": 7.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0001"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": 1,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 1.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": 2,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 2.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": 3,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 3.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": 4,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 4.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": 5,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 5.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": 6,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 6.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": 7,
-                                        "USUBJID": "0002",
-                                        "value": {
-                                            "DSSEQ": 7.0,
-                                            "POOLID": "Not in dataset",
-                                            "USUBJID": "0002"
-                                        }
-                                    }
-                                ]
+                                "execution_message": null,
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "ss1.xpt",
@@ -99520,150 +99215,9 @@
                                 "dataset": "ae.xpt",
                                 "domain": "AE",
                                 "execution_status": "success",
-                                "execution_message": "AESEQ is not a unique number per USUBJID per domain, nor a unique number per POOLID per domain, including when the domain is split into multiple files",
-                                "number_errors": 14,
-                                "errors": [
-                                    {
-                                        "row": 1,
-                                        "SEQ": 1,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 1.0,
-                                            "POOLID": "0001",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 2.0,
-                                            "POOLID": "0001",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 3,
-                                        "SEQ": 3,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 3.0,
-                                            "POOLID": "0001",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": 4,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 4.0,
-                                            "POOLID": "0001",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 5,
-                                        "SEQ": 5,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 5.0,
-                                            "POOLID": "0001",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 6,
-                                        "SEQ": 6,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 6.0,
-                                            "POOLID": "0001",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 7,
-                                        "SEQ": 7,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 7.0,
-                                            "POOLID": "0001",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 8,
-                                        "SEQ": 1,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 1.0,
-                                            "POOLID": "0002",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 9,
-                                        "SEQ": 2,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 2.0,
-                                            "POOLID": "0002",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 10,
-                                        "SEQ": 3,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 3.0,
-                                            "POOLID": "0002",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 11,
-                                        "SEQ": 4,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 4.0,
-                                            "POOLID": "0002",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 12,
-                                        "SEQ": 5,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 5.0,
-                                            "POOLID": "0002",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 13,
-                                        "SEQ": 6,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 6.0,
-                                            "POOLID": "0002",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    },
-                                    {
-                                        "row": 14,
-                                        "SEQ": 7,
-                                        "USUBJID": "None",
-                                        "value": {
-                                            "AESEQ": 7.0,
-                                            "POOLID": "0002",
-                                            "USUBJID": "Not in dataset"
-                                        }
-                                    }
-                                ]
+                                "execution_message": null,
+                                "number_errors": 0,
+                                "errors": []
                             },
                             {
                                 "dataset": "lbae.xpt",
@@ -99720,8 +99274,8 @@
                         ],
                         "old_vs_sql": {
                             "dataset_mismatch": false,
-                            "execution_status_mismatch": false,
-                            "number_of_errors_mismatch": true,
+                            "execution_status_mismatch": true,
+                            "number_of_errors_mismatch": false,
                             "diff": {}
                         },
                         "sql_overall_result": "success",

--- a/tests/unit/test_check_operators/test_sql_string_comparison.py
+++ b/tests/unit/test_check_operators/test_sql_string_comparison.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .helpers import create_sql_operators, assert_series_equals
+from .helpers import assert_series_equals, create_sql_operators
 
 
 @pytest.mark.parametrize(
@@ -8,6 +8,7 @@ from .helpers import create_sql_operators, assert_series_equals
     [
         ({"target": ["Att", "", None]}, [False, True, True]),
         ({"target": [1, 2, None]}, [False, False, True]),
+        ({"other": [1, 2, None]}, [True, True, True]),
     ],
 )
 def test_empty(data, expected_result):


### PR DESCRIPTION
Makes the `is_empty` check operator return True when the column isn't present, which seems to be a better model for rules which work on optional variables.

I've checked the changes in regression and they all match the highlighted cells from the data, so work as the author expected