### PR TITLE
fix: Adjust rule type to define-first instead of dataset-first

### DIFF
--- a/cdisc_rules_engine/sql_dataset_builders/sql_variables_metadata_with_define_and_library_dataset_builder.py
+++ b/cdisc_rules_engine/sql_dataset_builders/sql_variables_metadata_with_define_and_library_dataset_builder.py
@@ -37,7 +37,6 @@ class SqlVariablesMetadataWithDefineAndLibraryDatasetBuilder(SqlBaseDatasetBuild
 
         # adjust to define first check (ie vars in define but NOT in dataset will get included - note that therefore vars in dataset but not in define WILL NOT be included) # noqa
         for define_var, _ in define_vars_by_name.items():
-            print(1)
             define_var_name = define_var.upper() if define_var else ""
             var = next((v for v in self.dataset_metadata.variables if v.name.upper() == define_var_name), None)
             has_empty = self._has_empty_values(source_table_id, source_table_hash, var, table_is_empty)

--- a/cdisc_rules_engine/sql_dataset_builders/sql_variables_metadata_with_define_and_library_dataset_builder.py
+++ b/cdisc_rules_engine/sql_dataset_builders/sql_variables_metadata_with_define_and_library_dataset_builder.py
@@ -34,11 +34,14 @@ class SqlVariablesMetadataWithDefineAndLibraryDatasetBuilder(SqlBaseDatasetBuild
         table_is_empty = len(empty_check_data) == 0
 
         rows = []
-        for var in self.dataset_metadata.variables:
-            var_name = var.name.upper() if var else ""
-            has_empty = self._has_empty_values(source_table_id, source_table_hash, var, table_is_empty)
-            var_count = self._value_count(source_table_id, source_table_hash, var)
 
+        # adjust to define first check (ie vars in define but NOT in dataset will get included - note that therefore vars in dataset but not in define WILL NOT be included) # noqa
+        for define_var, _ in define_vars_by_name.items():
+            print(1)
+            define_var_name = define_var.upper() if define_var else ""
+            var = next((v for v in self.dataset_metadata.variables if v.name.upper() == define_var_name), None)
+            has_empty = self._has_empty_values(source_table_id, source_table_hash, var, table_is_empty)
+            var_count = self._value_count(source_table_id, source_table_hash, var) if var else 0
             row = {
                 "variable_name": var.name.upper() if var else "",
                 "variable_order_number": var.order if var else 0,
@@ -49,8 +52,27 @@ class SqlVariablesMetadataWithDefineAndLibraryDatasetBuilder(SqlBaseDatasetBuild
                 "variable_count": var_count,
                 "variable_is_empty": True if var_count == 0 else False,
             }
-            row.update(define_vars_by_name.get(var_name, {k: None for k in DEFINE_VARIABLES_TYPE}))
-            row.update(library_vars_by_name.get(var_name, {k: None for k in LIBRARY_VARIABLES_TYPE}))
+            row.update(define_vars_by_name.get(define_var_name, {k: None for k in DEFINE_VARIABLES_TYPE}))
+            row.update(library_vars_by_name.get(define_var_name, {k: None for k in LIBRARY_VARIABLES_TYPE}))
+
+            # leaving previous implementation of dataset first as a comment for now
+            # for var in self.dataset_metadata.variables:
+            #     var_name = var.name.upper() if var else ""
+            #     has_empty = self._has_empty_values(source_table_id, source_table_hash, var, table_is_empty)
+            #     var_count = self._value_count(source_table_id, source_table_hash, var)
+
+            #     row = {
+            #         "variable_name": var.name.upper() if var else "",
+            #         "variable_order_number": var.order if var else 0,
+            #         "variable_label": var.label if var else "",
+            #         "variable_size": var.length if var else 0,
+            #         "variable_data_type": var.type if var else "",
+            #         "variable_has_empty_values": str(has_empty),
+            #         "variable_count": var_count,
+            #         "variable_is_empty": True if var_count == 0 else False,
+            #     }
+            #     row.update(define_vars_by_name.get(var_name, {k: None for k in DEFINE_VARIABLES_TYPE}))
+            #     row.update(library_vars_by_name.get(var_name, {k: None for k in LIBRARY_VARIABLES_TYPE}))
 
             rows.append(row)
 


### PR DESCRIPTION
- changed Variable Metadata Check against Define XML and Library Metadata rule type to loop through define variables instead of dataset variables. Important change for the rules it has been used in so far - if there are dataset-first use cases for this rule type in the future we will need to reevaluate.