### PR TITLE
feat: Domain Presence Check against Define XML rule type

### DIFF
--- a/cdisc_rules_engine/enums/rule_types.py
+++ b/cdisc_rules_engine/enums/rule_types.py
@@ -9,6 +9,7 @@ class RuleTypes(BaseEnum):
     DEFINE_ITEM_GROUP_METADATA_CHECK = "Define Item Group Metadata Check"
     DEFINE_ITEM_METADATA_CHECK = "Define Item Metadata Check"
     DOMAIN_PRESENCE_CHECK = "Domain Presence Check"
+    DOMAIN_PRESENCE_CHECK_AGAINST_DEFINE = "Domain Presence Check against Define XML"
     VALUE_LEVEL_METADATA_CHECK_AGAINST_DEFINE = "Value Level Metadata Check against Define XML"
     VARIABLE_METADATA_CHECK = "Variable Metadata Check"
     VARIABLE_METADATA_CHECK_AGAINST_DEFINE = "Variable Metadata Check against Define XML"

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
@@ -34,6 +34,8 @@ class DefineXMLReader20(BaseDefineXMLReader):
         """
         Returns metadata as dictionary.
         """
+        has_no_data: str | None = getattr(metadata, "HasNoData", "")
+        has_no_data = has_no_data or ""
         return {
             "define_dataset_name": metadata.Name,
             "define_dataset_label": str(metadata.Description.TranslatedText[0]),
@@ -43,6 +45,7 @@ class DefineXMLReader20(BaseDefineXMLReader):
             "define_dataset_structure": str(metadata.Structure),
             # v2.0 does not support is_non_standard. Default to blank
             "define_dataset_is_non_standard": "",
+            "define_dataset_has_no_data": bool(has_no_data.lower() == "yes"),
         }
 
     def get_extensible_codelist_mappings(self):

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_0.py
@@ -3,6 +3,7 @@ from cdisc_rules_engine.services.define_xml.base_define_xml_reader import (
     BaseDefineXMLReader,
     DefineXMLVersion,
 )
+from typing import Optional
 
 
 class DefineXMLReader20(BaseDefineXMLReader):
@@ -34,7 +35,7 @@ class DefineXMLReader20(BaseDefineXMLReader):
         """
         Returns metadata as dictionary.
         """
