### PR TITLE
feat: OPERATION: expected variables

### DIFF
--- a/cdisc_rules_engine/sql_operations/expected_variables.py
+++ b/cdisc_rules_engine/sql_operations/expected_variables.py
@@ -1,0 +1,26 @@
+from typing import List
+from cdisc_rules_engine.constants.permissibility import EXPECTED
+from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
+from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
+from cdisc_rules_engine.utilities import sdtm_utilities
+
+
+class SqlExpectedVariablesOperation(SqlBaseOperation):
+    def _execute_operation(self):
+        variables_metadata: List[dict] = sdtm_utilities.get_variables_metadata_from_standard(
+            self.params.domain, self.library_metadata
+        )
+
+        expected_vars = []
+        for var in variables_metadata:
+            if self._get_allowed_variable_permissibility(var) == EXPECTED:
+                var_name = var["name"].replace("--", self.params.domain)
+                expected_vars.append(var_name)
+
+        if not expected_vars:
+            return SqlOperationResult(query="SELECT NULL AS value WHERE FALSE", type="collection", subtype="Char")
+
+        table_values_clause = ", ".join([f"('{name}')" for name in expected_vars])
+        query = f"SELECT column1 AS value FROM (VALUES {table_values_clause})"
+
+        return SqlOperationResult(query=query, type="collection", subtype="Char")

--- a/cdisc_rules_engine/sql_operations/sql_operations_factory.py
+++ b/cdisc_rules_engine/sql_operations/sql_operations_factory.py
@@ -13,6 +13,7 @@ from cdisc_rules_engine.sql_operations.date_operation import SqlDateOperation
 from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
 from cdisc_rules_engine.sql_operations.variable_exists import SqlVariableExistsOperation
 from cdisc_rules_engine.sql_operations.dataset_column_order import SqlDatasetColumnOrderOperation
+from cdisc_rules_engine.sql_operations.expected_variables import SqlExpectedVariablesOperation
 from cdisc_rules_engine.models.library_metadata_container import LibraryMetadataContainer
 
 
@@ -52,7 +53,7 @@ class SqlOperationsFactory:
         "domain_is_custom": None,
         "domain_label": SqlDomainLabelOperation,
         "required_variables": None,
-        "expected_variables": None,
+        "expected_variables": SqlExpectedVariablesOperation,
         "permissible_variables": None,
         "study_domains": None,
         "valid_codelist_dates": None,

--- a/tests/unit/test_operations/sql/test_sql_expected_variables.py
+++ b/tests/unit/test_operations/sql/test_sql_expected_variables.py
@@ -1,0 +1,107 @@
+from cdisc_rules_engine.data_service.postgresql_data_service import (
+    PostgresQLDataService,
+)
+from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
+from cdisc_rules_engine.models.library_metadata_container import LibraryMetadataContainer
+from cdisc_rules_engine.sql_operations.sql_operations_factory import (
+    SqlOperationsFactory,
+)
+from .helpers import (
+    assert_operation_collection,
+)
+
+
+def get_mock_library_metadata():
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "domains": {"AE"},
+        "classes": [
+            {
+                "name": "Events",
+                "datasets": [
+                    {
+                        "name": "AE",
+                        "label": "Adverse Events",
+                        "datasetVariables": [
+                            {"name": "AETEST", "ordinal": 1, "core": "Req"},
+                            {"name": "AENEW", "ordinal": 2, "core": "Exp"},
+                            {"name": "AEPERM", "ordinal": 3, "core": "Perm"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    model_metadata = {
+        "datasets": [{"name": "AE"}],
+        "classes": [
+            {
+                "name": "Events",
+                "classVariables": [
+                    {"name": "--SEQ", "ordinal": 1, "core": "Req"},
+                    {"name": "--TERM", "ordinal": 2},
+                ],
+            }
+        ],
+    }
+
+    return LibraryMetadataContainer(standard_metadata=standard_metadata, model_metadata=model_metadata)
+
+
+def test_sql_expected_variables():
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service,
+        table_name="ae",
+        column_data={"STUDYID": ["TEST1"], "AETERM": ["Headache"]},
+    )
+
+    library_metadata = get_mock_library_metadata()
+    params = SqlOperationParams(domain="ae", target=None, standard="sdtmig", standard_version="3-4")
+
+    operation = SqlOperationsFactory.get_service(
+        "expected_variables", params, data_service, library_metadata=library_metadata
+    )
+    result = operation.execute()
+
+    expected_vars = ["AENEW"]
+    assert_operation_collection(operation, result, expected_vars, unsorted=True)
+
+
+def test_sql_expected_variables_no_expected():
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service,
+        table_name="dm",
+        column_data={"STUDYID": ["TEST1"]},
+    )
+
+    standard_metadata = {
+        "_links": {"model": {"href": "/mdr/sdtm/1-5"}},
+        "domains": {"DM"},
+        "classes": [
+            {
+                "name": "Special Purpose",
+                "datasets": [
+                    {
+                        "name": "DM",
+                        "datasetVariables": [
+                            {"name": "RFSTDTC", "ordinal": 1, "core": "Req"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    model_metadata = {"datasets": [], "classes": []}
+    library_metadata = LibraryMetadataContainer(standard_metadata=standard_metadata, model_metadata=model_metadata)
+
+    params = SqlOperationParams(domain="dm", target=None, standard="sdtmig", standard_version="3-4")
+
+    operation = SqlOperationsFactory.get_service(
+        "expected_variables", params, data_service, library_metadata=library_metadata
+    )
+    result = operation.execute()
+
+    assert result.query == "SELECT NULL AS value WHERE FALSE"


### PR DESCRIPTION
Closes #143 

One of the three variable permissibility operations. PRs for permissible variables are to be expected after this.

Expected variables are expected to be present when that type of data is collected.
If the data was collected but the variable is missing, it's an error.

(((logic and tests are here but regression not ran yet)))

!!!!!! This PR has been postponed as there are higher priority tasks, namely rule types. Will be resumed when the chance opens up. !!!!!!