### PR TITLE
operation: Get Define External Dictionary Version

### DIFF
--- a/cdisc_rules_engine/models/sql_operation_params.py
+++ b/cdisc_rules_engine/models/sql_operation_params.py
@@ -30,6 +30,7 @@ class SqlOperationParams:
     ct_conditions: dict = None
     attribute_name: str = None
     subtract: str = None
+    external_dictionary_type: str = None
 
     # standard_substandard: str = None
     # attribute_name: str = None
@@ -45,7 +46,6 @@ class SqlOperationParams:
     # dictionary_term_type: str = None
     # external_dictionaries: ExternalDictionariesContainer = None
     # external_dictionary_term_variable: str = None
-    # external_dictionary_type: str = None
     # filter: dict = None
     # grouping: List[str] = None
     # grouping_aliases: List[str] = None

--- a/cdisc_rules_engine/sql_operations/define_exdict_version_operation.py
+++ b/cdisc_rules_engine/sql_operations/define_exdict_version_operation.py
@@ -1,0 +1,20 @@
+from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
+from cdisc_rules_engine.services.define_xml.define_xml_reader_factory import DefineXMLReaderFactory
+from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
+
+
+class SqlDefineExternalDictionaryVersionOperation(SqlBaseOperation):
+
+    def _execute_operation(self):
+        external_dictionary_type = self.params.external_dictionary_type
+
+        define_xml_reader = DefineXMLReaderFactory.get_define_xml_reader(
+            self.data_service.define_xml_path, self.data_service.define_xml_path, self.data_service, None
+        )
+        version = define_xml_reader.get_external_dictionary_version(external_dictionary_type)
+        if not version:
+            raise Exception(
+                f"Version for external dictionary type {external_dictionary_type} is not found in define.xml"
+            )
+
+        return SqlOperationResult(query=f"SELECT '{version}' AS value", type="constant", subtype="Char")

--- a/cdisc_rules_engine/sql_operations/sql_operations_factory.py
+++ b/cdisc_rules_engine/sql_operations/sql_operations_factory.py
@@ -36,6 +36,9 @@ from cdisc_rules_engine.sql_operations.get_codelist_attributes import SqlGetCode
 from cdisc_rules_engine.sql_operations.get_define_variables_metadata import (
     SqlGetDefineVariablesMetadata,
 )
+from cdisc_rules_engine.sql_operations.define_exdict_version_operation import (
+    SqlDefineExternalDictionaryVersionOperation,
+)
 from cdisc_rules_engine.sql_operations.whodrug_code_hierarchy import SqlWhodrugHierarchyOperation
 from cdisc_rules_engine.sql_operations.standard_domains import SqlStandardDomainsOperation
 
@@ -85,6 +88,7 @@ class SqlOperationsFactory:
         "valid_external_dictionary_code": None,
         "valid_external_dictionary_code_term_pair": None,
         "valid_define_external_dictionary_version": None,
+        "get_define_external_dictionary_version": SqlDefineExternalDictionaryVersionOperation,
         "get_dataset_filtered_variables": None,
     }
 

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -68,6 +68,7 @@ class SQLRuleProcessor:
                 ct_conditions=operation.get("ct_conditions"),
                 attribute_name=operation.get("attribute_name"),
                 subtract=operation.get("subtract"),
+                external_dictionary_type=operation.get("external_dictionary_type"),
             )
 
             operation = SqlOperationsFactory.get_service(rule_name, params=params, data_service=data_service)

--- a/tests/unit/test_operations/sql/test_get_define_exdict_version.py
+++ b/tests/unit/test_operations/sql/test_get_define_exdict_version.py
@@ -1,0 +1,25 @@
+import pytest
+
+from cdisc_rules_engine.data_service.postgresql_data_service import PostgresQLDataService
+from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
+from cdisc_rules_engine.sql_operations.define_exdict_version_operation import (
+    SqlDefineExternalDictionaryVersionOperation,
+)
+from .helpers import assert_operation_constant
+
+define_path = "tests/resources/define.xml"
+
+
+@pytest.mark.parametrize("dictionary, version", [("meddra", "22.0"), ("snomed", "2019-09-01")])
+def test_get_define_exdict_version(sdtm_standards_context, dictionary, version):
+    data_service = PostgresQLDataService.instance(define_xml_path=define_path)
+    params = SqlOperationParams(
+        domain="AE",
+        target="FAKEVARIABLE",
+        standards_context=sdtm_standards_context,
+        external_dictionary_type=dictionary,
+    )
+    operation = SqlDefineExternalDictionaryVersionOperation(params=params, data_service=data_service)
+    result = operation.execute()
+
+    assert_operation_constant(operation, result, expected=version)


### PR DESCRIPTION
Operation to retrieve the version written in the define xml for a specified external dictionary type (e.g. meddra, loinc) via the param "external_dictionary_type".

A variation of an unimplemented CDISC operation called "valid_define_external_dictionary_version".
No unit tests as of yet.