### PR TITLE
feat: add SUPP domain key variable uniqueness check in Dataset Contents Check against Define XML

### DIFF
--- a/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
+++ b/cdisc_rules_engine/services/define_xml/base_define_xml_reader.py
@@ -141,11 +141,11 @@ class BaseDefineXMLReader(ABC):
         return domain_metadata_dict
 
     @cached("define-variables-metadata")
-    def extract_variables_metadata(self, domain_name: str = None) -> List[dict]:
-        logger.info(f"Extracting variables metadata from Define-XML. domain_name={domain_name}")
+    def extract_variables_metadata(self, domain_name: str = None, name: str = None) -> List[dict]:
+        logger.info(f"Extracting variables metadata from Define-XML. name={name}, domain_name={domain_name}")
         try:
             metadata = self._odm_loader.MetaDataVersion()
-            domain_metadata = self._get_domain_metadata(metadata, domain_name)
+            domain_metadata = self._get_domain_metadata(metadata, domain_name, name)
             variables_metadata = []
             codelist_map = self._get_codelist_def_map(metadata.CodeList)
             for index, itemref in enumerate(domain_metadata.ItemRef):
@@ -224,9 +224,16 @@ class BaseDefineXMLReader(ABC):
         except StopIteration:
             raise DomainNotFoundInDefineXMLError(f"Dataset {dataset_name} is not found in Define XML")
 
-    def _get_domain_metadata(self, metadata, domain_name):
+    def _get_domain_metadata(self, metadata, domain_name: str = None, name: str = None):
         try:
-            domain_metadata = next(item for item in metadata.ItemGroupDef if item.Domain == domain_name)
+            if name and domain_name:
+                domain_metadata = next(
+                    item for item in metadata.ItemGroupDef if item.Domain == domain_name and item.Name == name
+                )
+            else:
+                domain_metadata = next(
+                    item for item in metadata.ItemGroupDef if item.Name == name or item.Domain == domain_name
+                )
             return domain_metadata
         except StopIteration:
             raise DomainNotFoundInDefineXMLError(f"Domain {domain_name} is not found in Define XML")

--- a/cdisc_rules_engine/sql_dataset_builders/sql_base_dataset_builder.py
+++ b/cdisc_rules_engine/sql_dataset_builders/sql_base_dataset_builder.py
@@ -6,7 +6,7 @@ from cdisc_rules_engine.data_service.postgresql_data_service import (
     PostgresQLDataService,
 )
 from cdisc_rules_engine.exceptions.custom_exceptions import DomainNotFoundInDefineXMLError
