### PR TITLE
feat: OPERATION: required variables

### DIFF
--- a/cdisc_rules_engine/sql_operations/required_variables.py
+++ b/cdisc_rules_engine/sql_operations/required_variables.py
@@ -1,0 +1,26 @@
+from typing import List
+from cdisc_rules_engine.constants.permissibility import REQUIRED
+from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
+from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
+from cdisc_rules_engine.utilities import sdtm_utilities
+
+
+class SqlRequiredVariablesOperation(SqlBaseOperation):
+    def _execute_operation(self):
+        variables_metadata: List[dict] = sdtm_utilities.get_variables_metadata_from_standard(
+            self.params.domain, self.library_metadata
+        )
+
+        required_vars = []
+        for var in variables_metadata:
+            if self._get_allowed_variable_permissibility(var) == REQUIRED:
+                var_name = var["name"].replace("--", self.params.domain)
+                required_vars.append(var_name)
+
+        if not required_vars:
+            return SqlOperationResult(query="SELECT NULL AS value WHERE FALSE", type="collection", subtype="Char")
+
+        table_values_clause = ", ".join([f"('{name}')" for name in required_vars])
+        query = f"SELECT column1 AS value FROM (VALUES {table_values_clause})"
+
+        return SqlOperationResult(query=query, type="collection", subtype="Char")

--- a/cdisc_rules_engine/sql_operations/sql_base_operation.py
+++ b/cdisc_rules_engine/sql_operations/sql_base_operation.py
@@ -1,5 +1,11 @@
 from abc import abstractmethod
 
+from cdisc_rules_engine.constants.permissibility import (
+    REQUIRED,
+    PERMISSIBILITY_KEY,
+    REQUIRED_MODEL_VARIABLES,
+    SEQ_VARIABLE,
+)
 from cdisc_rules_engine.data_service.postgresql_data_service import (
     PostgresQLDataService,
 )
@@ -104,6 +110,19 @@ class SqlBaseOperation:
                 raise ValueError(f"Unsupported filter value type: {type(value)} for column {column}")
 
         return "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
+
+    def _get_allowed_variable_permissibility(self, variable_metadata):
+        variable_name = variable_metadata.get("name")
+        if PERMISSIBILITY_KEY in variable_metadata:
+            return variable_metadata[PERMISSIBILITY_KEY]
+        elif variable_name in REQUIRED_MODEL_VARIABLES:
+            return REQUIRED
+        elif variable_name.replace("--", self.params.domain) == SEQ_VARIABLE.replace("--", self.params.domain):
+            return REQUIRED
+
+        from cdisc_rules_engine.constants.permissibility import PERMISSIBLE
+
+        return PERMISSIBLE
 
     @staticmethod
     def _replace_variable_wildcards(variables_metadata, domain):

--- a/cdisc_rules_engine/sql_operations/sql_operations_factory.py
+++ b/cdisc_rules_engine/sql_operations/sql_operations_factory.py
@@ -13,6 +13,7 @@ from cdisc_rules_engine.sql_operations.date_operation import SqlDateOperation
 from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
 from cdisc_rules_engine.sql_operations.variable_exists import SqlVariableExistsOperation
 from cdisc_rules_engine.sql_operations.dataset_column_order import SqlDatasetColumnOrderOperation
+from cdisc_rules_engine.sql_operations.required_variables import SqlRequiredVariablesOperation
 from cdisc_rules_engine.models.library_metadata_container import LibraryMetadataContainer
 
 
@@ -51,7 +52,7 @@ class SqlOperationsFactory:
         "variable_is_null": None,
         "domain_is_custom": None,
         "domain_label": SqlDomainLabelOperation,
-        "required_variables": None,
+        "required_variables": SqlRequiredVariablesOperation,
         "expected_variables": None,
         "permissible_variables": None,
         "study_domains": None,

--- a/tests/unit/test_operations/sql/test_sql_required_variables.py
+++ b/tests/unit/test_operations/sql/test_sql_required_variables.py
@@ -1,0 +1,96 @@
+from cdisc_rules_engine.data_service.postgresql_data_service import (
+    PostgresQLDataService,
+)
+from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
+from cdisc_rules_engine.models.library_metadata_container import LibraryMetadataContainer
+from cdisc_rules_engine.sql_operations.sql_operations_factory import (
+    SqlOperationsFactory,
+)
+from .helpers import (
+    assert_operation_collection,
+)
+
+
+def get_mock_library_metadata():
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "domains": {"AE"},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1, "core": "Req"},
+                            {"name": "AENEW", "ordinal": 2, "core": "Exp"},
+                            {"name": "AEPERM", "ordinal": 3, "core": "Perm"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    model_metadata = {
+        "datasets": [{"name": "AE"}],
+        "classes": [
+            {
+                "name": "Events",
+                "classVariables": [
+                    {"name": "--SEQ", "ordinal": 1, "core": "Req"},
+                    {"name": "--TERM", "ordinal": 2},
+                ],
+            }
+        ],
+    }
+
+    return LibraryMetadataContainer(standard_metadata=standard_metadata, model_metadata=model_metadata)
+
+
+def test_sql_required_variables():
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service,
+        table_name="ae",
+        column_data={"STUDYID": ["TEST1"], "AETERM": ["Headache"]},
+    )
+
+    library_metadata = get_mock_library_metadata()
+    params = SqlOperationParams(domain="ae", target=None, standard="sdtmig", standard_version="3-4")
+
+    operation = SqlOperationsFactory.get_service(
+        "required_variables", params, data_service, library_metadata=library_metadata
+    )
+    result = operation.execute()
+
+    expected_vars = ["STUDYID", "DOMAIN", "USUBJID", "AESEQ", "AETEST"]
+    assert_operation_collection(operation, result, expected_vars, unsorted=True)
+
+
+def test_sql_required_variables_empty_result():
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service,
+        table_name="custom",
+        column_data={"VAR1": ["TEST1"]},
+    )
+
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "domains": {},
+        "classes": [],
+    }
+    model_metadata = {"datasets": [], "classes": []}
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata, model_metadata=model_metadata)
+
+    params = SqlOperationParams(domain="custom", target=None, standard="sdtmig", standard_version="3-4")
+
+    operation = SqlOperationsFactory.get_service(
+        "required_variables", params, data_service, library_metadata=library_metadata
+    )
+    result = operation.execute()
+
+    expected_vars = ["STUDYID", "DOMAIN", "USUBJID"]
+    assert_operation_collection(operation, result, expected_vars, unsorted=True)


### PR DESCRIPTION
Closes #164 

One of the three variable permissibility operations. PRs for expected variables and permissible variables are to be expected after this.

Required variables are variables that must always be included in the dataset.
Examples: STUDYID, USUBJID, DOMAIN, --SEQ (like AESEQ for Adverse Events)
If missing, it's a critical error and the dataset is non-compliant.

(((regression not ran yet)))