### PR TITLE
fix: Library metadata

### DIFF
--- a/cdisc_rules_engine/sql_operations/sql_base_operation.py
+++ b/cdisc_rules_engine/sql_operations/sql_base_operation.py
@@ -21,6 +21,7 @@ from cdisc_rules_engine.exceptions.custom_exceptions import (
 )
 from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
 from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
+from cdisc_rules_engine.models.library_metadata_container import LibraryMetadataContainer
 from cdisc_rules_engine.services import logger
 
 
@@ -34,9 +35,15 @@ class SqlOperationError(Exception):
 
 
 class SqlBaseOperation:
-    def __init__(self, params: SqlOperationParams, data_service: PostgresQLDataService):
+    def __init__(
+        self, params: SqlOperationParams, data_service: PostgresQLDataService, library_metadata=LibraryMetadataContainer
+    ):
+        """
+        Initialize the SQL base operation.
+        """
         self.params = params
         self.data_service = data_service
+        self.library_metadata = library_metadata
 
     @abstractmethod
     def _execute_operation(self):

--- a/cdisc_rules_engine/sql_operations/sql_operations_factory.py
+++ b/cdisc_rules_engine/sql_operations/sql_operations_factory.py
@@ -12,6 +12,7 @@ from cdisc_rules_engine.sql_operations.numeric_operation import (
 from cdisc_rules_engine.sql_operations.date_operation import SqlDateOperation
 from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
 from cdisc_rules_engine.sql_operations.variable_exists import SqlVariableExistsOperation
+from cdisc_rules_engine.models.library_metadata_container import LibraryMetadataContainer
 
 
 class SqlOperationsFactory:
@@ -70,12 +71,19 @@ class SqlOperationsFactory:
         name: str,
         params: SqlOperationParams,
         data_service: PostgresQLDataService,
+        library_metadata=LibraryMetadataContainer,
     ) -> SqlBaseOperation:
         if name in cls._operations_map:
             operation = cls._operations_map.get(name)
             if operation is None:
                 raise NotImplementedError(f"Operation {name} is not implemented")
-            return operation(params, data_service)
+
+            # Check if operation is a lambda function (doesn't need library_metadata)
+            # TODO - improve this check if needed
+            if callable(operation) and hasattr(operation, "__name__") and operation.__name__ == "<lambda>":
+                return operation(params, data_service)
+            else:
+                return operation(params, data_service, library_metadata=library_metadata)
 
         raise ValueError(
             f"Operation name must be in  {list(cls._operations_map.keys())}, " f"given operation name is {name}"

--- a/cdisc_rules_engine/sql_rules_engine.py
+++ b/cdisc_rules_engine/sql_rules_engine.py
@@ -8,6 +8,7 @@ from business_rules.engine import run
 from psycopg2.errors import ProgrammingError
 
 from cdisc_rules_engine.check_operators.sql.base_sql_operator import SqlOperatorError
+from cdisc_rules_engine.models.library_metadata_container import LibraryMetadataContainer
 from cdisc_rules_engine.sql_operations.sql_base_operation import SqlOperationError
 from cdisc_rules_engine.data_service.postgresql_data_service import (
     PostgresQLDataService,
@@ -54,9 +55,10 @@ def clean_postgres_message(message: str) -> str:
 
 
 class SQLRulesEngine:
-    def __init__(self, data_service: PostgresQLDataService):
-        self.rule_processor = SQLRuleProcessor()
+    def __init__(self, data_service: PostgresQLDataService, library_metadata: LibraryMetadataContainer):
+        self.rule_processor = SQLRuleProcessor(library_metadata=library_metadata)
         self.data_service = data_service
+        self.library_metadata = library_metadata
 
     def get_schema(self):
         return export_rule_data(SqlVenmoObject, SqlVenmoResultHandler)

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -360,7 +360,9 @@ class SQLRuleProcessor:
                 filter=operation.get("filter"),
             )
 
-            operation = SqlOperationsFactory.get_service(rule_name, params=params, data_service=data_service)
+            operation = SqlOperationsFactory.get_service(
+                rule_name, params=params, data_service=data_service, library_metadata=self.library_metadata
+            )
             query = operation.execute()
             output_variables[output_variable] = query
 

--- a/scripts/run_sql_validation.py
+++ b/scripts/run_sql_validation.py
@@ -187,5 +187,9 @@ def sql_run_validation(args: Validation_args):
 
 # TODO: fix this one first
 # this is the tests entrypoint, CLI enters above where only the args are passed in
-def sql_run_single_rule_validation(data_service: PostgresQLDataService, rule: dict) -> dict:
-    return SQLRulesEngine(data_service=data_service).sql_validate_single_rule(SQLRule.from_cdisc_metadata(rule))
+def sql_run_single_rule_validation(
+    data_service: PostgresQLDataService, rule: dict, library_metadata: LibraryMetadataContainer
+) -> dict:
+    return SQLRulesEngine(data_service=data_service, library_metadata=library_metadata).sql_validate_single_rule(
+        SQLRule.from_cdisc_metadata(rule)
+    )

--- a/tests/rule_regression/regression.py
+++ b/tests/rule_regression/regression.py
@@ -289,7 +289,8 @@ def process_test_case_dataset(
         # Execute rule in SQL engine
         ds = PostgresQLDataService.from_list_of_testdatasets(data_test_datasets, standard=ig_specs)
         regression_errors["datasets_import_sql"] = "SUCCESS"
-        sql_results = sql_run_single_rule_validation(data_service=ds, rule=rule)
+        metadata = get_metadata(ig_specs, define_xml_file_path)
+        sql_results = sql_run_single_rule_validation(data_service=ds, rule=rule, library_metadata=metadata)
         regression_errors["results_present_sql"] = True
         sql_regression = extract_results_regression(sql_results)
         regression_errors["results_sql"] = sql_regression


### PR DESCRIPTION
Passes library metadata from datasets into SQL Engine.

This was discovered while implementing `get_model_filtered_variables` operation as the operation requires variable metadata

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211520965341869