-from cdisc_rules_engine.services.define_xml.define_xml_reader_factory import DefineXMLReaderFactory
+from cdisc_rules_engine.services.define_xml.define_xml_reader_factory import DefineXMLReaderFactory, BaseDefineXMLReader
 from cdisc_rules_engine.standards.base_standards_context import BaseStandardsContext
 
 LIBRARY_VARIABLES_TYPE = {
@@ -130,10 +130,12 @@ class SqlBaseDatasetBuilder(ABC):
         try:
             metadata = define_reader.extract_dataset_metadata(self.dataset_metadata.domain)
             metadata = self._format_metadata_dict(metadata)
+            domain = self.standards_context.derive_rdomain(self.dataset_metadata.name)
             if "define_dataset_variable_order" not in metadata.keys():
                 metadata["define_dataset_variable_order"] = self._get_define_dataset_variable_order(
                     reader=define_reader,
-                    domain=self.dataset_metadata.domain,
+                    domain=domain,
+                    name=self.dataset_metadata.name,
                 )
         except DomainNotFoundInDefineXMLError:
             metadata = {}
@@ -185,8 +187,8 @@ class SqlBaseDatasetBuilder(ABC):
             library_metadata[i] = self._format_metadata_dict(library_metadata[i])
         return library_metadata
 
-    def _get_define_dataset_variable_order(self, reader, domain: str) -> str:
-        metadata = reader.extract_variables_metadata(domain)
+    def _get_define_dataset_variable_order(self, reader: BaseDefineXMLReader, domain: str, name: str = None) -> str:
+        metadata = reader.extract_variables_metadata(domain, name)
         vars_order = {var["define_variable_name"]: var["define_variable_order_number"] for var in metadata}
         sorted_vars = sorted(vars_order.items(), key=lambda item: item[1])
         return ",".join([var[0].upper() for var in sorted_vars])

--- a/cdisc_rules_engine/sql_dataset_builders/sql_contents_define_dataset_builder.py
+++ b/cdisc_rules_engine/sql_dataset_builders/sql_contents_define_dataset_builder.py
@@ -56,17 +56,55 @@ class SqlContentsDefineDatasetBuilder(SqlBaseDatasetBuilder):
 
         self.data_service.pgi.add_column(table_id, SqlColumnSchema.define("define_key_sequence_is_unique", "Bool"))
 
+        # handle SUPP datasets - if SUPP exists then it may contribute key variables, and so join is necessary.
+        supp_table_id = f"SUPP{table_id}".lower()
+        supp_table_hash = self.data_service.pgi.schema.get_table_hash(supp_table_id)
+        if supp_table_hash:
+            idvar_cols_query = f"""SELECT STRING_AGG(DISTINCT IDVAR, ', ') as idvars, STRING_AGG(DISTINCT QNAM, ', ') as qnams from {supp_table_hash};"""  # noqa
+            self.data_service.pgi.execute_sql(idvar_cols_query)
+            all_cols = self.data_service.pgi.fetch_one()
+            idvar_cols = all_cols["idvars"].split(", ")
+            qnam_cols = all_cols["qnams"].split(", ")
+            non_supp_key_cols = [
+                col for col in define_ds_metadata["define_dataset_key_sequence"].split(",") if col not in qnam_cols
+            ]
+            key_vars = ", ".join([col for col in non_supp_key_cols + ["final_supp"]])
+
+            pivoted_supp_query = f"""
+                WITH pivoted_supp as (
+                    SELECT
+                        STUDYID, RDOMAIN, USUBJID, IDVARVAL, IDVAR,
+                        jsonb_object_agg(QNAM, QVAL) AS all_supp_vars
+                    FROM {supp_table_hash}
+                    GROUP BY 1, 2, 3, 4, 5
+                )"""
+
+            from_query = f"""
+                (SELECT
+                    a.id, {', '.join([f'a.{col}' for col in non_supp_key_cols])}
+                    ,COALESCE({', '.join([f'ps_{col}.all_supp_vars' for col in idvar_cols])}) as final_supp
+                FROM {table_hash} a
+                {' \n'.join([f"""LEFT JOIN pivoted_supp ps_{col}
+            ON a.STUDYID = ps_{col}.STUDYID
+            AND a.DOMAIN = ps_{col}.RDOMAIN
+            AND a.USUBJID = ps_{col}.USUBJID
+            AND ps_{col}.IDVAR = '{col}'
+            AND a.{col}::text = ps_{col}.IDVARVAL::text""" for col in idvar_cols])}
+                ) sub_inner"""
+        else:
+            key_vars = define_ds_metadata["define_dataset_key_sequence"]
+            from_query = table_hash
+            pivoted_supp_query = ""
+
         unique_col_hash = self.data_service.pgi.schema.get_column_hash(table_id, "define_key_sequence_is_unique")
         uniqueness_query = f"""
+            {pivoted_supp_query}
             UPDATE {table_hash} t
             SET {unique_col_hash} = sub.unique_status
             FROM (
                 SELECT id,
-                CASE
-                    WHEN COUNT(*) OVER (PARTITION BY {define_ds_metadata['define_dataset_key_sequence']}) = 1 THEN TRUE
-                    ELSE FALSE
-                END as unique_status
-                FROM {table_hash}
+                (COUNT(*) OVER (PARTITION BY {key_vars}) = 1) as unique_status
+                FROM {from_query}
             ) sub
             WHERE t.id = sub.id;
         """


### PR DESCRIPTION
Some tweaks to the define reader (_get_domain_metadata update brought through from recent CDISC change)
Adjusted sql_base_dataset_builder to handle SUPP domains properly in a couple of methods

Major change is to sql_contents_define_dataset_builder - complex SQL query to properly handle the uniqueness check on key variables from SUPP, regardless of IDVARs and QNAMs specified. Performance is reasonable - will have to verify on full CORE run in future but test on ~64k row SUPP dataset only took a few seconds. 

Might want to think about moving some of this logic elsewhere in future - I suspect at least some of it will be useful for SUPP handling more widely - but for now with it being the specific uniqueness check only used in this rule type I think it can stay put.

Probably some easy optimisations available - please suggest!