-        has_no_data: str | None = getattr(metadata, "HasNoData", "")
+        has_no_data: Optional[str] = getattr(metadata, "HasNoData", "")
         has_no_data = has_no_data or ""
         return {
             "define_dataset_name": metadata.Name,

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
@@ -4,7 +4,7 @@ from cdisc_rules_engine.services.define_xml.base_define_xml_reader import (
     DefineXMLVersion,
     StandardsCTMetadata,
 )
-from typing import List
+from typing import List, Optional
 from collections import Counter
 
 
@@ -37,7 +37,7 @@ class DefineXMLReader21(BaseDefineXMLReader):
         """
         Returns metadata as dictionary.
         """
-        has_no_data: str | None = getattr(metadata, "HasNoData", "")
+        has_no_data: Optional[str] = getattr(metadata, "HasNoData", "")
         has_no_data = has_no_data or ""
         return {
             "define_dataset_name": metadata.Name,

--- a/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
+++ b/cdisc_rules_engine/services/define_xml/define_xml_reader_2_1.py
@@ -37,6 +37,8 @@ class DefineXMLReader21(BaseDefineXMLReader):
         """
         Returns metadata as dictionary.
         """
+        has_no_data: str | None = getattr(metadata, "HasNoData", "")
+        has_no_data = has_no_data or ""
         return {
             "define_dataset_name": metadata.Name,
             "define_dataset_label": str(metadata.Description.TranslatedText[0]),
@@ -45,6 +47,7 @@ class DefineXMLReader21(BaseDefineXMLReader):
             "define_dataset_class": str(metadata.Class.Name),
             "define_dataset_structure": str(metadata.Structure),
             "define_dataset_is_non_standard": str(metadata.IsNonStandard or ""),
+            "define_dataset_has_no_data": bool(has_no_data.lower() == "yes"),
         }
 
     def get_ct_version(self):

--- a/cdisc_rules_engine/sql_dataset_builders/sql_base_dataset_builder.py
+++ b/cdisc_rules_engine/sql_dataset_builders/sql_base_dataset_builder.py
@@ -47,6 +47,7 @@ DEFINE_DATASETS_TYPE = {
     "define_dataset_class": "Char",
     "define_dataset_structure": "Char",
     "define_dataset_is_non_standard": "Char",
+    "define_dataset_has_no_data": "Bool",
     "define_dataset_variables": "Char",
     "define_dataset_key_sequence": "Char",
     "define_dataset_variable_order": "Char",
@@ -161,6 +162,12 @@ class SqlBaseDatasetBuilder(ABC):
                 continue
 
         return define_ds_metadata
+
+    def get_define_metadata(self):
+        define_xml_reader = DefineXMLReaderFactory.get_define_xml_reader(
+            self.data_service.define_xml_path, self.data_service.define_xml_path, self.data_service, None
+        )
+        return define_xml_reader.read()
 
     def get_define_vlms(self) -> List[dict]:
         define_reader = DefineXMLReaderFactory.get_define_xml_reader(

--- a/cdisc_rules_engine/sql_dataset_builders/sql_dataset_builder_factory.py
+++ b/cdisc_rules_engine/sql_dataset_builders/sql_dataset_builder_factory.py
@@ -54,6 +54,9 @@ from cdisc_rules_engine.sql_dataset_builders.sql_define_item_group_dataset_build
 from cdisc_rules_engine.sql_dataset_builders.sql_define_item_metadata_check_against_library_dataset_builder import (
     SqlDefineItemMetadataCheckAgainstLibraryDatasetBuilder,
 )
+from cdisc_rules_engine.sql_dataset_builders.sql_domain_check_against_define_dataset_builder import (
+    SqlDomainCheckAgainstDefineDatasetBuilder,
+)
 
 
 class SqlDatasetBuilderFactory:
@@ -78,6 +81,7 @@ class SqlDatasetBuilderFactory:
         RuleTypes.DEFINE_ITEM_METADATA_CHECK.value: SqlDefineVariablesDatasetBuilder,
         RuleTypes.DEFINE_ITEM_GROUP_METADATA_CHECK.value: SqlDefineItemGroupDatasetBuilder,
         RuleTypes.DEFINE_ITEM_METADATA_CHECK_AGAINST_LIBRARY.value: SqlDefineItemMetadataCheckAgainstLibraryDatasetBuilder,  # noqa: E501
+        RuleTypes.DOMAIN_PRESENCE_CHECK_AGAINST_DEFINE.value: SqlDomainCheckAgainstDefineDatasetBuilder,
     }
 
     @classmethod

--- a/cdisc_rules_engine/sql_dataset_builders/sql_domain_check_against_define_dataset_builder.py
+++ b/cdisc_rules_engine/sql_dataset_builders/sql_domain_check_against_define_dataset_builder.py
@@ -19,9 +19,10 @@ class SqlDomainCheckAgainstDefineDatasetBuilder(SqlBaseDatasetBuilder):
         rows = []
 
         for define_metadata in define_ds_metadata:
+            define_dataset_name = define_metadata.get("define_dataset_name")
             row = {
-                "domain": define_metadata["define_dataset_name"],
-                "filename": domain_files.get(define_metadata["define_dataset_name"], None),
+                "domain": define_dataset_name,
+                "filename": domain_files.get(define_dataset_name, None),
             }
             define_metadata_dict = {k: define_metadata.get(k) for k in DEFINE_DATASETS_TYPE.keys()}
             row.update(define_metadata_dict)

--- a/cdisc_rules_engine/sql_dataset_builders/sql_domain_check_against_define_dataset_builder.py
+++ b/cdisc_rules_engine/sql_dataset_builders/sql_domain_check_against_define_dataset_builder.py
@@ -1,0 +1,40 @@
+from cdisc_rules_engine.models.sql.column_schema import SqlColumnSchema
+from cdisc_rules_engine.models.sql.table_schema import SqlTableSchema
+from cdisc_rules_engine.sql_dataset_builders.sql_base_dataset_builder import SqlBaseDatasetBuilder, DEFINE_DATASETS_TYPE
+
+
+class SqlDomainCheckAgainstDefineDatasetBuilder(SqlBaseDatasetBuilder):
+    """
+    Creates a table merging the physical dataset metadata with Define-XML dataset metadata.
+    """
+
+    def build(self) -> str:
+        table_name = f"{self.dataset_metadata.name}_ds_metadata_with_define"
+        if self.data_service.pgi.schema.get_table(table_name) is not None:
+            return table_name
+
+        domain_files = {ds.domain: ds.filename for ds in self.datasets}
+        define_ds_metadata = self.get_define_metadata()
+
+        rows = []
+
+        for define_metadata in define_ds_metadata:
+            row = {
+                "domain": define_metadata["define_dataset_name"],
+                "filename": domain_files.get(define_metadata["define_dataset_name"], None),
+            }
+            define_metadata_dict = {k: define_metadata.get(k) for k in DEFINE_DATASETS_TYPE.keys()}
+            row.update(define_metadata_dict)
+            rows.append(row)
+
+        schema = SqlTableSchema.derived(table_name, self.data_service.pgi)
+        schema.add_column(SqlColumnSchema.generated("domain", "Char"))
+        schema.add_column(SqlColumnSchema.generated("filename", "Char"))
+        for col, type in DEFINE_DATASETS_TYPE.items():
+            schema.add_column(SqlColumnSchema.generated(col, type))
+
+        self.data_service.pgi.create_table(schema)
+        if rows:
+            self.data_service.pgi.insert_data(table_name, rows)
+
+        return table_name

--- a/tests/unit/test_define_xml_reader.py
+++ b/tests/unit/test_define_xml_reader.py
@@ -74,6 +74,7 @@ def test_read_define_xml():
                 "define_dataset_class",
                 "define_dataset_structure",
                 "define_dataset_is_non_standard",
+                "define_dataset_has_no_data",
             ]
 
 
@@ -94,6 +95,7 @@ def test_extract_domain_metadata(filename):
             "define_dataset_class": "TRIAL DESIGN",
             "define_dataset_structure": "One record per trial summary parameter value",
             "define_dataset_is_non_standard": "",
+            "define_dataset_has_no_data": False,
             "define_dataset_variables": [
                 "STUDYID",
                 "DOMAIN",


### PR DESCRIPTION
- implement Domain Presence Check against Define XML rule type
- add define_dataset_has_no_data param to define readers
- add get_define_metadata method (similar to cdisc implementation) to get all define metadata, not filtered by provided datasets
- needed for at least rules FB0401-413, probably more