### PR TITLE
feat: Contains CO support Target=operation

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/contains_all_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/contains_all_operator.py
@@ -12,8 +12,15 @@ class ContainsAllOperator(BaseSqlOperator):
         not per-row results like other operators.
 
         """
-        target_column = self.replace_prefix(other_value.get("target")).lower()
+        target = other_value.get("target")
         comparator = other_value.get("comparator")
+
+        if target in self.operation_variables:
+            target_var = self.operation_variables[target]
+            if target_var.type == "collection":
+                return self._handle_target_is_collection(target, comparator)
+
+        target_column = self.replace_prefix(target).lower()
 
         if isinstance(comparator, list):
             return self._handle_list_comparator(target_column, comparator)
@@ -130,6 +137,26 @@ class ContainsAllOperator(BaseSqlOperator):
                       THEN true
                       ELSE false
                       END"""
+
+        return self._do_check_operator(sql)
+
+    def _handle_target_is_collection(self, target_variable, comparator):
+        """Handle when the target is a collection operation variable."""
+
+        def sql():
+            collection_sql = self._collection_sql(target_variable)
+            comparator_sql = self._constant_sql(comparator)
+
+            return f"""CASE
+                        WHEN NOT EXISTS (SELECT 1 FROM {collection_sql}) THEN false
+                        WHEN EXISTS (
+                            SELECT 1 FROM {collection_sql} AS collection_values(value)
+                            WHERE collection_values.value IS NULL
+                               OR collection_values.value = ''
+                               OR collection_values.value NOT LIKE '%' || {comparator_sql} || '%'
+                        ) THEN false
+                        ELSE true
+                       END"""
 
         return self._do_check_operator(sql)
 

--- a/cdisc_rules_engine/check_operators/sql/contains_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/contains_operator.py
@@ -14,14 +14,16 @@ class ContainsOperator(BaseSqlOperator):
         Also handles cases where the target is a collection operation variable.
         Returns True if the comparator is found as a substring within the target column.
         """
-        target_column = self.replace_prefix(other_value.get("target"))
+        target = other_value.get("target")
         value_is_literal = other_value.get("value_is_literal", False)
         comparator = other_value.get("comparator")
 
-        if target_column in self.operation_variables:
-            target_var = self.operation_variables[target_column]
-            if target_var.type == "collection":
-                return self._handle_target_is_collection(target_column, comparator, value_is_literal)
+        if target in self.operation_variables:
+            target_var = self.operation_variables[target]
+            if target_var.type == "collection" and value_is_literal:
+                return self._handle_target_is_collection(target, comparator)
+
+        target_column = self.replace_prefix(target)
 
         if isinstance(comparator, str) and comparator in self.operation_variables:
             return self._handle_operation_variable_comparator(target_column, comparator)
@@ -126,11 +128,14 @@ class ContainsOperator(BaseSqlOperator):
         )
 
     def _handle_target_is_collection(self, target_variable, comparator, value_is_literal):
-        """Handle when the target is a collection operation variable and we check if it contains a value."""
+        """Handle when the target is a collection operation variable."""
 
         def sql():
             collection_sql = self._collection_sql(target_variable, lowercase=self.case_insensitive)
-            comparator_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
+            if value_is_literal:
+                comparator_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
+            else:
+                comparator_sql = self._sql(comparator, lowercase=self.case_insensitive)
 
             return f"""EXISTS (
                         SELECT 1 FROM {collection_sql} AS collection_values(value)


### PR DESCRIPTION
This feat comes off the back of development for CG0173. 
Allow containment check operators (contains, does_not_contain, contains_all, not_contains_all) to handle and support targets being operations of the type "collection" with comparators that are "value is literal".