### PR TITLE
feat: case insensitive functionality for external dictionary operators

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_code_reference_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_code_reference_operator.py
@@ -16,6 +16,7 @@ class ValidExDictCodeReferenceOperator(BaseSqlOperator):
 
         filter_conditions = []
         whodrug_condition = ""
+        case_insensitive = other_value.get("case_insensitive", False)
 
         if filter_attribute and filter_value:
             filter_conditions.append(f"{filter_attribute} = '{filter_value}'")
@@ -26,10 +27,16 @@ class ValidExDictCodeReferenceOperator(BaseSqlOperator):
 
             whodrug_condition = f"WHEN {self._column_sql(target_column, alias=False)} = 'MULTIPLE' THEN TRUE"
 
+        cast_expr = f"CAST({self._column_sql(target_column, alias=False)} AS TEXT)"
+        code_expr = "term_code"
+        if case_insensitive:
+            cast_expr = f"LOWER({cast_expr})"
+            code_expr = f"LOWER({code_expr})"
+
         query = f"""
             CASE
-                WHEN CAST({self._column_sql(target_column, alias=False)} AS TEXT) IN (
-                    SELECT term_code
+                WHEN {cast_expr} IN (
+                    SELECT {code_expr}
                     FROM {self.table_name}
                     {'WHERE ' + ' AND '.join(filter_conditions) if filter_conditions else ''}
                 ) THEN TRUE

--- a/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_code_term_pair_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_code_term_pair_operator.py
@@ -25,6 +25,7 @@ class ValidExDictCodeTermPairsOperator(BaseSqlOperator):
 
         filter_conditions = []
         whodrug_condition = ""
+        case_insensitive = other_value.get("case_insensitive", False)
 
         if filter_attribute and filter_value:
             filter_conditions.append(f"{filter_attribute} = '{filter_value}'")
@@ -35,13 +36,23 @@ class ValidExDictCodeTermPairsOperator(BaseSqlOperator):
 
             whodrug_condition = f"WHEN {self._column_sql(target_column, alias=False)} = 'MULTIPLE' THEN TRUE"
 
+        if case_insensitive:
+            comp_expr = f"""
+            LOWER(term_code) = LOWER(CAST({self._column_sql(code_column, alias=False)} AS TEXT))
+            AND LOWER(term_name) = LOWER(CAST({self._column_sql(term_column, alias=False)} AS TEXT))
+            """
+        else:
+            comp_expr = f"""
+            term_code = CAST({self._column_sql(code_column, alias=False)} AS TEXT)
+            AND term_name = CAST({self._column_sql(term_column, alias=False)} AS TEXT)
+            """
+
         query = f"""
             CASE
                 WHEN EXISTS (
                     SELECT 1
                     FROM {self.table_name}
-                    WHERE term_code = CAST({self._column_sql(code_column, alias=False)} AS TEXT)
-                      AND term_name = CAST({self._column_sql(term_column, alias=False)} AS TEXT)
+                    WHERE {comp_expr}
                         {'AND ' + ' AND '.join(filter_conditions) if filter_conditions else ''}
                 ) THEN TRUE
                 {whodrug_condition}

--- a/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_term_reference_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_term_reference_operator.py
@@ -17,6 +17,7 @@ class ValidExDictTermReferenceOperator(BaseSqlOperator):
 
         filter_conditions = []
         whodrug_condition = ""
+        case_insensitive = other_value.get("case_insensitive", False)
 
         if filter_attribute and filter_value:
             filter_conditions.append(f"{filter_attribute} = '{filter_value}'")
@@ -27,10 +28,16 @@ class ValidExDictTermReferenceOperator(BaseSqlOperator):
 
             whodrug_condition = f"WHEN {self._column_sql(target_column, alias=False)} = 'MULTIPLE' THEN TRUE"
 
+        cast_expr = f"CAST({self._column_sql(target_column, alias=False)} AS TEXT)"
+        term_expr = "TRIM(regexp_split_to_table(term_name, '[,;]'))"
+        if case_insensitive:
+            cast_expr = f"LOWER({cast_expr})"
+            term_expr = f"LOWER({term_expr})"
+
         query = f"""
             CASE
-                WHEN CAST({self._column_sql(target_column, alias=False)} AS TEXT) IN (
-                    SELECT TRIM(regexp_split_to_table(term_name, '[,;]'))
+                WHEN {cast_expr} IN (
+                    SELECT {term_expr}
                     FROM {self.table_name}
                     {'WHERE ' + ' AND '.join(filter_conditions) if filter_conditions else ''}
                 ) THEN TRUE

--- a/cdisc_rules_engine/enums/optional_condition_parameters.py
+++ b/cdisc_rules_engine/enums/optional_condition_parameters.py
@@ -13,3 +13,6 @@ class OptionalConditionParameters(BaseEnum):
     METADATA = "metadata"
     VALUE_IS_REFERENCE = "value_is_reference"
     TYPE_INSENSITIVE = "type_insensitive"
+    CASE_INSENSITIVE = "case_insensitive"
+    FILTER_ATTRIBUTE = "filter_attribute"
+    FILTER_VALUE = "filter_value"

--- a/cdisc_rules_engine/models/sql_operation_params.py
+++ b/cdisc_rules_engine/models/sql_operation_params.py
@@ -31,8 +31,6 @@ class SqlOperationParams:
     attribute_name: str = None
     subtract: str = None
     external_dictionary_type: str = None
-    filter_attribute: str = None
-    filter_value: str = None
 
     # standard_substandard: str = None
     # attribute_name: str = None
@@ -48,6 +46,7 @@ class SqlOperationParams:
     # dictionary_term_type: str = None
     # external_dictionaries: ExternalDictionariesContainer = None
     # external_dictionary_term_variable: str = None
+    # filter: dict = None
     # grouping: List[str] = None
     # grouping_aliases: List[str] = None
     # level: str = None


### PR DESCRIPTION
- add 'case_insensitive' optional parameter
- handle above param in ValidExDict operators to allow case insensitive comparison
- move filter parameters to operator (from operation)