### PR TITLE
op: label/name_referenced_variable_metadata

### DIFF
--- a/cdisc_rules_engine/sql_operations/label_referenced_variable_metadata.py
+++ b/cdisc_rules_engine/sql_operations/label_referenced_variable_metadata.py
@@ -24,7 +24,7 @@ class SqlLabelReferencedVariableMetadata(SqlBaseOperation):
             return SqlOperationResult(query="SELECT NULL", type="constant", subtype="Char")
 
         values_clause = ", ".join(mapping)
-        query = f"SELECT val FROM (VALUES {values_clause}) AS t(lbl, val) " f"WHERE t.lbl = %target%"
+        query = f"SELECT val FROM (VALUES {values_clause}) AS t(lbl, val) WHERE t.lbl = %target%"
 
         return SqlOperationResult(
             query=query,

--- a/cdisc_rules_engine/sql_operations/label_referenced_variable_metadata.py
+++ b/cdisc_rules_engine/sql_operations/label_referenced_variable_metadata.py
@@ -1,0 +1,34 @@
+from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
+from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
+
+
+class SqlLabelReferencedVariableMetadata(SqlBaseOperation):
+    def _execute_operation(self):
+        standard_metadata = self.params.standards_context.get_standard_metadata()
+        attribute = getattr(self.params, "attribute_name", "role")
+
+        mapping = []
+
+        for cls in standard_metadata.get("classes", []):
+            for dataset in cls.get("datasets", []):
+                for var in dataset.get("datasetVariables", []):
+                    label = var.get("label")
+                    attr_val = var.get(attribute)
+
+                    if not label or attr_val is None:
+                        continue
+
+                    mapping.append(f"('{label}', '{attr_val}')")
+
+        if not mapping:
+            return SqlOperationResult(query="SELECT NULL", type="constant", subtype="Char")
+
+        values_clause = ", ".join(mapping)
+        query = f"SELECT val FROM (VALUES {values_clause}) AS t(lbl, val) " f"WHERE t.lbl = %target%"
+
+        return SqlOperationResult(
+            query=query,
+            type="collection",
+            subtype="Char",
+            params={"%target%": self.params.target},
+        )

--- a/cdisc_rules_engine/sql_operations/name_referenced_variable_metadata.py
+++ b/cdisc_rules_engine/sql_operations/name_referenced_variable_metadata.py
@@ -24,7 +24,7 @@ class SqlNameReferencedVariableMetadata(SqlBaseOperation):
             return SqlOperationResult(query="SELECT NULL", type="constant", subtype="Char")
 
         values_clause = ", ".join(mapping)
-        query = f"SELECT val FROM (VALUES {values_clause}) AS t(name, val) " f"WHERE t.name = %target%"
+        query = f"SELECT val FROM (VALUES {values_clause}) AS t(name, val) WHERE t.name = %target%"
 
         return SqlOperationResult(
             query=query,

--- a/cdisc_rules_engine/sql_operations/name_referenced_variable_metadata.py
+++ b/cdisc_rules_engine/sql_operations/name_referenced_variable_metadata.py
@@ -1,0 +1,34 @@
+from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
+from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
+
+
+class SqlNameReferencedVariableMetadata(SqlBaseOperation):
+    def _execute_operation(self):
+        standard_metadata = self.params.standards_context.get_standard_metadata()
+        attribute = getattr(self.params, "attribute_name", "role")
+
+        mapping = []
+
+        for cls in standard_metadata.get("classes", []):
+            for dataset in cls.get("datasets", []):
+                for var in dataset.get("datasetVariables", []):
+                    name = var.get("name")
+                    attr_val = var.get(attribute)
+
+                    if not name or attr_val is None:
+                        continue
+
+                    mapping.append(f"('{name}', '{attr_val}')")
+
+        if not mapping:
+            return SqlOperationResult(query="SELECT NULL", type="constant", subtype="Char")
+
+        values_clause = ", ".join(mapping)
+        query = f"SELECT val FROM (VALUES {values_clause}) AS t(name, val) " f"WHERE t.name = %target%"
+
+        return SqlOperationResult(
+            query=query,
+            type="collection",
+            subtype="Char",
+            params={"%target%": self.params.target},
+        )

--- a/cdisc_rules_engine/sql_operations/sql_operations_factory.py
+++ b/cdisc_rules_engine/sql_operations/sql_operations_factory.py
@@ -41,6 +41,8 @@ from cdisc_rules_engine.sql_operations.define_exdict_version_operation import (
 )
 from cdisc_rules_engine.sql_operations.whodrug_code_hierarchy import SqlWhodrugHierarchyOperation
 from cdisc_rules_engine.sql_operations.standard_domains import SqlStandardDomainsOperation
+from cdisc_rules_engine.sql_operations.label_referenced_variable_metadata import SqlLabelReferencedVariableMetadata
+from cdisc_rules_engine.sql_operations.name_referenced_variable_metadata import SqlNameReferencedVariableMetadata
 
 
 class SqlOperationsFactory:
@@ -81,8 +83,8 @@ class SqlOperationsFactory:
         "standard_domains": SqlStandardDomainsOperation,
         "study_domains": SqlStudyDomainsOperation,
         "valid_codelist_dates": SqlValidCodelistDates,
-        "label_referenced_variable_metadata": None,
-        "name_referenced_variable_metadata": None,
+        "label_referenced_variable_metadata": SqlLabelReferencedVariableMetadata,
+        "name_referenced_variable_metadata": SqlNameReferencedVariableMetadata,
         "define_variable_metadata": SqlGetDefineVariablesMetadata,
         "valid_external_dictionary_value": None,
         "valid_external_dictionary_code": None,

--- a/tests/unit/test_operations/sql/test_label_referenced_variable_metadata.py
+++ b/tests/unit/test_operations/sql/test_label_referenced_variable_metadata.py
@@ -1,0 +1,74 @@
+from cdisc_rules_engine.data_service.postgresql_data_service import PostgresQLDataService
+from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
+from cdisc_rules_engine.standards.default_standards_context import DefaultStandardsContext
+from cdisc_rules_engine.sql_operations.sql_operations_factory import SqlOperationsFactory
+
+TEST_DATASET = {
+    "DUMMYVAR": ["Severity/Intensity", "Epoch", "DummyLabel"],
+}
+
+
+class DummyStandardsContext(DefaultStandardsContext):
+    def get_standard_metadata(self):
+        return {
+            "classes": [
+                {
+                    "datasets": [
+                        {
+                            "datasetVariables": [
+                                {"label": "Epoch", "role": "Timing", "core": "Perm"},
+                                {"label": "Severity/Intensity", "role": "Record Qualifier", "core": "Perm"},
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+
+def test_label_referenced_variable_metadata_role():
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service=data_service, table_name="AE", column_data=TEST_DATASET, standards_context=DummyStandardsContext()
+    )
+
+    params = SqlOperationParams(
+        domain="AE", target="DUMMYVAR", attribute_name="role", standards_context=DummyStandardsContext()
+    )
+    operation = SqlOperationsFactory.get_service("label_referenced_variable_metadata", params, data_service)
+
+    result = operation.execute()
+
+    assert result.type == "collection"
+    assert result.subtype == "Char"
+    assert result.params == {"%target%": "DUMMYVAR"}
+
+    assert result.query.startswith("SELECT val FROM (VALUES ")
+    assert "('Epoch', 'Timing')" in result.query
+    assert "('Severity/Intensity', 'Record Qualifier')" in result.query
+    assert "DummyLabel" not in result.query
+    assert result.query.endswith(" AS t(lbl, val) WHERE t.lbl = %target%")
+
+
+def test_label_referenced_variable_metadata_core():
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service=data_service, table_name="AE", column_data=TEST_DATASET, standards_context=DummyStandardsContext()
+    )
+
+    params = SqlOperationParams(
+        domain="AE", target="DUMMYVAR", attribute_name="core", standards_context=DummyStandardsContext()
+    )
+    operation = SqlOperationsFactory.get_service("label_referenced_variable_metadata", params, data_service)
+
+    result = operation.execute()
+
+    assert result.type == "collection"
+    assert result.subtype == "Char"
+    assert result.params == {"%target%": "DUMMYVAR"}
+
+    assert result.query.startswith("SELECT val FROM (VALUES ")
+    assert "('Epoch', 'Perm')" in result.query
+    assert "('Severity/Intensity', 'Perm')" in result.query
+    assert "DummyLabel" not in result.query
+    assert result.query.endswith(" AS t(lbl, val) WHERE t.lbl = %target%")

--- a/tests/unit/test_operations/sql/test_name_referenced_variable_metadata.py
+++ b/tests/unit/test_operations/sql/test_name_referenced_variable_metadata.py
@@ -1,0 +1,74 @@
+from cdisc_rules_engine.data_service.postgresql_data_service import PostgresQLDataService
+from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
+from cdisc_rules_engine.standards.default_standards_context import DefaultStandardsContext
+from cdisc_rules_engine.sql_operations.sql_operations_factory import SqlOperationsFactory
+
+TEST_DATASET = {
+    "DUMMYVAR": ["Severity/Intensity", "Epoch", "DummyLabel"],
+}
+
+
+class DummyStandardsContext(DefaultStandardsContext):
+    def get_standard_metadata(self):
+        return {
+            "classes": [
+                {
+                    "datasets": [
+                        {
+                            "datasetVariables": [
+                                {"name": "EPOCH", "role": "Timing", "core": "Perm"},
+                                {"name": "AESEV", "role": "Record Qualifier", "core": "Perm"},
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+
+def test_name_referenced_variable_metadata_role():
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service=data_service, table_name="AE", column_data=TEST_DATASET, standards_context=DummyStandardsContext()
+    )
+
+    params = SqlOperationParams(
+        domain="AE", target="DUMMYVAR", attribute_name="role", standards_context=DummyStandardsContext()
+    )
+    operation = SqlOperationsFactory.get_service("name_referenced_variable_metadata", params, data_service)
+
+    result = operation.execute()
+
+    assert result.type == "collection"
+    assert result.subtype == "Char"
+    assert result.params == {"%target%": "DUMMYVAR"}
+
+    assert result.query.startswith("SELECT val FROM (VALUES ")
+    assert "('EPOCH', 'Timing')" in result.query
+    assert "('AESEV', 'Record Qualifier')" in result.query
+    assert "DummyLabel" not in result.query
+    assert result.query.endswith(" AS t(name, val) WHERE t.name = %target%")
+
+
+def test_name_referenced_variable_metadata_core():
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service=data_service, table_name="AE", column_data=TEST_DATASET, standards_context=DummyStandardsContext()
+    )
+
+    params = SqlOperationParams(
+        domain="AE", target="DUMMYVAR", attribute_name="core", standards_context=DummyStandardsContext()
+    )
+    operation = SqlOperationsFactory.get_service("name_referenced_variable_metadata", params, data_service)
+
+    result = operation.execute()
+
+    assert result.type == "collection"
+    assert result.subtype == "Char"
+    assert result.params == {"%target%": "DUMMYVAR"}
+
+    assert result.query.startswith("SELECT val FROM (VALUES ")
+    assert "('EPOCH', 'Perm')" in result.query
+    assert "('AESEV', 'Perm')" in result.query
+    assert "DummyLabel" not in result.query
+    assert result.query.endswith(" AS t(name, val) WHERE t.name = %target%")


### PR DESCRIPTION
This feat comes off the back of development for CG0173.

New operations "label_referenced_variable_metadata" and "name_referenced_variable_metadata". Using new params attribute_name to find relevant variable metadata type, then a column of values to filter either the "name" or "label" in the metadata.

This is a slight change from the cdisc implementation, which outputs multiple 2xN dataframe object operations. This is obviously not really ideal with PostgresQL and so I've opted for this version. It also closely ties with the functionality we need for the aforementioned cited guidance. 