### PR TITLE
fix: DIFFS: source_row_num col for all data tables

### DIFF
--- a/cdisc_rules_engine/data_service/merges/join.py
+++ b/cdisc_rules_engine/data_service/merges/join.py
@@ -77,7 +77,7 @@ class SqlJoinMerge:
                     {', '.join(selected_right_columns)}
                 FROM {left.hash} l
                 {type} JOIN {right.hash} r ON {join_condition}
-                ORDER BY l.id
+                ORDER BY l.source_row_number, l.id
         """
 
         pgi.execute_sql(query)
@@ -100,7 +100,7 @@ class SqlJoinMerge:
         left_output_columns = []
         right_output_columns = []
 
-        # Add all of the left table's columns
+        # Add all of the left table's columns (including source_row_number)
         for name, column in left.get_columns():
             if name == "id":
                 continue

--- a/cdisc_rules_engine/data_service/sql_interface.py
+++ b/cdisc_rules_engine/data_service/sql_interface.py
@@ -160,19 +160,21 @@ class PostgresQLInterface:
         self, table_name: str, data: Union[Dict[str, list[str, int, float]], List[Dict[str, Any]]]
     ) -> Optional[int]:
         """Insert Python data into a table"""
-        if not self.db:
-            raise RuntimeError("Database not initialised. Call init_database() first.")
-
-        schema = self.schema.get_table(table_name)
-        if not schema:
-            raise ValueError(f"Table {table_name} does not exist in the schema")
-
         if isinstance(data, dict):
-            query = SQLSerialiser.insert_dict(schema, data)
-            self.execute_sql(query)
-            logger.info(f"Inserted 1 row into {table_name}")
-            return 1
+            query = SQLSerialiser.insert_dict(table_name, data)
+            return self.execute_sql(query)
         else:
+            if not self.db:
+                raise RuntimeError("Database not initialised. Call init_database() first.")
+
+            for idx, row in enumerate(data, start=1):
+                if "source_row_number" not in row:
+                    row["source_row_number"] = idx
+
+            schema = self.schema.get_table(table_name)
+            if not schema:
+                raise ValueError(f"Table {table_name} does not exist in the schema")
+
             query = SQLSerialiser.insert_many_dicts(schema, data)
             rows = self.execute_sql(query)
             logger.info(f"Inserted {rows} rows into {table_name}")

--- a/cdisc_rules_engine/models/sql/table_schema.py
+++ b/cdisc_rules_engine/models/sql/table_schema.py
@@ -17,6 +17,10 @@ class SqlTableSchema:
         id_column = SqlColumnSchema(name="id", hash="id", type="Num")
         self.add_column(id_column)
 
+        if source == "data":
+            source_row_column = SqlColumnSchema(name="source_row_number", hash="source_row_number", type="Num")
+            self.add_column(source_row_column)
+
     def add_column(self, data: SqlColumnSchema) -> None:
         self._columns[data.name.lower()] = data
 

--- a/cdisc_rules_engine/models/sql_venmo_result_handler.py
+++ b/cdisc_rules_engine/models/sql_venmo_result_handler.py
@@ -211,7 +211,11 @@ class SqlVenmoResultHandler(BaseActions):
         sequence_value = row.get(schema.get_column_hash(sequence_column))
         sequence = int(sequence_value) if sequence_value is not None and sequence_value != "" else None
 
-        row_id = row.get("id")
+        source_row_hash = schema.get_column_hash("source_row_number")
+        if source_row_hash and source_row_hash in row:
+            row_id = row.get(source_row_hash)
+        else:
+            row_id = row.get("id")
 
         values = {}
         for column in sorted(target_columns.keys()):
@@ -220,10 +224,8 @@ class SqlVenmoResultHandler(BaseActions):
                 continue
 
             if column.startswith("$"):
-                # Handle operation variables
                 value = self._evaluate_operation_variable(column, row, schema)
             else:
-                # Handle regular table columns
                 value = row.get(schema.get_column_hash(column))
 
             if value is None or value in NULL_FLAVORS:
@@ -233,7 +235,7 @@ class SqlVenmoResultHandler(BaseActions):
 
         return ValidationErrorEntity(
             dataset=self.dataset_metadata.filename,
-            row=row_id,
+            row=int(row_id),  # This now uses source_row_number
             usubjid=usubjid,
             sequence=sequence,
             value=values,


### PR DESCRIPTION
This PR is a diff fix, specifically targeted at CORE-000097, but fixes the diff problems for CORE-000253, 000254, 000597, 000726, 000744, 000747, 000757, 000766, 000767, 000784 and 000844.

The old engine uses "source_row_number" assigned during the XPT file reading which is just the physical position in the actual source xpt file (sequential numbering 1, 2, 3, 4...). But the sql engine was using our auto-generated id column BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY  which reflects the SQL insertion order, not the source file order. After join ops and data transformations, the same logical record appears at different positions.

There’s now a source_row_number column in all “data” tables, instead of just the resultant data tables from split dataset concat.
We now also populate the source_row_number column during data insertion.
Fresh updated error reporting that uses source_row_number, which falls back to id instead if unavailable.
I used the ORDER BY part of the join merge query to perserve the source_row_number columns during those operations.

(((regression not ran yet)))