### PR TITLE
feat: add regex sorting to target_is_sorted_by op

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/target_is_sorted_by_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/target_is_sorted_by_operator.py
@@ -44,8 +44,11 @@ class TargetIsSortedByOperator(BaseSqlOperator):
         Returns:
             Boolean series indicating if each record meets the sorting condition
         """
+        regex_sort = other_value.get("regex", None)
         target = self.replace_prefix(other_value.get("target"))
-        within = self.replace_prefix(other_value.get("within"))
+        val = other_value.get("within")
+        within = val if isinstance(val, list) else [val]
+        within = [self.replace_prefix(val) for val in within]
         comparators = other_value["comparator"]
 
         if not all([target, within, comparators]):
@@ -58,9 +61,14 @@ class TargetIsSortedByOperator(BaseSqlOperator):
             null_pos = comp["null_position"]
             comparator_parts.append(f"{name}_{order}_{null_pos}")
 
-        cache_key = f"{target}_is_sorted_by_{'_'.join(comparator_parts)}_within_{within}"
+        cache_key = f"{target}_is_sorted_by_{'_'.join(comparator_parts)}_within_{'_'.join(val for val in within)}"
 
         def sql(table_name, column_name):
+
+            target_sql = self._column_sql(target, alias=False)
+            target_sql = (
+                target_sql if not regex_sort else f"CAST((regexp_match({target_sql}, '{regex_sort}'))[1] AS INTEGER)"
+            )
 
             # Build CTEs for each individual comparator check
             comparator_ctes = []
@@ -87,11 +95,11 @@ class TargetIsSortedByOperator(BaseSqlOperator):
             comp_{i}_presorted AS (
                 SELECT
                     id,
-                    {self._column_sql(target, alias=False)} AS target_val,
-                    {self._column_sql(within, alias=False)} AS within_val,
+                    {target_sql} AS target_val,
+                    {' '.join(f'{self._column_sql(val, alias=False)} AS within_val{n},' for n, val in enumerate(within, start=1))}
                     {comp_sql} AS comp_val,
                     ROW_NUMBER() OVER (
-                        PARTITION BY {self._column_sql(within, alias=False)}
+                        PARTITION BY {', '.join(f'{self._column_sql(val, alias=False)}' for val in within)}
                         ORDER BY {order_part}
                     ) - 1 AS position_in_comp_order
                 FROM {table_name}
@@ -100,7 +108,7 @@ class TargetIsSortedByOperator(BaseSqlOperator):
                 SELECT
                     *,
                     ROW_NUMBER() OVER (
-                        PARTITION BY within_val
+                        PARTITION BY {', '.join(f'within_val{n}' for n in range(1, len(within) + 1))}
                         ORDER BY
                             CASE WHEN target_val IS NULL THEN 1 ELSE 0 END,
                             target_val ASC
@@ -119,7 +127,6 @@ class TargetIsSortedByOperator(BaseSqlOperator):
                 FROM comp_{i}_sorted
             )"""
                 )
-
             all_ctes = ",".join(comparator_ctes)
 
             # Build the join to combine all comparator checks
@@ -150,6 +157,7 @@ class TargetIsSortedByOperator(BaseSqlOperator):
 
             order_by_clause = ", ".join(order_by_parts)
             comparator_columns_sql = ", ".join(comparator_columns)
+            final_join = " AND ".join(f"s1.within_val{n} = s2.within_val{n}" for n in range(1, len(within) + 1))
 
             return f"""
             -- Check if target is sorted correctly by each comparator independently (matches old engine)
@@ -163,10 +171,11 @@ class TargetIsSortedByOperator(BaseSqlOperator):
             sorted_for_overlap AS (
                 SELECT
                     id,
-                    {self._column_sql(within, alias=False)} AS within_val,
+                    {self._column_sql(target, alias=False)} AS target_val,
+                    {' '.join(f'{self._column_sql(val, alias=False)} AS within_val{n},' for n, val in enumerate(within, start=1))}
                     {comparator_columns_sql},
                     ROW_NUMBER() OVER (
-                        PARTITION BY {self._column_sql(within, alias=False)}
+                        PARTITION BY {', '.join(f'{self._column_sql(val, alias=False)}' for val in within)}
                         ORDER BY {order_by_clause}
                     ) AS row_position
                 FROM {table_name}
@@ -191,7 +200,7 @@ class TargetIsSortedByOperator(BaseSqlOperator):
                         ELSE true
                     END AS date_overlap_ok
                 FROM sorted_for_overlap s1
-                LEFT JOIN sorted_for_overlap s2 ON s1.within_val = s2.within_val
+                LEFT JOIN sorted_for_overlap s2 ON {final_join}
                     AND s2.row_position = s1.row_position + 1
             )
             UPDATE {table_name} t

--- a/tests/resources/rules/rules.json
+++ b/tests/resources/rules/rules.json
@@ -3531,8 +3531,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "EXDOSE": 1.0,
-                                            "EXTRT": "PLACEBO"
+                                            "EXTRT": "PLACEBO",
+                                            "EXDOSE": 1.0
                                         }
                                     },
                                     {
@@ -3540,8 +3540,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "EXDOSE": 12.0,
-                                            "EXTRT": "PLACEBO"
+                                            "EXTRT": "PLACEBO",
+                                            "EXDOSE": 12.0
                                         }
                                     }
                                 ]
@@ -3832,8 +3832,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "DTHDTC": "2018-12-11",
-                                            "DTHFL": null
+                                            "DTHFL": null,
+                                            "DTHDTC": "2018-12-11"
                                         }
                                     }
                                 ]
@@ -3975,8 +3975,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "456",
                                         "value": {
-                                            "ELEMENT": "Unplanned Drug B",
-                                            "ETCD": "UNPLAN"
+                                            "ETCD": "UNPLAN",
+                                            "ELEMENT": "Unplanned Drug B"
                                         }
                                     }
                                 ]
@@ -5498,9 +5498,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "Y",
                                             "AGPRESP": null,
-                                            "AGSTAT": null
+                                            "AGSTAT": null,
+                                            "AGOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -5508,9 +5508,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "N",
                                             "AGPRESP": null,
-                                            "AGSTAT": null
+                                            "AGSTAT": null,
+                                            "AGOCCUR": "N"
                                         }
                                     },
                                     {
@@ -5518,9 +5518,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "Y",
                                             "AGPRESP": null,
-                                            "AGSTAT": "NOT DONE"
+                                            "AGSTAT": "NOT DONE",
+                                            "AGOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -5537,9 +5537,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CMPRESP": null,
                                             "CMOCCUR": "Y",
-                                            "CMSTAT": null,
-                                            "CMPRESP": null
+                                            "CMSTAT": null
                                         }
                                     },
                                     {
@@ -5547,9 +5547,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CMPRESP": null,
                                             "CMOCCUR": "N",
-                                            "CMSTAT": null,
-                                            "CMPRESP": null
+                                            "CMSTAT": null
                                         }
                                     },
                                     {
@@ -5557,9 +5557,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CMPRESP": null,
                                             "CMOCCUR": "Y",
-                                            "CMSTAT": "NOT DONE",
-                                            "CMPRESP": null
+                                            "CMSTAT": "NOT DONE"
                                         }
                                     }
                                 ]
@@ -5576,8 +5576,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "Y",
                                             "ECPRESP": null,
+                                            "ECOCCUR": "Y",
                                             "ECSTAT": "Not in dataset"
                                         }
                                     },
@@ -5586,8 +5586,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "N",
                                             "ECPRESP": null,
+                                            "ECOCCUR": "N",
                                             "ECSTAT": "Not in dataset"
                                         }
                                     },
@@ -5596,8 +5596,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "Y",
                                             "ECPRESP": null,
+                                            "ECOCCUR": "Y",
                                             "ECSTAT": "Not in dataset"
                                         }
                                     }
@@ -5624,8 +5624,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": null,
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -5634,8 +5634,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": null,
-                                            "MLOCCUR": "N",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "N"
                                         }
                                     },
                                     {
@@ -5644,8 +5644,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": "NOT DONE",
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -5662,9 +5662,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": null,
                                             "PRPRESP": null,
-                                            "PROCCUR": "Y"
+                                            "PROCCUR": "Y",
+                                            "PRSTAT": null
                                         }
                                     },
                                     {
@@ -5672,9 +5672,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": "NOT DONE",
                                             "PRPRESP": null,
-                                            "PROCCUR": "N"
+                                            "PROCCUR": "N",
+                                            "PRSTAT": "NOT DONE"
                                         }
                                     },
                                     {
@@ -5682,9 +5682,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": null,
                                             "PRPRESP": null,
-                                            "PROCCUR": "Y"
+                                            "PROCCUR": "Y",
+                                            "PRSTAT": null
                                         }
                                     }
                                 ]
@@ -5701,8 +5701,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
                                             "SUOCCUR": "Y",
+                                            "SUPRESP": null,
                                             "SUSTAT": null
                                         }
                                     },
@@ -5711,8 +5711,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
                                             "SUOCCUR": "N",
+                                            "SUPRESP": null,
                                             "SUSTAT": "NOT DONE"
                                         }
                                     },
@@ -5721,8 +5721,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
                                             "SUOCCUR": "Y",
+                                            "SUPRESP": null,
                                             "SUSTAT": null
                                         }
                                     }
@@ -5748,9 +5748,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": "Y",
                                             "BEPRESP": null,
-                                            "BESTAT": null,
-                                            "BEOCCUR": "Y"
+                                            "BESTAT": null
                                         }
                                     },
                                     {
@@ -5758,9 +5758,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": "N",
                                             "BEPRESP": null,
-                                            "BESTAT": null,
-                                            "BEOCCUR": "N"
+                                            "BESTAT": null
                                         }
                                     },
                                     {
@@ -5768,9 +5768,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": "Y",
                                             "BEPRESP": null,
-                                            "BESTAT": "NOT DONE",
-                                            "BEOCCUR": "Y"
+                                            "BESTAT": "NOT DONE"
                                         }
                                     },
                                     {
@@ -5778,9 +5778,9 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": "N",
                                             "BEPRESP": null,
-                                            "BESTAT": null,
-                                            "BEOCCUR": "N"
+                                            "BESTAT": null
                                         }
                                     }
                                 ]
@@ -5797,9 +5797,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": "Y",
                                             "CESTAT": null,
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -5807,9 +5807,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": "N",
                                             "CESTAT": null,
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "N"
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -5817,9 +5817,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": "Y",
                                             "CESTAT": "NOT DONE",
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -5827,9 +5827,9 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": "N",
                                             "CESTAT": null,
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "N"
+                                            "CEPRESP": null
                                         }
                                     }
                                 ]
@@ -5912,8 +5912,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -5922,8 +5922,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": "NOT DONE",
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "N"
+                                            "MHOCCUR": "N",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -5932,8 +5932,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": "NOT DONE",
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -5942,8 +5942,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "N"
+                                            "MHOCCUR": "N",
+                                            "MHPRESP": null
                                         }
                                     }
                                 ]
@@ -6360,9 +6360,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "Y",
                                             "AGPRESP": null,
-                                            "AGSTAT": null
+                                            "AGSTAT": null,
+                                            "AGOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -6370,9 +6370,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "Y",
                                             "AGPRESP": null,
-                                            "AGSTAT": "NOT DONE"
+                                            "AGSTAT": "NOT DONE",
+                                            "AGOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -6389,9 +6389,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CMPRESP": null,
                                             "CMOCCUR": "Y",
-                                            "CMSTAT": null,
-                                            "CMPRESP": null
+                                            "CMSTAT": null
                                         }
                                     },
                                     {
@@ -6399,9 +6399,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CMPRESP": null,
                                             "CMOCCUR": "Y",
-                                            "CMSTAT": "NOT DONE",
-                                            "CMPRESP": null
+                                            "CMSTAT": "NOT DONE"
                                         }
                                     }
                                 ]
@@ -6418,9 +6418,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECSTAT": null,
+                                            "ECPRESP": null,
                                             "ECOCCUR": "Y",
-                                            "ECPRESP": null
+                                            "ECSTAT": null
                                         }
                                     },
                                     {
@@ -6428,9 +6428,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECSTAT": "NOT DONE",
+                                            "ECPRESP": null,
                                             "ECOCCUR": "Y",
-                                            "ECPRESP": null
+                                            "ECSTAT": "NOT DONE"
                                         }
                                     },
                                     {
@@ -6438,9 +6438,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECSTAT": null,
+                                            "ECPRESP": null,
                                             "ECOCCUR": "N",
-                                            "ECPRESP": null
+                                            "ECSTAT": null
                                         }
                                     }
                                 ]
@@ -6466,8 +6466,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": null,
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -6476,8 +6476,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": "NOT DONE",
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -6494,9 +6494,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": null,
                                             "PRPRESP": null,
-                                            "PROCCUR": "Y"
+                                            "PROCCUR": "Y",
+                                            "PRSTAT": null
                                         }
                                     },
                                     {
@@ -6504,9 +6504,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": "NOT DONE",
                                             "PRPRESP": null,
-                                            "PROCCUR": "Y"
+                                            "PROCCUR": "Y",
+                                            "PRSTAT": "NOT DONE"
                                         }
                                     }
                                 ]
@@ -6523,8 +6523,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
                                             "SUOCCUR": "Y",
+                                            "SUPRESP": null,
                                             "SUSTAT": null
                                         }
                                     },
@@ -6533,8 +6533,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
                                             "SUOCCUR": "Y",
+                                            "SUPRESP": null,
                                             "SUSTAT": "NOT DONE"
                                         }
                                     }
@@ -6560,9 +6560,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": "Y",
                                             "BEPRESP": null,
-                                            "BESTAT": null,
-                                            "BEOCCUR": "Y"
+                                            "BESTAT": null
                                         }
                                     },
                                     {
@@ -6570,9 +6570,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": "Y",
                                             "BEPRESP": null,
-                                            "BESTAT": "NOT DONE",
-                                            "BEOCCUR": "Y"
+                                            "BESTAT": "NOT DONE"
                                         }
                                     },
                                     {
@@ -6580,9 +6580,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": "N",
                                             "BEPRESP": null,
-                                            "BESTAT": null,
-                                            "BEOCCUR": "N"
+                                            "BESTAT": null
                                         }
                                     }
                                 ]
@@ -6599,9 +6599,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": "Y",
                                             "CESTAT": null,
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -6609,9 +6609,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": "Y",
                                             "CESTAT": "NOT DONE",
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -6619,9 +6619,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": "N",
                                             "CESTAT": null,
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "N"
+                                            "CEPRESP": null
                                         }
                                     }
                                 ]
@@ -6694,8 +6694,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -6704,8 +6704,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": "NOT DONE",
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -6714,8 +6714,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "N"
+                                            "MHOCCUR": "N",
+                                            "MHPRESP": null
                                         }
                                     }
                                 ]
@@ -8443,8 +8443,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "Y",
-                                            "AGPRESP": null
+                                            "AGPRESP": null,
+                                            "AGOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -8452,8 +8452,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "N",
-                                            "AGPRESP": null
+                                            "AGPRESP": null,
+                                            "AGOCCUR": "N"
                                         }
                                     },
                                     {
@@ -8461,8 +8461,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "Y",
-                                            "AGPRESP": null
+                                            "AGPRESP": null,
+                                            "AGOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -8479,8 +8479,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CMOCCUR": "Y",
-                                            "CMPRESP": null
+                                            "CMPRESP": null,
+                                            "CMOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -8488,8 +8488,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CMOCCUR": "N",
-                                            "CMPRESP": null
+                                            "CMPRESP": null,
+                                            "CMOCCUR": "N"
                                         }
                                     },
                                     {
@@ -8497,8 +8497,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CMOCCUR": "Y",
-                                            "CMPRESP": null
+                                            "CMPRESP": null,
+                                            "CMOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -8515,8 +8515,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "Y",
-                                            "ECPRESP": null
+                                            "ECPRESP": null,
+                                            "ECOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -8524,8 +8524,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "N",
-                                            "ECPRESP": null
+                                            "ECPRESP": null,
+                                            "ECOCCUR": "N"
                                         }
                                     },
                                     {
@@ -8533,8 +8533,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "Y",
-                                            "ECPRESP": null
+                                            "ECPRESP": null,
+                                            "ECOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -8559,8 +8559,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -8568,8 +8568,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MLOCCUR": "N",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "N"
                                         }
                                     },
                                     {
@@ -8577,8 +8577,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -8631,8 +8631,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
-                                            "SUOCCUR": "Y"
+                                            "SUOCCUR": "Y",
+                                            "SUPRESP": null
                                         }
                                     },
                                     {
@@ -8640,8 +8640,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
-                                            "SUOCCUR": "N"
+                                            "SUOCCUR": "N",
+                                            "SUPRESP": null
                                         }
                                     },
                                     {
@@ -8649,8 +8649,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
-                                            "SUOCCUR": "N"
+                                            "SUOCCUR": "N",
+                                            "SUPRESP": null
                                         }
                                     }
                                 ]
@@ -8720,8 +8720,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEOCCUR": "Y",
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -8729,8 +8729,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEOCCUR": "Y",
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -8738,8 +8738,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEOCCUR": "Y",
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -8747,8 +8747,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "N"
+                                            "CEOCCUR": "N",
+                                            "CEPRESP": null
                                         }
                                     }
                                 ]
@@ -8826,8 +8826,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -8835,8 +8835,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -8844,8 +8844,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -8853,8 +8853,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "N"
+                                            "MHOCCUR": "N",
+                                            "MHPRESP": null
                                         }
                                     }
                                 ]
@@ -9246,8 +9246,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "Y",
-                                            "AGPRESP": null
+                                            "AGPRESP": null,
+                                            "AGOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -9255,8 +9255,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": "Y",
-                                            "AGPRESP": "y"
+                                            "AGPRESP": "y",
+                                            "AGOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -9273,8 +9273,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CMOCCUR": "Y",
-                                            "CMPRESP": null
+                                            "CMPRESP": null,
+                                            "CMOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -9282,8 +9282,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CMOCCUR": "N",
-                                            "CMPRESP": "N"
+                                            "CMPRESP": "N",
+                                            "CMOCCUR": "N"
                                         }
                                     }
                                 ]
@@ -9300,8 +9300,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "Y",
-                                            "ECPRESP": null
+                                            "ECPRESP": null,
+                                            "ECOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -9309,8 +9309,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "Y",
-                                            "ECPRESP": "y"
+                                            "ECPRESP": "y",
+                                            "ECOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -9318,8 +9318,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "Y",
-                                            "ECPRESP": "N"
+                                            "ECPRESP": "N",
+                                            "ECOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -9344,8 +9344,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": "y"
+                                            "MLPRESP": "y",
+                                            "MLOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -9353,8 +9353,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -9398,8 +9398,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": "y",
-                                            "SUOCCUR": "Y"
+                                            "SUOCCUR": "Y",
+                                            "SUPRESP": "y"
                                         }
                                     },
                                     {
@@ -9407,8 +9407,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": "y",
-                                            "SUOCCUR": "N"
+                                            "SUOCCUR": "N",
+                                            "SUPRESP": "y"
                                         }
                                     }
                                 ]
@@ -9469,8 +9469,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEOCCUR": "Y",
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -9478,8 +9478,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": "y",
-                                            "CEOCCUR": "N"
+                                            "CEOCCUR": "N",
+                                            "CEPRESP": "y"
                                         }
                                     },
                                     {
@@ -9487,8 +9487,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEOCCUR": "Y",
+                                            "CEPRESP": null
                                         }
                                     }
                                 ]
@@ -9557,8 +9557,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHPRESP": "y",
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": "y"
                                         }
                                     },
                                     {
@@ -9566,8 +9566,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHPRESP": "y",
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": "y"
                                         }
                                     },
                                     {
@@ -9575,8 +9575,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHPRESP": "y",
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": "y"
                                         }
                                     }
                                 ]
@@ -10067,8 +10067,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CMOCCUR": "Y",
-                                            "CMPRESP": null
+                                            "CMPRESP": null,
+                                            "CMOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -10085,8 +10085,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "Y",
-                                            "ECPRESP": null
+                                            "ECPRESP": null,
+                                            "ECOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -10094,8 +10094,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "N",
-                                            "ECPRESP": null
+                                            "ECPRESP": null,
+                                            "ECOCCUR": "N"
                                         }
                                     },
                                     {
@@ -10103,8 +10103,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECOCCUR": "Y",
-                                            "ECPRESP": null
+                                            "ECPRESP": null,
+                                            "ECOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -10129,8 +10129,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "Y"
                                         }
                                     },
                                     {
@@ -10138,8 +10138,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MLOCCUR": "N",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "N"
                                         }
                                     },
                                     {
@@ -10147,8 +10147,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MLOCCUR": "Y",
-                                            "MLPRESP": null
+                                            "MLPRESP": null,
+                                            "MLOCCUR": "Y"
                                         }
                                     }
                                 ]
@@ -10201,8 +10201,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
-                                            "SUOCCUR": "Y"
+                                            "SUOCCUR": "Y",
+                                            "SUPRESP": null
                                         }
                                     },
                                     {
@@ -10210,8 +10210,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
-                                            "SUOCCUR": "N"
+                                            "SUOCCUR": "N",
+                                            "SUPRESP": null
                                         }
                                     },
                                     {
@@ -10219,8 +10219,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": null,
-                                            "SUOCCUR": "N"
+                                            "SUOCCUR": "N",
+                                            "SUPRESP": null
                                         }
                                     }
                                 ]
@@ -10290,8 +10290,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEOCCUR": "Y",
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -10299,8 +10299,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEOCCUR": "Y",
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -10308,8 +10308,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "Y"
+                                            "CEOCCUR": "Y",
+                                            "CEPRESP": null
                                         }
                                     },
                                     {
@@ -10317,8 +10317,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CEPRESP": null,
-                                            "CEOCCUR": "N"
+                                            "CEOCCUR": "N",
+                                            "CEPRESP": null
                                         }
                                     }
                                 ]
@@ -10396,8 +10396,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -10405,8 +10405,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -10414,8 +10414,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "Y"
+                                            "MHOCCUR": "Y",
+                                            "MHPRESP": null
                                         }
                                     },
                                     {
@@ -10423,8 +10423,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "MHPRESP": null,
-                                            "MHOCCUR": "N"
+                                            "MHOCCUR": "N",
+                                            "MHPRESP": null
                                         }
                                     }
                                 ]
@@ -11579,9 +11579,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": null,
                                             "AGPRESP": "Y",
-                                            "AGSTAT": null
+                                            "AGSTAT": null,
+                                            "AGOCCUR": null
                                         }
                                     },
                                     {
@@ -11589,9 +11589,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": null,
                                             "AGPRESP": "Y",
-                                            "AGSTAT": null
+                                            "AGSTAT": null,
+                                            "AGOCCUR": null
                                         }
                                     },
                                     {
@@ -11599,9 +11599,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": null,
                                             "AGPRESP": "Y",
-                                            "AGSTAT": null
+                                            "AGSTAT": null,
+                                            "AGOCCUR": null
                                         }
                                     }
                                 ]
@@ -11640,8 +11640,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": null,
-                                            "MLOCCUR": null,
-                                            "MLPRESP": "Y"
+                                            "MLPRESP": "Y",
+                                            "MLOCCUR": null
                                         }
                                     },
                                     {
@@ -11650,8 +11650,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": null,
-                                            "MLOCCUR": null,
-                                            "MLPRESP": "Y"
+                                            "MLPRESP": "Y",
+                                            "MLOCCUR": null
                                         }
                                     },
                                     {
@@ -11660,8 +11660,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": null,
-                                            "MLOCCUR": null,
-                                            "MLPRESP": "Y"
+                                            "MLPRESP": "Y",
+                                            "MLOCCUR": null
                                         }
                                     }
                                 ]
@@ -11678,9 +11678,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": null,
                                             "PRPRESP": "Y",
-                                            "PROCCUR": null
+                                            "PROCCUR": null,
+                                            "PRSTAT": null
                                         }
                                     },
                                     {
@@ -11688,9 +11688,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": null,
                                             "PRPRESP": "Y",
-                                            "PROCCUR": null
+                                            "PROCCUR": null,
+                                            "PRSTAT": null
                                         }
                                     },
                                     {
@@ -11698,9 +11698,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": null,
                                             "PRPRESP": "Y",
-                                            "PROCCUR": null
+                                            "PROCCUR": null,
+                                            "PRSTAT": null
                                         }
                                     }
                                 ]
@@ -11717,8 +11717,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": "Y",
                                             "SUOCCUR": null,
+                                            "SUPRESP": "Y",
                                             "SUSTAT": null
                                         }
                                     },
@@ -11727,8 +11727,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": "Y",
                                             "SUOCCUR": null,
+                                            "SUPRESP": "Y",
                                             "SUSTAT": null
                                         }
                                     },
@@ -11737,8 +11737,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": "Y",
                                             "SUOCCUR": null,
+                                            "SUPRESP": "Y",
                                             "SUSTAT": null
                                         }
                                     }
@@ -11764,9 +11764,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": null,
                                             "BEPRESP": "Y",
-                                            "BESTAT": null,
-                                            "BEOCCUR": null
+                                            "BESTAT": null
                                         }
                                     },
                                     {
@@ -11774,9 +11774,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": null,
                                             "BEPRESP": "Y",
-                                            "BESTAT": null,
-                                            "BEOCCUR": null
+                                            "BESTAT": null
                                         }
                                     },
                                     {
@@ -11784,9 +11784,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": null,
                                             "BEPRESP": "Y",
-                                            "BESTAT": null,
-                                            "BEOCCUR": null
+                                            "BESTAT": null
                                         }
                                     },
                                     {
@@ -11794,9 +11794,9 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": null,
                                             "BEPRESP": "Y",
-                                            "BESTAT": null,
-                                            "BEOCCUR": null
+                                            "BESTAT": null
                                         }
                                     }
                                 ]
@@ -11813,9 +11813,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": null,
                                             "CESTAT": null,
-                                            "CEPRESP": "Y",
-                                            "CEOCCUR": null
+                                            "CEPRESP": "Y"
                                         }
                                     },
                                     {
@@ -11823,9 +11823,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": null,
                                             "CESTAT": null,
-                                            "CEPRESP": "Y",
-                                            "CEOCCUR": null
+                                            "CEPRESP": "Y"
                                         }
                                     },
                                     {
@@ -11833,9 +11833,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": null,
                                             "CESTAT": null,
-                                            "CEPRESP": "Y",
-                                            "CEOCCUR": null
+                                            "CEPRESP": "Y"
                                         }
                                     },
                                     {
@@ -11843,9 +11843,9 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": null,
                                             "CESTAT": null,
-                                            "CEPRESP": "Y",
-                                            "CEOCCUR": null
+                                            "CEPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -11928,8 +11928,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": "Y",
-                                            "MHOCCUR": null
+                                            "MHOCCUR": null,
+                                            "MHPRESP": "Y"
                                         }
                                     },
                                     {
@@ -11938,8 +11938,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": "Y",
-                                            "MHOCCUR": null
+                                            "MHOCCUR": null,
+                                            "MHPRESP": "Y"
                                         }
                                     },
                                     {
@@ -11948,8 +11948,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": "Y",
-                                            "MHOCCUR": null
+                                            "MHOCCUR": null,
+                                            "MHPRESP": "Y"
                                         }
                                     },
                                     {
@@ -11958,8 +11958,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": "Y",
-                                            "MHOCCUR": null
+                                            "MHOCCUR": null,
+                                            "MHPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -12379,9 +12379,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": null,
                                             "AGPRESP": "Y",
-                                            "AGSTAT": null
+                                            "AGSTAT": null,
+                                            "AGOCCUR": null
                                         }
                                     },
                                     {
@@ -12389,9 +12389,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AGOCCUR": null,
                                             "AGPRESP": "Y",
-                                            "AGSTAT": null
+                                            "AGSTAT": null,
+                                            "AGOCCUR": null
                                         }
                                     }
                                 ]
@@ -12408,9 +12408,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CMPRESP": "Y",
                                             "CMOCCUR": null,
-                                            "CMSTAT": null,
-                                            "CMPRESP": "Y"
+                                            "CMSTAT": null
                                         }
                                     },
                                     {
@@ -12418,9 +12418,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CMPRESP": "Y",
                                             "CMOCCUR": null,
-                                            "CMSTAT": null,
-                                            "CMPRESP": "Y"
+                                            "CMSTAT": null
                                         }
                                     }
                                 ]
@@ -12437,9 +12437,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECSTAT": null,
+                                            "ECPRESP": "Y",
                                             "ECOCCUR": null,
-                                            "ECPRESP": "Y"
+                                            "ECSTAT": null
                                         }
                                     },
                                     {
@@ -12447,9 +12447,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECSTAT": null,
+                                            "ECPRESP": "Y",
                                             "ECOCCUR": null,
-                                            "ECPRESP": "Y"
+                                            "ECSTAT": null
                                         }
                                     },
                                     {
@@ -12457,9 +12457,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ECSTAT": null,
+                                            "ECPRESP": "Y",
                                             "ECOCCUR": null,
-                                            "ECPRESP": "Y"
+                                            "ECSTAT": null
                                         }
                                     }
                                 ]
@@ -12485,8 +12485,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": null,
-                                            "MLOCCUR": null,
-                                            "MLPRESP": "Y"
+                                            "MLPRESP": "Y",
+                                            "MLOCCUR": null
                                         }
                                     },
                                     {
@@ -12495,8 +12495,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MLSTAT": null,
-                                            "MLOCCUR": null,
-                                            "MLPRESP": "Y"
+                                            "MLPRESP": "Y",
+                                            "MLOCCUR": null
                                         }
                                     }
                                 ]
@@ -12513,9 +12513,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": null,
                                             "PRPRESP": "Y",
-                                            "PROCCUR": null
+                                            "PROCCUR": null,
+                                            "PRSTAT": null
                                         }
                                     },
                                     {
@@ -12523,9 +12523,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "PRSTAT": null,
                                             "PRPRESP": "Y",
-                                            "PROCCUR": null
+                                            "PROCCUR": null,
+                                            "PRSTAT": null
                                         }
                                     }
                                 ]
@@ -12542,8 +12542,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": "Y",
                                             "SUOCCUR": null,
+                                            "SUPRESP": "Y",
                                             "SUSTAT": null
                                         }
                                     },
@@ -12552,8 +12552,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SUPRESP": "Y",
                                             "SUOCCUR": null,
+                                            "SUPRESP": "Y",
                                             "SUSTAT": null
                                         }
                                     }
@@ -12579,9 +12579,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": null,
                                             "BEPRESP": "Y",
-                                            "BESTAT": null,
-                                            "BEOCCUR": null
+                                            "BESTAT": null
                                         }
                                     },
                                     {
@@ -12589,9 +12589,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": null,
                                             "BEPRESP": "Y",
-                                            "BESTAT": null,
-                                            "BEOCCUR": null
+                                            "BESTAT": null
                                         }
                                     },
                                     {
@@ -12599,9 +12599,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "BEOCCUR": null,
                                             "BEPRESP": "Y",
-                                            "BESTAT": null,
-                                            "BEOCCUR": null
+                                            "BESTAT": null
                                         }
                                     }
                                 ]
@@ -12618,9 +12618,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": null,
                                             "CESTAT": null,
-                                            "CEPRESP": "Y",
-                                            "CEOCCUR": null
+                                            "CEPRESP": "Y"
                                         }
                                     },
                                     {
@@ -12628,9 +12628,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": null,
                                             "CESTAT": null,
-                                            "CEPRESP": "Y",
-                                            "CEOCCUR": null
+                                            "CEPRESP": "Y"
                                         }
                                     },
                                     {
@@ -12638,9 +12638,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "CEOCCUR": null,
                                             "CESTAT": null,
-                                            "CEPRESP": "Y",
-                                            "CEOCCUR": null
+                                            "CEPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -12713,8 +12713,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": "Y",
-                                            "MHOCCUR": null
+                                            "MHOCCUR": null,
+                                            "MHPRESP": "Y"
                                         }
                                     },
                                     {
@@ -12723,8 +12723,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": "Y",
-                                            "MHOCCUR": null
+                                            "MHOCCUR": null,
+                                            "MHPRESP": "Y"
                                         }
                                     },
                                     {
@@ -12733,8 +12733,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "MHSTAT": null,
-                                            "MHPRESP": "Y",
-                                            "MHOCCUR": null
+                                            "MHOCCUR": null,
+                                            "MHPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -13930,8 +13930,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "456",
                                         "value": {
-                                            "TAETORD": 3.0,
-                                            "ETCD": "UNPLAN"
+                                            "ETCD": "UNPLAN",
+                                            "TAETORD": 3.0
                                         }
                                     }
                                 ]
@@ -14118,9 +14118,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBDRVFL": null,
+                                            "LBSTRESC": null,
                                             "LBORRES": "93",
-                                            "LBSTRESC": null
+                                            "LBDRVFL": null
                                         }
                                     },
                                     {
@@ -14128,9 +14128,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBDRVFL": "Y",
+                                            "LBSTRESC": null,
                                             "LBORRES": null,
-                                            "LBSTRESC": null
+                                            "LBDRVFL": "Y"
                                         }
                                     }
                                 ]
@@ -14147,8 +14147,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "VSSTRESC": null,
                                             "VSORRES": "71",
+                                            "VSSTRESC": null,
                                             "VSDRVFL": null
                                         }
                                     },
@@ -14157,8 +14157,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "VSSTRESC": null,
                                             "VSORRES": null,
+                                            "VSSTRESC": null,
                                             "VSDRVFL": "Y"
                                         }
                                     }
@@ -14494,16 +14494,16 @@
                                         "SEQ": 727,
                                         "USUBJID": "CDISC-TEST-046",
                                         "value": {
-                                            "AESTDTC": "2019-03-24",
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESTDTC": "2019-03-24",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "Y",
                                             "AESCONG": "N",
                                             "AESER": "N",
-                                            "AESCAN": "Y",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AETERM": "UPSET STOMACH"
                                         }
                                     },
@@ -14512,16 +14512,16 @@
                                         "SEQ": 735,
                                         "USUBJID": "CDISC-TEST-046",
                                         "value": {
-                                            "AESTDTC": "2019-04-29",
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESTDTC": "2019-04-29",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "Y",
                                             "AESER": "N",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AETERM": "HEADACHE"
                                         }
                                     },
@@ -14530,16 +14530,16 @@
                                         "SEQ": 782,
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
-                                            "AESTDTC": "2019-03-09",
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "Y",
                                             "AESOD": "N",
+                                            "AESTDTC": "2019-03-09",
+                                            "AESDISAB": "Y",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "N",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AETERM": "HEADACHE"
                                         }
                                     },
@@ -14548,16 +14548,16 @@
                                         "SEQ": 783,
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
-                                            "AESTDTC": "2019-03-15",
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESTDTC": "2019-03-15",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "N",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
                                             "AESDTH": "Y",
+                                            "AESLIFE": "N",
                                             "AETERM": "HEADACHE"
                                         }
                                     },
@@ -14566,16 +14566,16 @@
                                         "SEQ": 839,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AESTDTC": "2019-05-08",
+                                            "AESMIE": "N",
                                             "AESHOSP": "Y",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESTDTC": "2019-05-08",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "N",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AETERM": "HEADACHE"
                                         }
                                     },
@@ -14584,16 +14584,16 @@
                                         "SEQ": 840,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AESTDTC": "2019-03-30",
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESTDTC": "2019-03-30",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "N",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "Y",
-                                            "AESMIE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "Y",
                                             "AETERM": "HYPERTENSION"
                                         }
                                     },
@@ -14602,16 +14602,16 @@
                                         "SEQ": 843,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AESTDTC": "2019-07-10",
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "Y",
+                                            "AESTDTC": "2019-07-10",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "N",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AETERM": "HYPERTENSION"
                                         }
                                     },
@@ -14620,16 +14620,16 @@
                                         "SEQ": 844,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AESTDTC": "2019-03-26",
+                                            "AESMIE": "Y",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESTDTC": "2019-03-26",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "N",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "Y",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AETERM": "HYPOGLYCAEMIA"
                                         }
                                     },
@@ -14638,16 +14638,16 @@
                                         "SEQ": 881,
                                         "USUBJID": "CDISC-TEST-055",
                                         "value": {
-                                            "AESTDTC": "2019-08-31",
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESTDTC": "2019-08-31",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "Y",
                                             "AESER": null,
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AETERM": "CARDIAC ARREST"
                                         }
                                     },
@@ -14656,16 +14656,16 @@
                                         "SEQ": 882,
                                         "USUBJID": "CDISC-TEST-055",
                                         "value": {
-                                            "AESTDTC": "2019-04-18",
+                                            "AESMIE": null,
                                             "AESHOSP": null,
-                                            "AESDISAB": null,
                                             "AESOD": null,
+                                            "AESTDTC": "2019-04-18",
+                                            "AESDISAB": null,
+                                            "AESCAN": "Y",
                                             "AESCONG": null,
                                             "AESER": null,
-                                            "AESCAN": "Y",
-                                            "AESLIFE": null,
-                                            "AESMIE": null,
                                             "AESDTH": null,
+                                            "AESLIFE": null,
                                             "AETERM": "DIARRHOEA"
                                         }
                                     },
@@ -14674,16 +14674,16 @@
                                         "SEQ": 897,
                                         "USUBJID": "CDISC-TEST-055",
                                         "value": {
-                                            "AESTDTC": "2019-03-21",
+                                            "AESMIE": null,
                                             "AESHOSP": null,
-                                            "AESDISAB": null,
                                             "AESOD": null,
+                                            "AESTDTC": "2019-03-21",
+                                            "AESDISAB": null,
+                                            "AESCAN": null,
                                             "AESCONG": null,
                                             "AESER": null,
-                                            "AESCAN": null,
-                                            "AESLIFE": null,
-                                            "AESMIE": null,
                                             "AESDTH": "Y",
+                                            "AESLIFE": null,
                                             "AETERM": "PNEUMONIA"
                                         }
                                     }
@@ -14961,8 +14961,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "AEBODSYS": "Musculoskeletal and connective tissue disorders",
-                                            "AEBDSYCD": null
+                                            "AEBDSYCD": null,
+                                            "AEBODSYS": "Musculoskeletal and connective tissue disorders"
                                         }
                                     },
                                     {
@@ -14970,8 +14970,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "AEBODSYS": "Nervous system disorders",
-                                            "AEBDSYCD": null
+                                            "AEBDSYCD": null,
+                                            "AEBODSYS": "Nervous system disorders"
                                         }
                                     },
                                     {
@@ -14979,8 +14979,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "AEBODSYS": "Vascular disorders",
-                                            "AEBDSYCD": null
+                                            "AEBDSYCD": null,
+                                            "AEBODSYS": "Vascular disorders"
                                         }
                                     }
                                 ]
@@ -15127,8 +15127,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC015",
                                         "value": {
-                                            "IESTRESC": "Yup",
-                                            "IEORRES": "Y"
+                                            "IEORRES": "Y",
+                                            "IESTRESC": "Yup"
                                         }
                                     },
                                     {
@@ -15136,8 +15136,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "IESTRESC": "Yippy",
-                                            "IEORRES": "Yes"
+                                            "IEORRES": "Yes",
+                                            "IESTRESC": "Yippy"
                                         }
                                     },
                                     {
@@ -15145,8 +15145,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC017",
                                         "value": {
-                                            "IESTRESC": "Nah",
-                                            "IEORRES": "Nope"
+                                            "IEORRES": "Nope",
+                                            "IESTRESC": "Nah"
                                         }
                                     }
                                 ]
@@ -15406,9 +15406,9 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TEENRL": null,
+                                            "ETCD": "SCREEN",
                                             "TEDUR": null,
-                                            "ETCD": "SCREEN"
+                                            "TEENRL": null
                                         }
                                     }
                                 ]
@@ -15610,8 +15610,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "MLTPTREF": null,
-                                            "MLELTM": "-PT10M"
+                                            "MLELTM": "-PT10M",
+                                            "MLTPTREF": null
                                         }
                                     },
                                     {
@@ -15619,8 +15619,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "MLTPTREF": null,
-                                            "MLELTM": "PT1H"
+                                            "MLELTM": "PT1H",
+                                            "MLTPTREF": null
                                         }
                                     },
                                     {
@@ -15628,8 +15628,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "MLTPTREF": null,
-                                            "MLELTM": "PT2H"
+                                            "MLELTM": "PT2H",
+                                            "MLTPTREF": null
                                         }
                                     },
                                     {
@@ -15637,8 +15637,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "MLTPTREF": null,
-                                            "MLELTM": "PT24H"
+                                            "MLELTM": "PT24H",
+                                            "MLTPTREF": null
                                         }
                                     },
                                     {
@@ -15646,8 +15646,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "MLTPTREF": null,
-                                            "MLELTM": "PT48H"
+                                            "MLELTM": "PT48H",
+                                            "MLTPTREF": null
                                         }
                                     }
                                 ]
@@ -15664,8 +15664,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "PCTPTREF": null,
-                                            "PCELTM": "PT2H"
+                                            "PCELTM": "PT2H",
+                                            "PCTPTREF": null
                                         }
                                     },
                                     {
@@ -15673,8 +15673,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "PCTPTREF": null,
-                                            "PCELTM": "PT24H"
+                                            "PCELTM": "PT24H",
+                                            "PCTPTREF": null
                                         }
                                     },
                                     {
@@ -15682,8 +15682,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "PCTPTREF": null,
-                                            "PCELTM": "PT48H"
+                                            "PCELTM": "PT48H",
+                                            "PCTPTREF": null
                                         }
                                     }
                                 ]
@@ -16725,8 +16725,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-300-0004-00002",
                                         "value": {
-                                            "DSDECOD": "ADVERSE EVENT",
-                                            "DSTERM": "COMPLETED"
+                                            "DSTERM": "COMPLETED",
+                                            "DSDECOD": "ADVERSE EVENT"
                                         }
                                     }
                                 ]
@@ -16893,9 +16893,9 @@
                                         "SEQ": 7,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "DTHDTC": "2021-02-18",
+                                            "DSDECOD": "DEATH",
                                             "DSSTDTC": "2022-02-20",
-                                            "DSDECOD": "DEATH"
+                                            "DTHDTC": "2021-02-18"
                                         }
                                     },
                                     {
@@ -16903,9 +16903,9 @@
                                         "SEQ": 4,
                                         "USUBJID": "015246-888-0008-08888",
                                         "value": {
-                                            "DTHDTC": null,
+                                            "DSDECOD": "DEATH",
                                             "DSSTDTC": "2019-01-10",
-                                            "DSDECOD": "DEATH"
+                                            "DTHDTC": null
                                         }
                                     },
                                     {
@@ -16913,9 +16913,9 @@
                                         "SEQ": 5,
                                         "USUBJID": "015246-999-0003-09999",
                                         "value": {
-                                            "DTHDTC": "2021-01",
+                                            "DSDECOD": "DEATH",
                                             "DSSTDTC": "2021-01-10",
-                                            "DSDECOD": "DEATH"
+                                            "DTHDTC": "2021-01"
                                         }
                                     }
                                 ]
@@ -17079,8 +17079,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": null,
-                                            "VISITDY": 31.0
+                                            "VISITDY": 31.0,
+                                            "SVPRESP": null
                                         }
                                     },
                                     {
@@ -17088,8 +17088,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": null,
-                                            "VISITDY": 62.0
+                                            "VISITDY": 62.0,
+                                            "SVPRESP": null
                                         }
                                     },
                                     {
@@ -17097,8 +17097,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": null,
-                                            "VISITDY": 63.0
+                                            "VISITDY": 63.0,
+                                            "SVPRESP": null
                                         }
                                     }
                                 ]
@@ -17618,8 +17618,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 14.0
+                                            "VISITNUM": 14.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -17627,8 +17627,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 15.0
+                                            "VISITNUM": 15.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -17636,8 +17636,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 16.0
+                                            "VISITNUM": 16.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -17645,8 +17645,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 5.01
+                                            "VISITNUM": 5.01,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -17654,8 +17654,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 17.0
+                                            "VISITNUM": 17.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -17663,8 +17663,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 19.0
+                                            "VISITNUM": 19.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -17672,8 +17672,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 101.0
+                                            "VISITNUM": 101.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -17681,8 +17681,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 201.0
+                                            "VISITNUM": 201.0,
+                                            "SVPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -17844,8 +17844,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVPRESP": null,
-                                            "VISITNUM": 101.0
+                                            "VISITNUM": 101.0,
+                                            "SVPRESP": null
                                         }
                                     }
                                 ]
@@ -23337,9 +23337,9 @@
                                         "USUBJID": null,
                                         "value": {
                                             "ECTPTREF": "1",
+                                            "ECTPT": "Not in dataset",
                                             "ECTPTNUM": "Not in dataset",
-                                            "ECELTM": "Not in dataset",
-                                            "ECTPT": "Not in dataset"
+                                            "ECELTM": "Not in dataset"
                                         }
                                     }
                                 ]
@@ -23801,8 +23801,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "VSORRES": null,
-                                            "VSLOBXFL": "Y",
-                                            "VSDRVFL": null
+                                            "VSDRVFL": null,
+                                            "VSLOBXFL": "Y"
                                         }
                                     },
                                     {
@@ -23811,8 +23811,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "VSORRES": null,
-                                            "VSLOBXFL": "Y",
-                                            "VSDRVFL": null
+                                            "VSDRVFL": null,
+                                            "VSLOBXFL": "Y"
                                         }
                                     },
                                     {
@@ -23821,8 +23821,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "VSORRES": null,
-                                            "VSLOBXFL": "Y",
-                                            "VSDRVFL": null
+                                            "VSDRVFL": null,
+                                            "VSLOBXFL": "Y"
                                         }
                                     }
                                 ]
@@ -24366,8 +24366,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CMSTTPT": "SCREENING",
-                                            "CMSTRTPT": null
+                                            "CMSTRTPT": null,
+                                            "CMSTTPT": "SCREENING"
                                         }
                                     },
                                     {
@@ -24375,8 +24375,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CMSTTPT": "SCREENING",
-                                            "CMSTRTPT": null
+                                            "CMSTRTPT": null,
+                                            "CMSTTPT": "SCREENING"
                                         }
                                     }
                                 ]
@@ -25167,8 +25167,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "XYZ-001-002",
                                         "value": {
-                                            "AGTRTV": null,
-                                            "AGVAMT": "0.1"
+                                            "AGVAMT": "0.1",
+                                            "AGTRTV": null
                                         }
                                     }
                                 ]
@@ -25307,8 +25307,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "YY-20",
                                         "value": {
-                                            "IDVAR": "AESEQ",
-                                            "RDOMAIN": null
+                                            "RDOMAIN": null,
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -25316,8 +25316,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "AB-99",
                                         "value": {
-                                            "IDVAR": "VSGRPID",
-                                            "RDOMAIN": null
+                                            "RDOMAIN": null,
+                                            "IDVAR": "VSGRPID"
                                         }
                                     }
                                 ]
@@ -25447,8 +25447,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "XYZ-001-002",
                                         "value": {
-                                            "AGVAMTU": "mL",
-                                            "AGTRTV": null
+                                            "AGTRTV": null,
+                                            "AGVAMTU": "mL"
                                         }
                                     }
                                 ]
@@ -25706,8 +25706,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "1201002",
                                         "value": {
-                                            "SEUPDES": "Unplanned treatement",
-                                            "ETCD": "TRTZ"
+                                            "ETCD": "TRTZ",
+                                            "SEUPDES": "Unplanned treatement"
                                         }
                                     }
                                 ]
@@ -26206,9 +26206,9 @@
                                         "SEQ": null,
                                         "USUBJID": "1201001",
                                         "value": {
-                                            "SESTDTC": "2018-08-13",
                                             "SVSTDTC": "2018-08-20",
-                                            "EPOCH": "SCREENING"
+                                            "EPOCH": "SCREENING",
+                                            "SESTDTC": "2018-08-13"
                                         }
                                     }
                                 ]
@@ -26694,8 +26694,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "123102",
                                         "value": {
-                                            "EGORRES": "0.15",
-                                            "EGSTAT": "NOT DONE"
+                                            "EGSTAT": "NOT DONE",
+                                            "EGORRES": "0.15"
                                         }
                                     }
                                 ]
@@ -26738,8 +26738,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "LBORRES": "30",
-                                            "LBSTAT": "NOT DONE"
+                                            "LBSTAT": "NOT DONE",
+                                            "LBORRES": "30"
                                         }
                                     }
                                 ]
@@ -26756,8 +26756,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "VSSTAT": "NOT DONE",
-                                            "VSORRES": "154"
+                                            "VSORRES": "154",
+                                            "VSSTAT": "NOT DONE"
                                         }
                                     }
                                 ]
@@ -26951,8 +26951,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "XYZ-001-002",
                                         "value": {
-                                            "AGTRTV": null,
-                                            "AGVAMT": "0.1"
+                                            "AGVAMT": "0.1",
+                                            "AGTRTV": null
                                         }
                                     }
                                 ]
@@ -27186,8 +27186,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "MSSTRESC": null,
-                                            "MSRESCAT": "JDKSAJJDSAKF"
+                                            "MSRESCAT": "JDKSAJJDSAKF",
+                                            "MSSTRESC": null
                                         }
                                     }
                                 ]
@@ -27481,8 +27481,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "AETOXGR": null,
-                                            "AETOX": "CTCAE 4.03"
+                                            "AETOX": "CTCAE 4.03",
+                                            "AETOXGR": null
                                         }
                                     }
                                 ]
@@ -27947,8 +27947,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "XYZ-001-001",
                                         "value": {
-                                            "AGCAT": null,
-                                            "AGSCAT": "DFAJF"
+                                            "AGSCAT": "DFAJF",
+                                            "AGCAT": null
                                         }
                                     }
                                 ]
@@ -28015,8 +28015,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "1234005",
                                         "value": {
-                                            "SUSCAT": "TOBACCO",
-                                            "SUCAT": null
+                                            "SUCAT": null,
+                                            "SUSCAT": "TOBACCO"
                                         }
                                     },
                                     {
@@ -28024,8 +28024,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "1234005",
                                         "value": {
-                                            "SUSCAT": "CAFFEINE",
-                                            "SUCAT": null
+                                            "SUCAT": null,
+                                            "SUSCAT": "CAFFEINE"
                                         }
                                     }
                                 ]
@@ -28042,8 +28042,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "1234005",
                                         "value": {
-                                            "AECAT": null,
-                                            "AESCAT": "NEUROLOGIC"
+                                            "AESCAT": "NEUROLOGIC",
+                                            "AECAT": null
                                         }
                                     }
                                 ]
@@ -28100,8 +28100,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "EGSCAT": "INTERVAL",
-                                            "EGCAT": null
+                                            "EGCAT": null,
+                                            "EGSCAT": "INTERVAL"
                                         }
                                     }
                                 ]
@@ -29981,9 +29981,9 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
+                                            "LBSEQ": 1.0,
                                             "DOMAIN": "LB",
-                                            "STUDYID": "XYZ",
-                                            "LBSEQ": 1.0
+                                            "STUDYID": "XYZ"
                                         }
                                     }
                                 ]
@@ -30207,9 +30207,9 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "DOMAIN": "SU",
                                             "STUDYID": "XYZ",
-                                            "SUSEQ": 1.0
+                                            "SUSEQ": 1.0,
+                                            "DOMAIN": "SU"
                                         }
                                     }
                                 ]
@@ -30245,8 +30245,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "STUDYID": "XYZ",
                                             "MHSEQ": 1.0,
+                                            "STUDYID": "XYZ",
                                             "DOMAIN": "MH"
                                         }
                                     }
@@ -30264,9 +30264,9 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
+                                            "LBSEQ": 1.0,
                                             "DOMAIN": "LB",
-                                            "STUDYID": "XYZ",
-                                            "LBSEQ": 1.0
+                                            "STUDYID": "XYZ"
                                         }
                                     }
                                 ]
@@ -30283,9 +30283,9 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "RESEQ": 1.0,
+                                            "DOMAIN": "RE",
                                             "STUDYID": "XYZ",
-                                            "DOMAIN": "RE"
+                                            "RESEQ": 1.0
                                         }
                                     }
                                 ]
@@ -30558,8 +30558,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "STUDYID": "CDISCPILOT01",
                                             "TSSEQ": 1.0,
+                                            "STUDYID": "CDISCPILOT01",
                                             "DOMAIN": "TS"
                                         }
                                     }
@@ -30785,8 +30785,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "USUBJID": "CDISC002",
-                                            "DTHFL": null
+                                            "DTHFL": null,
+                                            "USUBJID": "CDISC002"
                                         }
                                     }
                                 ]
@@ -32308,8 +32308,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "CMOCCUR": null,
-                                            "CMPRESP": "Y"
+                                            "CMPRESP": "Y",
+                                            "CMOCCUR": null
                                         }
                                     }
                                 ]
@@ -32326,8 +32326,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "MHPRESP": "Y",
-                                            "MHOCCUR": null
+                                            "MHOCCUR": null,
+                                            "MHPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -32473,8 +32473,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-099-0000-00000",
                                         "value": {
-                                            "ARM": "IKd",
-                                            "ARMCD": null
+                                            "ARMCD": null,
+                                            "ARM": "IKd"
                                         }
                                     }
                                 ]
@@ -32735,8 +32735,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-099-0000-00003",
                                         "value": {
-                                            "ACTARMCD": "PLACEBO",
                                             "ARMCD": "IKD",
+                                            "ACTARMCD": "PLACEBO",
                                             "ARMNRS": "UNPLANNED TREATMENT"
                                         }
                                     }
@@ -32869,9 +32869,9 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-099-0000-00002",
                                         "value": {
-                                            "AGE": null,
+                                            "AGETXT": null,
                                             "AGEU": "YEARS",
-                                            "AGETXT": null
+                                            "AGE": null
                                         }
                                     }
                                 ]
@@ -32965,8 +32965,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-099-0000-00000",
                                         "value": {
-                                            "AGE": null,
                                             "AGEU": "YEARS",
+                                            "AGE": null,
                                             "AGETXT": "Not in dataset"
                                         }
                                     },
@@ -32975,8 +32975,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-099-0000-00001",
                                         "value": {
-                                            "AGE": null,
                                             "AGEU": "YEARS",
+                                            "AGE": null,
                                             "AGETXT": "Not in dataset"
                                         }
                                     },
@@ -32985,8 +32985,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-099-0000-00002",
                                         "value": {
-                                            "AGE": null,
                                             "AGEU": "YEARS",
+                                            "AGE": null,
                                             "AGETXT": "Not in dataset"
                                         }
                                     },
@@ -32995,8 +32995,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-099-0000-00003",
                                         "value": {
-                                            "AGE": null,
                                             "AGEU": "YEARS",
+                                            "AGE": null,
                                             "AGETXT": "Not in dataset"
                                         }
                                     }
@@ -34336,8 +34336,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "LBSTRESU": "mg/L",
-                                            "LBSTRESC": null
+                                            "LBSTRESC": null,
+                                            "LBSTRESU": "mg/L"
                                         }
                                     }
                                 ]
@@ -34568,10 +34568,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "1"
+                                            "IDVARVAL": "1",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34579,10 +34579,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "10"
+                                            "IDVARVAL": "10",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34590,10 +34590,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "11"
+                                            "IDVARVAL": "11",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34601,10 +34601,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "12"
+                                            "IDVARVAL": "12",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34612,10 +34612,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "13"
+                                            "IDVARVAL": "13",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34623,10 +34623,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "14"
+                                            "IDVARVAL": "14",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34634,10 +34634,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "15"
+                                            "IDVARVAL": "15",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34645,10 +34645,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "2"
+                                            "IDVARVAL": "2",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34656,10 +34656,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "3"
+                                            "IDVARVAL": "3",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34667,10 +34667,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "DICTVER",
-                                            "IDVAR": null,
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "4"
+                                            "IDVARVAL": "4",
+                                            "QNAM": "DICTVER",
+                                            "IDVAR": null
                                         }
                                     }
                                 ]
@@ -34801,10 +34801,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "QNAM": "ECREASOC",
-                                            "IDVAR": null,
                                             "RDOMAIN": "EC",
-                                            "IDVARVAL": "122"
+                                            "IDVARVAL": "122",
+                                            "QNAM": "ECREASOC",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34812,10 +34812,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "QNAM": "ECREASOC",
-                                            "IDVAR": null,
                                             "RDOMAIN": "EC",
-                                            "IDVARVAL": "123"
+                                            "IDVARVAL": "123",
+                                            "QNAM": "ECREASOC",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34823,10 +34823,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "QNAM": "ECREASOC",
-                                            "IDVAR": null,
                                             "RDOMAIN": "EC",
-                                            "IDVARVAL": "124"
+                                            "IDVARVAL": "124",
+                                            "QNAM": "ECREASOC",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34834,10 +34834,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "QNAM": "ECREASOC",
-                                            "IDVAR": null,
                                             "RDOMAIN": "EC",
-                                            "IDVARVAL": "125"
+                                            "IDVARVAL": "125",
+                                            "QNAM": "ECREASOC",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34845,10 +34845,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "QNAM": "ECREASOC",
-                                            "IDVAR": null,
                                             "RDOMAIN": "EC",
-                                            "IDVARVAL": "126"
+                                            "IDVARVAL": "126",
+                                            "QNAM": "ECREASOC",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34856,10 +34856,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "QNAM": "ECREASOC",
-                                            "IDVAR": null,
                                             "RDOMAIN": "EC",
-                                            "IDVARVAL": "127"
+                                            "IDVARVAL": "127",
+                                            "QNAM": "ECREASOC",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -34867,10 +34867,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "QNAM": "ECREASOC",
-                                            "IDVAR": null,
                                             "RDOMAIN": "EC",
-                                            "IDVARVAL": "128"
+                                            "IDVARVAL": "128",
+                                            "QNAM": "ECREASOC",
+                                            "IDVAR": null
                                         }
                                     }
                                 ]
@@ -35135,9 +35135,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35145,9 +35145,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35155,9 +35155,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35165,9 +35165,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35175,9 +35175,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35185,9 +35185,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35195,9 +35195,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35205,9 +35205,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35215,9 +35215,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35225,9 +35225,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "DICTVER",
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "AESEQ"
                                         }
                                     }
                                 ]
@@ -35351,9 +35351,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "ECREASOC",
-                                            "IDVAR": "ECSEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "ECSEQ"
                                         }
                                     },
                                     {
@@ -35361,9 +35361,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "ECREASOC",
-                                            "IDVAR": "ECSEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "ECSEQ"
                                         }
                                     },
                                     {
@@ -35371,9 +35371,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "ECREASOC",
-                                            "IDVAR": "ECSEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "ECSEQ"
                                         }
                                     },
                                     {
@@ -35381,9 +35381,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "ECREASOC",
-                                            "IDVAR": "ECSEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "ECSEQ"
                                         }
                                     },
                                     {
@@ -35391,9 +35391,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "ECREASOC",
-                                            "IDVAR": "ECSEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "ECSEQ"
                                         }
                                     },
                                     {
@@ -35401,9 +35401,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "ECREASOC",
-                                            "IDVAR": "ECSEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "ECSEQ"
                                         }
                                     },
                                     {
@@ -35411,9 +35411,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "ECREASOC",
-                                            "IDVAR": "ECSEQ",
-                                            "IDVARVAL": null
+                                            "IDVAR": "ECSEQ"
                                         }
                                     }
                                 ]
@@ -35655,10 +35655,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IDVAR": "DDSEQ",
-                                            "IDVARVAL": null,
                                             "RDOMAIN": "DD",
-                                            "RELID": "AEDD"
+                                            "IDVARVAL": null,
+                                            "RELID": "AEDD",
+                                            "IDVAR": "DDSEQ"
                                         }
                                     },
                                     {
@@ -35666,10 +35666,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null,
                                             "RDOMAIN": "AE",
-                                            "RELID": "AEFA"
+                                            "IDVARVAL": null,
+                                            "RELID": "AEFA",
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35677,10 +35677,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IDVAR": "FASEQ",
-                                            "IDVARVAL": null,
                                             "RDOMAIN": "FA",
-                                            "RELID": "AEFA"
+                                            "IDVARVAL": null,
+                                            "RELID": "AEFA",
+                                            "IDVAR": "FASEQ"
                                         }
                                     },
                                     {
@@ -35688,10 +35688,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null,
                                             "RDOMAIN": "AE",
-                                            "RELID": "AECM1"
+                                            "IDVARVAL": null,
+                                            "RELID": "AECM1",
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35699,10 +35699,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IDVAR": "CMSEQ",
-                                            "IDVARVAL": null,
                                             "RDOMAIN": "AE",
-                                            "RELID": "AECM1"
+                                            "IDVARVAL": null,
+                                            "RELID": "AECM1",
+                                            "IDVAR": "CMSEQ"
                                         }
                                     },
                                     {
@@ -35710,10 +35710,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IDVAR": "AESEQ",
-                                            "IDVARVAL": null,
                                             "RDOMAIN": "AE",
-                                            "RELID": "AEMH1"
+                                            "IDVARVAL": null,
+                                            "RELID": "AEMH1",
+                                            "IDVAR": "AESEQ"
                                         }
                                     },
                                     {
@@ -35721,10 +35721,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IDVAR": "MHSEQ",
-                                            "IDVARVAL": null,
                                             "RDOMAIN": "AE",
-                                            "RELID": "AEMH1"
+                                            "IDVARVAL": null,
+                                            "RELID": "AEMH1",
+                                            "IDVAR": "MHSEQ"
                                         }
                                     }
                                 ]
@@ -35895,10 +35895,10 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "ECDOSE": -1.0,
-                                            "ECSTAT": null,
+                                            "ECSTDTC": "2012-12-28",
                                             "ECOCCUR": "Y",
                                             "ECDOSTXT": null,
-                                            "ECSTDTC": "2012-12-28"
+                                            "ECSTAT": null
                                         }
                                     },
                                     {
@@ -35907,10 +35907,10 @@
                                         "USUBJID": "CDISC008",
                                         "value": {
                                             "ECDOSE": 0.0,
-                                            "ECSTAT": null,
+                                            "ECSTDTC": "2014-09-11",
                                             "ECOCCUR": "Y",
                                             "ECDOSTXT": null,
-                                            "ECSTDTC": "2014-09-11"
+                                            "ECSTAT": null
                                         }
                                     },
                                     {
@@ -35919,10 +35919,10 @@
                                         "USUBJID": "CDISC008",
                                         "value": {
                                             "ECDOSE": 0.0,
-                                            "ECSTAT": null,
+                                            "ECSTDTC": "2014-09-13",
                                             "ECOCCUR": "Y",
                                             "ECDOSTXT": null,
-                                            "ECSTDTC": "2014-09-13"
+                                            "ECSTAT": null
                                         }
                                     },
                                     {
@@ -35931,10 +35931,10 @@
                                         "USUBJID": "CDISC008",
                                         "value": {
                                             "ECDOSE": -5.0,
-                                            "ECSTAT": null,
+                                            "ECSTDTC": "2014-09-14",
                                             "ECOCCUR": null,
                                             "ECDOSTXT": null,
-                                            "ECSTDTC": "2014-09-14"
+                                            "ECSTAT": null
                                         }
                                     }
                                 ]
@@ -36464,9 +36464,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
+                                            "EXENDY": 1.0,
                                             "EXENDTC": "2012-11-30",
-                                            "EXENDY": 1.0
+                                            "RFSTDTC": "2012-11"
                                         }
                                     },
                                     {
@@ -36474,9 +36474,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
+                                            "EXENDY": 2.0,
                                             "EXENDTC": "2012-12-01",
-                                            "EXENDY": 2.0
+                                            "RFSTDTC": "2012-11"
                                         }
                                     },
                                     {
@@ -36484,9 +36484,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
+                                            "EXENDY": 3.0,
                                             "EXENDTC": "2012-12-02",
-                                            "EXENDY": 3.0
+                                            "RFSTDTC": "2012-11"
                                         }
                                     },
                                     {
@@ -36494,9 +36494,9 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
+                                            "EXENDY": 4.0,
                                             "EXENDTC": "2012-12-03",
-                                            "EXENDY": 4.0
+                                            "RFSTDTC": "2012-11"
                                         }
                                     },
                                     {
@@ -36504,9 +36504,9 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
+                                            "EXENDY": 5.0,
                                             "EXENDTC": "2012-12-04",
-                                            "EXENDY": 5.0
+                                            "RFSTDTC": "2012-11"
                                         }
                                     },
                                     {
@@ -36514,9 +36514,9 @@
                                         "SEQ": 6,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
+                                            "EXENDY": 6.0,
                                             "EXENDTC": "2012-12-05",
-                                            "EXENDY": 6.0
+                                            "RFSTDTC": "2012-11"
                                         }
                                     },
                                     {
@@ -36524,9 +36524,9 @@
                                         "SEQ": 7,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
+                                            "EXENDY": 7.0,
                                             "EXENDTC": "2012-12-06",
-                                            "EXENDY": 7.0
+                                            "RFSTDTC": "2012-11"
                                         }
                                     },
                                     {
@@ -36534,9 +36534,9 @@
                                         "SEQ": 8,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
+                                            "EXENDY": 8.0,
                                             "EXENDTC": "2012-12-07",
-                                            "EXENDY": 8.0
+                                            "RFSTDTC": "2012-11"
                                         }
                                     },
                                     {
@@ -36544,9 +36544,9 @@
                                         "SEQ": 9,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
+                                            "EXENDY": 9.0,
                                             "EXENDTC": "2012-12-08",
-                                            "EXENDY": 9.0
+                                            "RFSTDTC": "2012-11"
                                         }
                                     }
                                 ]
@@ -37691,11 +37691,11 @@
                                         "SEQ": 120,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "VISITNUM": 2.0,
                                             "FTTPTNUM": 1.0,
                                             "FTTPT": "30 MIN POST",
                                             "DOMAIN": "FT",
-                                            "FTELTM": "PT30M",
-                                            "VISITNUM": 2.0
+                                            "FTELTM": "PT30M"
                                         }
                                     },
                                     {
@@ -37703,11 +37703,11 @@
                                         "SEQ": 121,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "VISITNUM": 2.0,
                                             "FTTPTNUM": 1.0,
                                             "FTTPT": "30 MIN POST",
                                             "DOMAIN": "FT",
-                                            "FTELTM": "PT03M",
-                                            "VISITNUM": 2.0
+                                            "FTELTM": "PT03M"
                                         }
                                     },
                                     {
@@ -37715,11 +37715,11 @@
                                         "SEQ": 134,
                                         "USUBJID": "CDISC007",
                                         "value": {
+                                            "VISITNUM": 201.0,
                                             "FTTPTNUM": 2.0,
                                             "FTTPT": "90 MIN POST",
                                             "DOMAIN": "FT",
-                                            "FTELTM": "PT1H",
-                                            "VISITNUM": 201.0
+                                            "FTELTM": "PT1H"
                                         }
                                     },
                                     {
@@ -37727,11 +37727,11 @@
                                         "SEQ": 135,
                                         "USUBJID": "CDISC007",
                                         "value": {
+                                            "VISITNUM": 201.0,
                                             "FTTPTNUM": 2.0,
                                             "FTTPT": "90 MIN POST",
                                             "DOMAIN": "FT",
-                                            "FTELTM": "PT2H",
-                                            "VISITNUM": 201.0
+                                            "FTELTM": "PT2H"
                                         }
                                     }
                                 ]
@@ -37833,11 +37833,11 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "DOMAIN": "VS",
-                                            "VSTPTNUM": "14",
-                                            "VSTPT": "4H PREDOSE",
                                             "VSELTM": "-PT4H",
-                                            "VISITNUM": null
+                                            "VISITNUM": null,
+                                            "DOMAIN": "VS",
+                                            "VSTPT": "4H PREDOSE",
+                                            "VSTPTNUM": "14"
                                         }
                                     },
                                     {
@@ -37845,11 +37845,11 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "DOMAIN": "VS",
-                                            "VSTPTNUM": "14",
-                                            "VSTPT": "4H PREDOSE",
                                             "VSELTM": "PT4H",
-                                            "VISITNUM": null
+                                            "VISITNUM": null,
+                                            "DOMAIN": "VS",
+                                            "VSTPT": "4H PREDOSE",
+                                            "VSTPTNUM": "14"
                                         }
                                     },
                                     {
@@ -37857,11 +37857,11 @@
                                         "SEQ": 6,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "DOMAIN": "VS",
-                                            "VSTPTNUM": "110",
-                                            "VSTPT": "10MIN POSTDOSE",
                                             "VSELTM": "10",
-                                            "VISITNUM": 4.0
+                                            "VISITNUM": 4.0,
+                                            "DOMAIN": "VS",
+                                            "VSTPT": "10MIN POSTDOSE",
+                                            "VSTPTNUM": "110"
                                         }
                                     },
                                     {
@@ -37869,11 +37869,11 @@
                                         "SEQ": 7,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "DOMAIN": "VS",
-                                            "VSTPTNUM": "110",
-                                            "VSTPT": "10MIN POSTDOSE",
                                             "VSELTM": "11",
-                                            "VISITNUM": 4.0
+                                            "VISITNUM": 4.0,
+                                            "DOMAIN": "VS",
+                                            "VSTPT": "10MIN POSTDOSE",
+                                            "VSTPTNUM": "110"
                                         }
                                     }
                                 ]
@@ -38621,8 +38621,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TAETORD": 2.0,
-                                            "ARM": "Placebo"
+                                            "ARM": "Placebo",
+                                            "TAETORD": 2.0
                                         }
                                     },
                                     {
@@ -38630,8 +38630,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TAETORD": 2.0,
-                                            "ARM": "Placebo"
+                                            "ARM": "Placebo",
+                                            "TAETORD": 2.0
                                         }
                                     },
                                     {
@@ -38639,8 +38639,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TAETORD": 1.0,
-                                            "ARM": "Zanomaline Low Dose (54 mg)"
+                                            "ARM": "Zanomaline Low Dose (54 mg)",
+                                            "TAETORD": 1.0
                                         }
                                     },
                                     {
@@ -38648,8 +38648,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TAETORD": 1.0,
-                                            "ARM": "Zanomaline Low Dose (54 mg)"
+                                            "ARM": "Zanomaline Low Dose (54 mg)",
+                                            "TAETORD": 1.0
                                         }
                                     },
                                     {
@@ -38657,8 +38657,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TAETORD": 3.0,
-                                            "ARM": "Zanomaline High Dose (81 mg)"
+                                            "ARM": "Zanomaline High Dose (81 mg)",
+                                            "TAETORD": 3.0
                                         }
                                     },
                                     {
@@ -38666,8 +38666,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TAETORD": 3.0,
-                                            "ARM": "Zanomaline High Dose (81 mg)"
+                                            "ARM": "Zanomaline High Dose (81 mg)",
+                                            "TAETORD": 3.0
                                         }
                                     }
                                 ]
@@ -39901,8 +39901,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "N",
-                                            "TSVALCD": "C49487"
+                                            "TSVALCD": "C49487",
+                                            "TSVAL": "N"
                                         }
                                     },
                                     {
@@ -39910,8 +39910,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "N",
-                                            "TSVALCD": "C49488"
+                                            "TSVALCD": "C49488",
+                                            "TSVAL": "N"
                                         }
                                     },
                                     {
@@ -39919,8 +39919,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "N",
-                                            "TSVALCD": "C49487"
+                                            "TSVALCD": "C49487",
+                                            "TSVAL": "N"
                                         }
                                     },
                                     {
@@ -39928,8 +39928,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Y",
-                                            "TSVALCD": "C49488"
+                                            "TSVALCD": "C49488",
+                                            "TSVAL": "Y"
                                         }
                                     }
                                 ]
@@ -40288,8 +40288,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "DOSE",
-                                            "TSSEQ": 3.0
+                                            "TSSEQ": 3.0,
+                                            "TSPARMCD": "DOSE"
                                         }
                                     },
                                     {
@@ -40297,8 +40297,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "DOSE",
-                                            "TSSEQ": 3.0
+                                            "TSSEQ": 3.0,
+                                            "TSPARMCD": "DOSE"
                                         }
                                     },
                                     {
@@ -40306,8 +40306,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "OUTMSPRI",
-                                            "TSSEQ": 1.0
+                                            "TSSEQ": 1.0,
+                                            "TSPARMCD": "OUTMSPRI"
                                         }
                                     },
                                     {
@@ -40315,8 +40315,8 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "OUTMSPRI",
-                                            "TSSEQ": 2.0
+                                            "TSSEQ": 2.0,
+                                            "TSPARMCD": "OUTMSPRI"
                                         }
                                     },
                                     {
@@ -40324,8 +40324,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "OUTMSPRI",
-                                            "TSSEQ": 1.0
+                                            "TSSEQ": 1.0,
+                                            "TSPARMCD": "OUTMSPRI"
                                         }
                                     },
                                     {
@@ -40333,8 +40333,8 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "OUTMSPRI",
-                                            "TSSEQ": 2.0
+                                            "TSSEQ": 2.0,
+                                            "TSPARMCD": "OUTMSPRI"
                                         }
                                     },
                                     {
@@ -40342,8 +40342,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "TTYPE",
-                                            "TSSEQ": 1.0
+                                            "TSSEQ": 1.0,
+                                            "TSPARMCD": "TTYPE"
                                         }
                                     },
                                     {
@@ -40351,8 +40351,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "TTYPE",
-                                            "TSSEQ": 1.0
+                                            "TSSEQ": 1.0,
+                                            "TSPARMCD": "TTYPE"
                                         }
                                     }
                                 ]
@@ -46511,8 +46511,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "SSDTC": "2021-03-12",
                                             "SSSTRESC": "DEAD",
+                                            "SSDTC": "2021-03-12",
                                             "$max_ds_dsstdtc": "2021-03-13"
                                         }
                                     },
@@ -46521,8 +46521,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "SSDTC": "2021-04-09",
                                             "SSSTRESC": "DEAD",
+                                            "SSDTC": "2021-04-09",
                                             "$max_ds_dsstdtc": "2021-05-09"
                                         }
                                     },
@@ -46531,8 +46531,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SSDTC": "2021-05-02",
                                             "SSSTRESC": "DEAD",
+                                            "SSDTC": "2021-05-02",
                                             "$max_ds_dsstdtc": "2021-06-01"
                                         }
                                     },
@@ -46541,8 +46541,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "SSDTC": "2021-08-13",
                                             "SSSTRESC": "DEAD",
+                                            "SSDTC": "2021-08-13",
                                             "$max_ds_dsstdtc": "2021-08-16"
                                         }
                                     }
@@ -48592,8 +48592,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48601,8 +48601,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48610,8 +48610,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48619,8 +48619,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48628,8 +48628,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48637,8 +48637,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48646,8 +48646,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48655,8 +48655,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48664,8 +48664,8 @@
                                         "SEQ": 7,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48673,8 +48673,8 @@
                                         "SEQ": 8,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48682,8 +48682,8 @@
                                         "SEQ": 9,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "AEBODSYS": "Apple",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Apple"
                                         }
                                     },
                                     {
@@ -48691,8 +48691,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48700,8 +48700,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48709,8 +48709,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48718,8 +48718,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48727,8 +48727,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48736,8 +48736,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48745,8 +48745,8 @@
                                         "SEQ": 7,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48754,8 +48754,8 @@
                                         "SEQ": 8,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48763,8 +48763,8 @@
                                         "SEQ": 9,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48772,8 +48772,8 @@
                                         "SEQ": 10,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48781,8 +48781,8 @@
                                         "SEQ": 11,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48790,8 +48790,8 @@
                                         "SEQ": 12,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48799,8 +48799,8 @@
                                         "SEQ": 13,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48808,8 +48808,8 @@
                                         "SEQ": 14,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48817,8 +48817,8 @@
                                         "SEQ": 15,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48826,8 +48826,8 @@
                                         "SEQ": 16,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48835,8 +48835,8 @@
                                         "SEQ": 17,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48844,8 +48844,8 @@
                                         "SEQ": 18,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48853,8 +48853,8 @@
                                         "SEQ": 19,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48862,8 +48862,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48871,8 +48871,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48880,8 +48880,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48889,8 +48889,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48898,8 +48898,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48907,8 +48907,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48916,8 +48916,8 @@
                                         "SEQ": 7,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AEBODSYS": "Blue",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Blue"
                                         }
                                     },
                                     {
@@ -48925,8 +48925,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -48934,8 +48934,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -48943,8 +48943,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -48952,8 +48952,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -48961,8 +48961,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -48970,8 +48970,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -48979,8 +48979,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -48988,8 +48988,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -48997,8 +48997,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC011",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49006,8 +49006,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC011",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49015,8 +49015,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC011",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49024,8 +49024,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC011",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49033,8 +49033,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49042,8 +49042,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC014",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49051,8 +49051,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC014",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49060,8 +49060,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49069,8 +49069,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49078,8 +49078,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49087,8 +49087,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49096,8 +49096,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49105,8 +49105,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49114,8 +49114,8 @@
                                         "SEQ": 7,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49123,8 +49123,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC017",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49132,8 +49132,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC017",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49141,8 +49141,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC017",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49150,8 +49150,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC017",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49159,8 +49159,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC017",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49168,8 +49168,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49177,8 +49177,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49186,8 +49186,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49195,8 +49195,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49204,8 +49204,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49213,8 +49213,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49222,8 +49222,8 @@
                                         "SEQ": 7,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49231,8 +49231,8 @@
                                         "SEQ": 8,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "A"
+                                            "AEBDSYCD": "A",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49240,8 +49240,8 @@
                                         "SEQ": 9,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "B"
+                                            "AEBDSYCD": "B",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     },
                                     {
@@ -49249,8 +49249,8 @@
                                         "SEQ": 10,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "AEBODSYS": "Carrot",
-                                            "AEBDSYCD": "C"
+                                            "AEBDSYCD": "C",
+                                            "AEBODSYS": "Carrot"
                                         }
                                     }
                                 ]
@@ -49849,8 +49849,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "AGE": 26.0,
-                                            "AGEU": null
+                                            "AGEU": null,
+                                            "AGE": 26.0
                                         }
                                     },
                                     {
@@ -49858,8 +49858,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-003",
                                         "value": {
-                                            "AGE": 57.0,
-                                            "AGEU": null
+                                            "AGEU": null,
+                                            "AGE": 57.0
                                         }
                                     },
                                     {
@@ -49867,8 +49867,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-005",
                                         "value": {
-                                            "AGE": 21.0,
-                                            "AGEU": null
+                                            "AGEU": null,
+                                            "AGE": 21.0
                                         }
                                     }
                                 ]
@@ -50007,8 +50007,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-002",
                                         "value": {
-                                            "AGE": null,
-                                            "AGEU": "YEARS"
+                                            "AGEU": "YEARS",
+                                            "AGE": null
                                         }
                                     },
                                     {
@@ -50016,8 +50016,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-004",
                                         "value": {
-                                            "AGE": null,
-                                            "AGEU": "YEARS"
+                                            "AGEU": "YEARS",
+                                            "AGE": null
                                         }
                                     }
                                 ]
@@ -50156,8 +50156,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFENDTC": null,
-                                            "ARM": "Zanomaline Low Dose (54 mg)"
+                                            "ARM": "Zanomaline Low Dose (54 mg)",
+                                            "RFENDTC": null
                                         }
                                     },
                                     {
@@ -50165,8 +50165,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "RFENDTC": null,
-                                            "ARM": "Zanomaline High Dose (100 mg)"
+                                            "ARM": "Zanomaline High Dose (100 mg)",
+                                            "RFENDTC": null
                                         }
                                     }
                                 ]
@@ -50304,8 +50304,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "RFENDTC": "2013-10-29",
-                                            "ARMNRS": "SCREEN FAILURE"
+                                            "ARMNRS": "SCREEN FAILURE",
+                                            "RFENDTC": "2013-10-29"
                                         }
                                     },
                                     {
@@ -50313,8 +50313,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "RFENDTC": "2014-03-18",
-                                            "ARMNRS": "ASSIGNED, NOT TREATED"
+                                            "ARMNRS": "ASSIGNED, NOT TREATED",
+                                            "RFENDTC": "2014-03-18"
                                         }
                                     }
                                 ]
@@ -53793,8 +53793,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AECAT": "INJECTION SITE REACTION",
-                                            "AEDECOD": "INJECTION SITE REACTION"
+                                            "AEDECOD": "INJECTION SITE REACTION",
+                                            "AECAT": "INJECTION SITE REACTION"
                                         }
                                     },
                                     {
@@ -53802,8 +53802,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AECAT": "INJECTION SITE REACTION",
-                                            "AEDECOD": "INJECTION SITE REACTION"
+                                            "AEDECOD": "INJECTION SITE REACTION",
+                                            "AECAT": "INJECTION SITE REACTION"
                                         }
                                     },
                                     {
@@ -53811,8 +53811,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AECAT": "INJECTION SITE REACTION",
-                                            "AEDECOD": "INJECTION SITE REACTION"
+                                            "AEDECOD": "INJECTION SITE REACTION",
+                                            "AECAT": "INJECTION SITE REACTION"
                                         }
                                     },
                                     {
@@ -53820,8 +53820,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AECAT": "CHEST DISCOMFORT",
-                                            "AEDECOD": "CHEST DISCOMFORT"
+                                            "AEDECOD": "CHEST DISCOMFORT",
+                                            "AECAT": "CHEST DISCOMFORT"
                                         }
                                     },
                                     {
@@ -53829,8 +53829,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AECAT": "HEADACHE",
-                                            "AEDECOD": "HEADACHE"
+                                            "AEDECOD": "HEADACHE",
+                                            "AECAT": "HEADACHE"
                                         }
                                     },
                                     {
@@ -53838,8 +53838,8 @@
                                         "SEQ": 7,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "AECAT": "COUGH",
-                                            "AEDECOD": "Cough"
+                                            "AEDECOD": "Cough",
+                                            "AECAT": "COUGH"
                                         }
                                     },
                                     {
@@ -53847,8 +53847,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "AECAT": "MYOCARDIAL INFARCTION",
-                                            "AEDECOD": "MYOCARDIAL INFARCTION"
+                                            "AEDECOD": "MYOCARDIAL INFARCTION",
+                                            "AECAT": "MYOCARDIAL INFARCTION"
                                         }
                                     },
                                     {
@@ -53856,8 +53856,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AECAT": "Paraesthesia Oral",
-                                            "AEDECOD": "PARAESTHESIA ORAL"
+                                            "AEDECOD": "PARAESTHESIA ORAL",
+                                            "AECAT": "Paraesthesia Oral"
                                         }
                                     },
                                     {
@@ -53865,8 +53865,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AECAT": "NASOPHARYNGITIS",
-                                            "AEDECOD": "NASOPHARYNGITIS"
+                                            "AEDECOD": "NASOPHARYNGITIS",
+                                            "AECAT": "NASOPHARYNGITIS"
                                         }
                                     },
                                     {
@@ -53874,8 +53874,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AECAT": "SUPRAVENTRICULAR EXTRASYSTOLES",
-                                            "AEDECOD": "SUPRAVENTRICULAR EXTRASYSTOLES"
+                                            "AEDECOD": "SUPRAVENTRICULAR EXTRASYSTOLES",
+                                            "AECAT": "SUPRAVENTRICULAR EXTRASYSTOLES"
                                         }
                                     },
                                     {
@@ -53883,8 +53883,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AECAT": "RASH PRURITIC",
-                                            "AEDECOD": "RASH PRURITIC"
+                                            "AEDECOD": "RASH PRURITIC",
+                                            "AECAT": "RASH PRURITIC"
                                         }
                                     },
                                     {
@@ -53892,8 +53892,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AECAT": "VENTRICULAR EXTRASYSTOLES",
-                                            "AEDECOD": "VENTRICULAR EXTRASYSTOLES"
+                                            "AEDECOD": "VENTRICULAR EXTRASYSTOLES",
+                                            "AECAT": "VENTRICULAR EXTRASYSTOLES"
                                         }
                                     },
                                     {
@@ -53901,8 +53901,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AECAT": "CONJUNCTIVAL HAEMORRHAGE",
-                                            "AEDECOD": "CONJUNCTIVAL HAEMORRHAGE"
+                                            "AEDECOD": "CONJUNCTIVAL HAEMORRHAGE",
+                                            "AECAT": "CONJUNCTIVAL HAEMORRHAGE"
                                         }
                                     },
                                     {
@@ -53910,8 +53910,8 @@
                                         "SEQ": 7,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "AECAT": "CERUMEN IMPACTION",
-                                            "AEDECOD": "Cerumen Impaction"
+                                            "AEDECOD": "Cerumen Impaction",
+                                            "AECAT": "CERUMEN IMPACTION"
                                         }
                                     }
                                 ]
@@ -54073,8 +54073,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "DSCAT": "INFORMED CONSENT OBTAINED",
-                                            "DSDECOD": "INFORMED CONSENT OBTAINED"
+                                            "DSDECOD": "INFORMED CONSENT OBTAINED",
+                                            "DSCAT": "INFORMED CONSENT OBTAINED"
                                         }
                                     },
                                     {
@@ -54082,8 +54082,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "DSCAT": "ADVERSE EVENT",
-                                            "DSDECOD": "ADVERSE EVENT"
+                                            "DSDECOD": "ADVERSE EVENT",
+                                            "DSCAT": "ADVERSE EVENT"
                                         }
                                     },
                                     {
@@ -54091,8 +54091,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "DSCAT": "DEATH",
-                                            "DSDECOD": "DEATH"
+                                            "DSDECOD": "DEATH",
+                                            "DSCAT": "DEATH"
                                         }
                                     },
                                     {
@@ -54100,8 +54100,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "DSCAT": "INFORMED CONSENT OBTAINED",
-                                            "DSDECOD": "INFORMED CONSENT OBTAINED"
+                                            "DSDECOD": "INFORMED CONSENT OBTAINED",
+                                            "DSCAT": "INFORMED CONSENT OBTAINED"
                                         }
                                     },
                                     {
@@ -54109,8 +54109,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "DSCAT": "WITHDRAWAL BY SUBJECT",
-                                            "DSDECOD": "WITHDRAWAL BY SUBJECT"
+                                            "DSDECOD": "WITHDRAWAL BY SUBJECT",
+                                            "DSCAT": "WITHDRAWAL BY SUBJECT"
                                         }
                                     },
                                     {
@@ -54118,8 +54118,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "DSCAT": "WITHDRAWAL BY SUBJECT",
-                                            "DSDECOD": "WITHDRAWAL BY SUBJECT"
+                                            "DSDECOD": "WITHDRAWAL BY SUBJECT",
+                                            "DSCAT": "WITHDRAWAL BY SUBJECT"
                                         }
                                     },
                                     {
@@ -54127,8 +54127,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC010",
                                         "value": {
-                                            "DSCAT": "PROTOCOL MILESTONE",
-                                            "DSDECOD": "PROTOCOL MILESTONE"
+                                            "DSDECOD": "PROTOCOL MILESTONE",
+                                            "DSCAT": "PROTOCOL MILESTONE"
                                         }
                                     },
                                     {
@@ -54136,8 +54136,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC010",
                                         "value": {
-                                            "DSCAT": "WITHDRAWAL BY SUBJECT",
-                                            "DSDECOD": "WITHDRAWAL BY SUBJECT"
+                                            "DSDECOD": "WITHDRAWAL BY SUBJECT",
+                                            "DSCAT": "WITHDRAWAL BY SUBJECT"
                                         }
                                     },
                                     {
@@ -54145,8 +54145,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC010",
                                         "value": {
-                                            "DSCAT": "Disposition Event",
-                                            "DSDECOD": "DISPOSITION EVENT"
+                                            "DSDECOD": "DISPOSITION EVENT",
+                                            "DSCAT": "Disposition Event"
                                         }
                                     },
                                     {
@@ -54154,8 +54154,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "DSCAT": "INFORMED CONSENT OBTAINED",
-                                            "DSDECOD": "INFORMED CONSENT OBTAINED"
+                                            "DSDECOD": "INFORMED CONSENT OBTAINED",
+                                            "DSCAT": "INFORMED CONSENT OBTAINED"
                                         }
                                     },
                                     {
@@ -54163,8 +54163,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "DSCAT": "DEATH",
-                                            "DSDECOD": "Death"
+                                            "DSDECOD": "Death",
+                                            "DSCAT": "DEATH"
                                         }
                                     },
                                     {
@@ -54172,8 +54172,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
-                                            "DSDECOD": "DISPOSITION EVENT"
+                                            "DSDECOD": "DISPOSITION EVENT",
+                                            "DSCAT": "DISPOSITION EVENT"
                                         }
                                     }
                                 ]
@@ -54407,9 +54407,9 @@
                                         "SEQ": 1593,
                                         "USUBJID": "CDISC-TEST-099",
                                         "value": {
+                                            "AEBODSYS": "Infections and infestations",
                                             "AECAT": "INFECTIONS AND INFESTATIONS",
-                                            "AETERM": "PNEUMONIA",
-                                            "AEBODSYS": "Infections and infestations"
+                                            "AETERM": "PNEUMONIA"
                                         }
                                     },
                                     {
@@ -54417,9 +54417,9 @@
                                         "SEQ": 1594,
                                         "USUBJID": "CDISC-TEST-099",
                                         "value": {
+                                            "AEBODSYS": "Infections and infestations",
                                             "AECAT": "INFECTIONS AND INFESTATIONS",
-                                            "AETERM": "PNEUMONIA",
-                                            "AEBODSYS": "Infections and infestations"
+                                            "AETERM": "PNEUMONIA"
                                         }
                                     },
                                     {
@@ -54427,9 +54427,9 @@
                                         "SEQ": 1595,
                                         "USUBJID": "CDISC-TEST-099",
                                         "value": {
+                                            "AEBODSYS": "INFECTIONS AND INFESTATIONS",
                                             "AECAT": "INFECTIONS AND INFESTATIONS",
-                                            "AETERM": "URINARY TRACT INFECTION",
-                                            "AEBODSYS": "INFECTIONS AND INFESTATIONS"
+                                            "AETERM": "URINARY TRACT INFECTION"
                                         }
                                     },
                                     {
@@ -54437,9 +54437,9 @@
                                         "SEQ": 1596,
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
+                                            "AEBODSYS": "Gastrointestinal disorders",
                                             "AECAT": "Gastrointestinal disorders",
-                                            "AETERM": "UPSET STOMACH",
-                                            "AEBODSYS": "Gastrointestinal disorders"
+                                            "AETERM": "UPSET STOMACH"
                                         }
                                     },
                                     {
@@ -54447,9 +54447,9 @@
                                         "SEQ": 1597,
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
+                                            "AEBODSYS": "Cardiac disorders",
                                             "AECAT": "CARDIAC DISORDERS",
-                                            "AETERM": "ATRIAL FIBRILLATION",
-                                            "AEBODSYS": "Cardiac disorders"
+                                            "AETERM": "ATRIAL FIBRILLATION"
                                         }
                                     },
                                     {
@@ -54457,9 +54457,9 @@
                                         "SEQ": 1598,
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
+                                            "AEBODSYS": "Musculoskeletal and connective tissue disorders",
                                             "AECAT": "MUSCULOSKELETAL AND CONNECTIVE TISSUE DISORDERS",
-                                            "AETERM": "BACK PAIN",
-                                            "AEBODSYS": "Musculoskeletal and connective tissue disorders"
+                                            "AETERM": "BACK PAIN"
                                         }
                                     },
                                     {
@@ -54467,9 +54467,9 @@
                                         "SEQ": 1599,
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
+                                            "AEBODSYS": "Musculoskeletal and connective tissue disorders",
                                             "AECAT": "MUSCULOSKELETAL AND CONNECTIVE TISSUE DISORDERS",
-                                            "AETERM": "BACK PAIN",
-                                            "AEBODSYS": "Musculoskeletal and connective tissue disorders"
+                                            "AETERM": "BACK PAIN"
                                         }
                                     }
                                 ]
@@ -54693,9 +54693,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54703,9 +54703,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54713,9 +54713,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54723,9 +54723,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "NEURODEGENERATIVE DISEASES",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54733,9 +54733,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54743,9 +54743,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54753,9 +54753,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54763,9 +54763,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "MHBODSYS": "NEURODEGENERATIVE DISEASES",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "NEURODEGENERATIVE DISEASES"
                                         }
                                     },
                                     {
@@ -54773,9 +54773,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54783,9 +54783,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC010",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54793,9 +54793,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC011",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54803,9 +54803,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC012",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54813,9 +54813,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54823,9 +54823,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC014",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54833,9 +54833,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54843,9 +54843,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC017",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -54853,9 +54853,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     }
                                 ]
@@ -55089,9 +55089,9 @@
                                         "SEQ": 1593,
                                         "USUBJID": "CDISC-TEST-099",
                                         "value": {
-                                            "AETERM": "PNEUMONIA",
+                                            "AESCAT": "INFECTIONS AND INFESTATIONS",
                                             "AEBODSYS": "Infections and infestations",
-                                            "AESCAT": "INFECTIONS AND INFESTATIONS"
+                                            "AETERM": "PNEUMONIA"
                                         }
                                     },
                                     {
@@ -55099,9 +55099,9 @@
                                         "SEQ": 1594,
                                         "USUBJID": "CDISC-TEST-099",
                                         "value": {
-                                            "AETERM": "PNEUMONIA",
+                                            "AESCAT": "INFECTIONS AND INFESTATIONS",
                                             "AEBODSYS": "Infections and infestations",
-                                            "AESCAT": "INFECTIONS AND INFESTATIONS"
+                                            "AETERM": "PNEUMONIA"
                                         }
                                     },
                                     {
@@ -55109,9 +55109,9 @@
                                         "SEQ": 1595,
                                         "USUBJID": "CDISC-TEST-099",
                                         "value": {
-                                            "AETERM": "URINARY TRACT INFECTION",
+                                            "AESCAT": "INFECTIONS AND INFESTATIONS",
                                             "AEBODSYS": "INFECTIONS AND INFESTATIONS",
-                                            "AESCAT": "INFECTIONS AND INFESTATIONS"
+                                            "AETERM": "URINARY TRACT INFECTION"
                                         }
                                     },
                                     {
@@ -55119,9 +55119,9 @@
                                         "SEQ": 1596,
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
-                                            "AETERM": "UPSET STOMACH",
+                                            "AESCAT": "Gastrointestinal disorders",
                                             "AEBODSYS": "Gastrointestinal disorders",
-                                            "AESCAT": "Gastrointestinal disorders"
+                                            "AETERM": "UPSET STOMACH"
                                         }
                                     },
                                     {
@@ -55129,9 +55129,9 @@
                                         "SEQ": 1597,
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
-                                            "AETERM": "ATRIAL FIBRILLATION",
+                                            "AESCAT": "CARDIAC DISORDERS",
                                             "AEBODSYS": "Cardiac disorders",
-                                            "AESCAT": "CARDIAC DISORDERS"
+                                            "AETERM": "ATRIAL FIBRILLATION"
                                         }
                                     },
                                     {
@@ -55139,9 +55139,9 @@
                                         "SEQ": 1598,
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
-                                            "AETERM": "BACK PAIN",
+                                            "AESCAT": "MUSCULOSKELETAL AND CONNECTIVE TISSUE DISORDERS",
                                             "AEBODSYS": "Musculoskeletal and connective tissue disorders",
-                                            "AESCAT": "MUSCULOSKELETAL AND CONNECTIVE TISSUE DISORDERS"
+                                            "AETERM": "BACK PAIN"
                                         }
                                     },
                                     {
@@ -55149,9 +55149,9 @@
                                         "SEQ": 1599,
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
-                                            "AETERM": "BACK PAIN",
+                                            "AESCAT": "MUSCULOSKELETAL AND CONNECTIVE TISSUE DISORDERS",
                                             "AEBODSYS": "Musculoskeletal and connective tissue disorders",
-                                            "AESCAT": "MUSCULOSKELETAL AND CONNECTIVE TISSUE DISORDERS"
+                                            "AETERM": "BACK PAIN"
                                         }
                                     }
                                 ]
@@ -55375,9 +55375,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55385,9 +55385,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55395,9 +55395,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55405,9 +55405,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "NEURODEGENERATIVE DISEASES",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55415,9 +55415,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55425,9 +55425,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55435,9 +55435,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55445,9 +55445,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "MHBODSYS": "NEURODEGENERATIVE DISEASES",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "NEURODEGENERATIVE DISEASES"
                                         }
                                     },
                                     {
@@ -55455,9 +55455,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55465,9 +55465,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC010",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55475,9 +55475,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC011",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55485,9 +55485,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC012",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55495,9 +55495,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55505,9 +55505,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC014",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55515,9 +55515,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55525,9 +55525,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC017",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -55535,9 +55535,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSCAT": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     }
                                 ]
@@ -56245,9 +56245,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBDRVFL": null,
+                                            "LBSTAT": null,
                                             "LBORRES": null,
-                                            "LBSTAT": null
+                                            "LBDRVFL": null
                                         }
                                     },
                                     {
@@ -56255,9 +56255,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBDRVFL": null,
+                                            "LBSTAT": null,
                                             "LBORRES": null,
-                                            "LBSTAT": null
+                                            "LBDRVFL": null
                                         }
                                     }
                                 ]
@@ -56331,8 +56331,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBDRVFL": null,
                                             "LBORRES": null,
+                                            "LBDRVFL": null,
                                             "LBSTAT": "Not in dataset"
                                         }
                                     },
@@ -56341,8 +56341,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBDRVFL": "N",
                                             "LBORRES": null,
+                                            "LBDRVFL": "N",
                                             "LBSTAT": "Not in dataset"
                                         }
                                     }
@@ -56417,8 +56417,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBORRES": null,
                                             "LBSTAT": null,
+                                            "LBORRES": null,
                                             "LBDRVFL": "Not in dataset"
                                         }
                                     },
@@ -56427,8 +56427,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBORRES": null,
                                             "LBSTAT": null,
+                                            "LBORRES": null,
                                             "LBDRVFL": "Not in dataset"
                                         }
                                     }
@@ -57065,8 +57065,8 @@
                                         "SEQ": null,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "IDVAR": "LBSEQ",
-                                            "RELTYPE": "ONE"
+                                            "RELTYPE": "ONE",
+                                            "IDVAR": "LBSEQ"
                                         }
                                     },
                                     {
@@ -57074,8 +57074,8 @@
                                         "SEQ": null,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "IDVAR": "LBSEQ",
-                                            "RELTYPE": "ONE"
+                                            "RELTYPE": "ONE",
+                                            "IDVAR": "LBSEQ"
                                         }
                                     }
                                 ]
@@ -57250,10 +57250,10 @@
                                         "SEQ": null,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "QNAM": "LBCLSIG",
                                             "IDVAR": "LBSEQ",
-                                            "USUBJID": "S001",
-                                            "IDVARVAL": "220"
+                                            "IDVARVAL": "220",
+                                            "QNAM": "LBCLSIG",
+                                            "USUBJID": "S001"
                                         }
                                     },
                                     {
@@ -57261,10 +57261,10 @@
                                         "SEQ": null,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "QNAM": "LBCLSIG",
                                             "IDVAR": "LBSEQ",
-                                            "USUBJID": "S001",
-                                            "IDVARVAL": "220"
+                                            "IDVARVAL": "220",
+                                            "QNAM": "LBCLSIG",
+                                            "USUBJID": "S001"
                                         }
                                     }
                                 ]
@@ -57281,10 +57281,10 @@
                                         "SEQ": null,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "QNAM": "RACEMLT",
                                             "IDVAR": null,
-                                            "USUBJID": "S001",
-                                            "IDVARVAL": null
+                                            "IDVARVAL": null,
+                                            "QNAM": "RACEMLT",
+                                            "USUBJID": "S001"
                                         }
                                     },
                                     {
@@ -57292,10 +57292,10 @@
                                         "SEQ": null,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "QNAM": "RACEMLT",
                                             "IDVAR": null,
-                                            "USUBJID": "S001",
-                                            "IDVARVAL": null
+                                            "IDVARVAL": null,
+                                            "QNAM": "RACEMLT",
+                                            "USUBJID": "S001"
                                         }
                                     }
                                 ]
@@ -57466,8 +57466,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "USUBJID": "CDISC001",
-                                            "VISITNUM": 1.0
+                                            "VISITNUM": 1.0,
+                                            "USUBJID": "CDISC001"
                                         }
                                     },
                                     {
@@ -57475,8 +57475,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "USUBJID": "CDISC001",
-                                            "VISITNUM": 1.0
+                                            "VISITNUM": 1.0,
+                                            "USUBJID": "CDISC001"
                                         }
                                     }
                                 ]
@@ -57704,9 +57704,9 @@
                                         "USUBJID": "S001",
                                         "value": {
                                             "IDVAR": "LBGRPID",
-                                            "USUBJID": "S001",
                                             "RDOMAIN": "LB",
-                                            "IDVARVAL": "20"
+                                            "IDVARVAL": "20",
+                                            "USUBJID": "S001"
                                         }
                                     }
                                 ]
@@ -57724,9 +57724,9 @@
                                         "USUBJID": "S001",
                                         "value": {
                                             "IDVAR": "LBSEQ",
-                                            "USUBJID": "S001",
                                             "RDOMAIN": "LB",
-                                            "IDVARVAL": "320"
+                                            "IDVARVAL": "320",
+                                            "USUBJID": "S001"
                                         }
                                     },
                                     {
@@ -57735,9 +57735,9 @@
                                         "USUBJID": "S001",
                                         "value": {
                                             "IDVAR": "AESEQ",
-                                            "USUBJID": "S001",
                                             "RDOMAIN": "AE",
-                                            "IDVARVAL": "2"
+                                            "IDVARVAL": "2",
+                                            "USUBJID": "S001"
                                         }
                                     }
                                 ]
@@ -57755,9 +57755,9 @@
                                         "USUBJID": "S001",
                                         "value": {
                                             "IDVAR": "LBSEQ",
-                                            "USUBJID": "S001",
                                             "RDOMAIN": "LB",
-                                            "IDVARVAL": "320"
+                                            "IDVARVAL": "320",
+                                            "USUBJID": "S001"
                                         }
                                     }
                                 ]
@@ -59253,8 +59253,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSSCAT": "STUDY PARTICIPATION",
-                                            "EPOCH": "TREATMENT"
+                                            "EPOCH": "TREATMENT",
+                                            "DSSCAT": "STUDY PARTICIPATION"
                                         }
                                     },
                                     {
@@ -59262,8 +59262,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSSCAT": "STUDY PARTICIPATION",
-                                            "EPOCH": "TREATMENT"
+                                            "EPOCH": "TREATMENT",
+                                            "DSSCAT": "STUDY PARTICIPATION"
                                         }
                                     }
                                 ]
@@ -59379,8 +59379,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "DSSCAT": "STUDY PARTICIPATION",
-                                            "EPOCH": "TREATMENT"
+                                            "EPOCH": "TREATMENT",
+                                            "DSSCAT": "STUDY PARTICIPATION"
                                         }
                                     },
                                     {
@@ -59388,8 +59388,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "DSSCAT": "STUDY PARTICIPATION",
-                                            "EPOCH": "TREATMENT"
+                                            "EPOCH": "TREATMENT",
+                                            "DSSCAT": "STUDY PARTICIPATION"
                                         }
                                     }
                                 ]
@@ -59577,10 +59577,10 @@
                                         "SEQ": 1,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
+                                            "EPOCH": "TREATMENT",
                                             "DSSCAT": "STUDY PARTICIPATION",
-                                            "USUBJID": "S001",
-                                            "EPOCH": "TREATMENT"
+                                            "DSCAT": "DISPOSITION EVENT",
+                                            "USUBJID": "S001"
                                         }
                                     },
                                     {
@@ -59588,10 +59588,10 @@
                                         "SEQ": 2,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
+                                            "EPOCH": "TREATMENT",
                                             "DSSCAT": "STUDY PARTICIPATION",
-                                            "USUBJID": "S001",
-                                            "EPOCH": "TREATMENT"
+                                            "DSCAT": "DISPOSITION EVENT",
+                                            "USUBJID": "S001"
                                         }
                                     }
                                 ]
@@ -59733,8 +59733,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
                                             "DSSCAT": "STUDY TREATMENT",
+                                            "DSCAT": "DISPOSITION EVENT",
                                             "USUBJID": "S001"
                                         }
                                     },
@@ -59743,8 +59743,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
                                             "DSSCAT": "STUDY TREATMENT",
+                                            "DSCAT": "DISPOSITION EVENT",
                                             "USUBJID": "S001"
                                         }
                                     }
@@ -60060,9 +60060,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "ECDOSE": null,
-                                            "ECSTAT": null,
                                             "ECOCCUR": "Y",
-                                            "ECDOSTXT": null
+                                            "ECDOSTXT": null,
+                                            "ECSTAT": null
                                         }
                                     }
                                 ]
@@ -60210,8 +60210,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "IDVAR": null,
-                                            "IDVARVAL": "122"
+                                            "IDVARVAL": "122",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -60219,8 +60219,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "IDVAR": null,
-                                            "IDVARVAL": "123"
+                                            "IDVARVAL": "123",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -60228,8 +60228,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "IDVAR": null,
-                                            "IDVARVAL": "124"
+                                            "IDVARVAL": "124",
+                                            "IDVAR": null
                                         }
                                     }
                                 ]
@@ -60301,8 +60301,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "IDVAR": null,
-                                            "IDVARVAL": "20"
+                                            "IDVARVAL": "20",
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -60310,8 +60310,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "IDVAR": null,
-                                            "IDVARVAL": "1"
+                                            "IDVARVAL": "1",
+                                            "IDVAR": null
                                         }
                                     }
                                 ]
@@ -61555,9 +61555,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "1",
                                             "QNAM": "DICTVERSION",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "1"
+                                            "IDVAR": "AESPID"
                                         }
                                     },
                                     {
@@ -61565,9 +61565,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "10",
                                             "QNAM": "DICTVERSION",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "10"
+                                            "IDVAR": "AESPID"
                                         }
                                     },
                                     {
@@ -61575,9 +61575,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "11",
                                             "QNAM": "1DICTV",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "11"
+                                            "IDVAR": "AESPID"
                                         }
                                     },
                                     {
@@ -61585,9 +61585,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "12",
                                             "QNAM": "dICTV",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "12"
+                                            "IDVAR": "AESPID"
                                         }
                                     },
                                     {
@@ -61595,9 +61595,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "13",
                                             "QNAM": "DI&ION",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "13"
+                                            "IDVAR": "AESPID"
                                         }
                                     },
                                     {
@@ -61605,9 +61605,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "14",
                                             "QNAM": "DICTVERSION",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "14"
+                                            "IDVAR": "AESPID"
                                         }
                                     },
                                     {
@@ -61615,9 +61615,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "15",
                                             "QNAM": "DICTVER'",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "15"
+                                            "IDVAR": "AESPID"
                                         }
                                     },
                                     {
@@ -61625,9 +61625,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "2",
                                             "QNAM": "DICTVERSION",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "2"
+                                            "IDVAR": "AESPID"
                                         }
                                     },
                                     {
@@ -61635,9 +61635,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "3",
                                             "QNAM": "DICTVERSION",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "3"
+                                            "IDVAR": "AESPID"
                                         }
                                     },
                                     {
@@ -61645,9 +61645,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "IDVARVAL": "4",
                                             "QNAM": "DICTVERSION",
-                                            "IDVAR": "AESPID",
-                                            "IDVARVAL": "4"
+                                            "IDVAR": "AESPID"
                                         }
                                     }
                                 ]
@@ -61741,9 +61741,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC006",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "RACE11111",
-                                            "IDVAR": null,
-                                            "IDVARVAL": null
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -61751,9 +61751,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC007",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "RaCE22",
-                                            "IDVAR": null,
-                                            "IDVARVAL": null
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -61761,9 +61761,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC008",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "RACE@3",
-                                            "IDVAR": null,
-                                            "IDVARVAL": null
+                                            "IDVAR": null
                                         }
                                     },
                                     {
@@ -61771,9 +61771,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
+                                            "IDVARVAL": null,
                                             "QNAM": "1RACE",
-                                            "IDVAR": null,
-                                            "IDVARVAL": null
+                                            "IDVAR": null
                                         }
                                     }
                                 ]
@@ -62038,8 +62038,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "1"
+                                            "IDVARVAL": "1",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     },
                                     {
@@ -62048,8 +62048,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "10"
+                                            "IDVARVAL": "10",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     },
                                     {
@@ -62058,8 +62058,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "11"
+                                            "IDVARVAL": "11",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     },
                                     {
@@ -62068,8 +62068,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "12"
+                                            "IDVARVAL": "12",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     },
                                     {
@@ -62078,8 +62078,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "13"
+                                            "IDVARVAL": "13",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     },
                                     {
@@ -62088,8 +62088,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "14"
+                                            "IDVARVAL": "14",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     },
                                     {
@@ -62098,8 +62098,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "15"
+                                            "IDVARVAL": "15",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     },
                                     {
@@ -62108,8 +62108,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "2"
+                                            "IDVARVAL": "2",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     },
                                     {
@@ -62118,8 +62118,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "3"
+                                            "IDVARVAL": "3",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     },
                                     {
@@ -62128,8 +62128,8 @@
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
                                             "IDVAR": "AESPID",
-                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study",
-                                            "IDVARVAL": "4"
+                                            "IDVARVAL": "4",
+                                            "QLABEL": "This is the wrongly used Dictionary Version in this Study"
                                         }
                                     }
                                 ]
@@ -62214,8 +62214,8 @@
                                         "USUBJID": "CDISC008",
                                         "value": {
                                             "IDVAR": null,
-                                            "QLABEL": "Race 1Race 1Race 1Race 1Race 1Race 1vRace 1Race 1Race 1Race 1Race 1Race 1vvvRace 1Race 1Race 1vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv",
-                                            "IDVARVAL": null
+                                            "IDVARVAL": null,
+                                            "QLABEL": "Race 1Race 1Race 1Race 1Race 1Race 1vRace 1Race 1Race 1Race 1Race 1Race 1vvvRace 1Race 1Race 1vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"
                                         }
                                     },
                                     {
@@ -62224,8 +62224,8 @@
                                         "USUBJID": "CDISC008",
                                         "value": {
                                             "IDVAR": null,
-                                            "QLABEL": "Race 22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
-                                            "IDVARVAL": null
+                                            "IDVARVAL": null,
+                                            "QLABEL": "Race 22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
                                         }
                                     },
                                     {
@@ -62234,8 +62234,8 @@
                                         "USUBJID": "CDISC008",
                                         "value": {
                                             "IDVAR": null,
-                                            "QLABEL": "Race 3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
-                                            "IDVARVAL": null
+                                            "IDVARVAL": null,
+                                            "QLABEL": "Race 3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333"
                                         }
                                     }
                                 ]
@@ -62804,8 +62804,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "CMSTAT": "Not Done",
-                                            "CMREASND": "Subject's Decision"
+                                            "CMREASND": "Subject's Decision",
+                                            "CMSTAT": "Not Done"
                                         }
                                     }
                                 ]
@@ -63470,8 +63470,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-001",
                                         "value": {
-                                            "USUBJID": "HEM021-001",
-                                            "POOLID": "HEM021-001"
+                                            "POOLID": "HEM021-001",
+                                            "USUBJID": "HEM021-001"
                                         }
                                     },
                                     {
@@ -63479,8 +63479,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-001",
                                         "value": {
-                                            "USUBJID": "HEM021-001",
-                                            "POOLID": "HEM021-001"
+                                            "POOLID": "HEM021-001",
+                                            "USUBJID": "HEM021-001"
                                         }
                                     },
                                     {
@@ -63488,8 +63488,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-002",
                                         "value": {
-                                            "USUBJID": "HEM021-002",
-                                            "POOLID": "HEM021-002"
+                                            "POOLID": "HEM021-002",
+                                            "USUBJID": "HEM021-002"
                                         }
                                     },
                                     {
@@ -63497,8 +63497,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-002",
                                         "value": {
-                                            "USUBJID": "HEM021-002",
-                                            "POOLID": "HEM021-002"
+                                            "POOLID": "HEM021-002",
+                                            "USUBJID": "HEM021-002"
                                         }
                                     },
                                     {
@@ -63506,8 +63506,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-003",
                                         "value": {
-                                            "USUBJID": "HEM021-003",
-                                            "POOLID": "HEM021-003"
+                                            "POOLID": "HEM021-003",
+                                            "USUBJID": "HEM021-003"
                                         }
                                     },
                                     {
@@ -63515,8 +63515,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-003",
                                         "value": {
-                                            "USUBJID": "HEM021-003",
-                                            "POOLID": "HEM021-003"
+                                            "POOLID": "HEM021-003",
+                                            "USUBJID": "HEM021-003"
                                         }
                                     }
                                 ]
@@ -63673,8 +63673,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-001",
                                         "value": {
-                                            "USUBJID": "HEM021-001",
-                                            "RSUBJID": "HEM021-001"
+                                            "RSUBJID": "HEM021-001",
+                                            "USUBJID": "HEM021-001"
                                         }
                                     },
                                     {
@@ -63682,8 +63682,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-002",
                                         "value": {
-                                            "USUBJID": "HEM021-002",
-                                            "RSUBJID": "HEM021-002"
+                                            "RSUBJID": "HEM021-002",
+                                            "USUBJID": "HEM021-002"
                                         }
                                     },
                                     {
@@ -63691,8 +63691,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-003",
                                         "value": {
-                                            "USUBJID": "HEM021-003",
-                                            "RSUBJID": "HEM021-003"
+                                            "RSUBJID": "HEM021-003",
+                                            "USUBJID": "HEM021-003"
                                         }
                                     },
                                     {
@@ -63700,8 +63700,8 @@
                                         "SEQ": null,
                                         "USUBJID": "HEM021-004",
                                         "value": {
-                                            "USUBJID": "HEM021-004",
-                                            "RSUBJID": "HEM021-004"
+                                            "RSUBJID": "HEM021-004",
+                                            "USUBJID": "HEM021-004"
                                         }
                                     }
                                 ]
@@ -64049,8 +64049,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "RDEVID": "AB0001",
-                                            "RSUBJID": "HEM021-002"
+                                            "RSUBJID": "HEM021-002",
+                                            "RDEVID": "AB0001"
                                         }
                                     }
                                 ]
@@ -64067,8 +64067,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "RDEVID": "ABCD001",
-                                            "RSUBJID": "GRNMO13"
+                                            "RSUBJID": "GRNMO13",
+                                            "RDEVID": "ABCD001"
                                         }
                                     }
                                 ]
@@ -64239,8 +64239,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "RDEVID": "Device X",
-                                            "RSUBJID": "HEM021-001"
+                                            "RSUBJID": "HEM021-001",
+                                            "RDEVID": "Device X"
                                         }
                                     }
                                 ]
@@ -64257,8 +64257,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "RDEVID": "CK001",
-                                            "RSUBJID": "CK001"
+                                            "RSUBJID": "CK001",
+                                            "RDEVID": "CK001"
                                         }
                                     }
                                 ]
@@ -64414,9 +64414,9 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "USUBJID": null,
                                             "RSUBJID": "CDISC-TEST-001",
-                                            "POOLID": null
+                                            "POOLID": null,
+                                            "USUBJID": null
                                         }
                                     }
                                 ]
@@ -64769,8 +64769,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "123101",
                                         "value": {
-                                            "AECAT": "TEST CATEGORY",
-                                            "AESCAT": "TEST CATEGORY"
+                                            "AESCAT": "TEST CATEGORY",
+                                            "AECAT": "TEST CATEGORY"
                                         }
                                     }
                                 ]
@@ -66442,8 +66442,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "LBTPTREF": null,
-                                            "LBRFTDTC": "2019-03-12T10:00"
+                                            "LBRFTDTC": "2019-03-12T10:00",
+                                            "LBTPTREF": null
                                         }
                                     },
                                     {
@@ -66451,8 +66451,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "LBTPTREF": null,
-                                            "LBRFTDTC": "2019-03-12T10:00"
+                                            "LBRFTDTC": "2019-03-12T10:00",
+                                            "LBTPTREF": null
                                         }
                                     }
                                 ]
@@ -70768,27 +70768,13 @@
                             {
                                 "dataset": "ss.xpt",
                                 "domain": "SS",
-                                "execution_status": "success",
-                                "execution_message": "DSDECOD is not \"DEATH\", When SS.SSSTRESC = \"DEAD\".",
-                                "number_errors": 2,
+                                "execution_status": "execution_error",
+                                "execution_message": "SQL operator execution error",
+                                "number_errors": 1,
                                 "errors": [
                                     {
-                                        "row": 2,
-                                        "SEQ": 2,
-                                        "USUBJID": "015246-076-0003-00003",
-                                        "value": {
-                                            "SSSTRESC": "DEAD",
-                                            "$ds_dsdecod": "ADVERSE EVENT"
-                                        }
-                                    },
-                                    {
-                                        "row": 4,
-                                        "SEQ": 2,
-                                        "USUBJID": "015246-300-0004-00002",
-                                        "value": {
-                                            "SSSTRESC": "DEAD",
-                                            "$ds_dsdecod": "ADVERSE EVENT"
-                                        }
+                                        "error": "SQL error in does_not_contain operator",
+                                        "message": "ContainsOperator._handle_target_is_collection() missing 1 required positional argument: 'value_is_literal'"
                                     }
                                 ]
                             }
@@ -70816,7 +70802,6 @@
                                         "SEQ": 2,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "SSSTRESC": "DEAD",
                                             "$ds_dsdecod": [
                                                 "ADVERSE EVENT",
                                                 "ALIVE",
@@ -70825,7 +70810,8 @@
                                                 "LAST CONTACT",
                                                 "PROGRESSIVE DISEASE",
                                                 "RANDOMIZED"
-                                            ]
+                                            ],
+                                            "SSSTRESC": "DEAD"
                                         }
                                     },
                                     {
@@ -70833,7 +70819,6 @@
                                         "SEQ": 2,
                                         "USUBJID": "015246-300-0004-00002",
                                         "value": {
-                                            "SSSTRESC": "DEAD",
                                             "$ds_dsdecod": [
                                                 "ADVERSE EVENT",
                                                 "ALIVE",
@@ -70841,7 +70826,8 @@
                                                 "INFORMED CONSENT OBTAINED",
                                                 "LAST CONTACT",
                                                 "RANDOMIZED"
-                                            ]
+                                            ],
+                                            "SSSTRESC": "DEAD"
                                         }
                                     }
                                 ]
@@ -70849,72 +70835,12 @@
                         ],
                         "old_vs_sql": {
                             "dataset_mismatch": false,
-                            "execution_status_mismatch": false,
+                            "execution_status_mismatch": true,
                             "number_of_errors_mismatch": false,
-                            "diff": {
-                                "ss.xpt": {
-                                    "values_changed": {
-                                        "root[0]": {
-                                            "new_value": {
-                                                "row": 2,
-                                                "SEQ": 2,
-                                                "USUBJID": "015246-076-0003-00003",
-                                                "value": {
-                                                    "SSSTRESC": "DEAD",
-                                                    "$ds_dsdecod": "ADVERSE EVENT"
-                                                }
-                                            },
-                                            "old_value": {
-                                                "row": 2,
-                                                "SEQ": 2,
-                                                "USUBJID": "015246-076-0003-00003",
-                                                "value": {
-                                                    "SSSTRESC": "DEAD",
-                                                    "$ds_dsdecod": [
-                                                        "ADVERSE EVENT",
-                                                        "ALIVE",
-                                                        "COMPLETED",
-                                                        "INFORMED CONSENT OBTAINED",
-                                                        "LAST CONTACT",
-                                                        "PROGRESSIVE DISEASE",
-                                                        "RANDOMIZED"
-                                                    ]
-                                                }
-                                            }
-                                        },
-                                        "root[1]": {
-                                            "new_value": {
-                                                "row": 4,
-                                                "SEQ": 2,
-                                                "USUBJID": "015246-300-0004-00002",
-                                                "value": {
-                                                    "SSSTRESC": "DEAD",
-                                                    "$ds_dsdecod": "ADVERSE EVENT"
-                                                }
-                                            },
-                                            "old_value": {
-                                                "row": 4,
-                                                "SEQ": 2,
-                                                "USUBJID": "015246-300-0004-00002",
-                                                "value": {
-                                                    "SSSTRESC": "DEAD",
-                                                    "$ds_dsdecod": [
-                                                        "ADVERSE EVENT",
-                                                        "ALIVE",
-                                                        "COMPLETED",
-                                                        "INFORMED CONSENT OBTAINED",
-                                                        "LAST CONTACT",
-                                                        "RANDOMIZED"
-                                                    ]
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                            "diff": {}
                         },
                         "whitelisted": false,
-                        "sql_overall_result": "success",
+                        "sql_overall_result": "execution_error",
                         "old_overall_result": "success",
                         "validated_results_folder_exists": false,
                         "validation_file": "",
@@ -70947,10 +70873,15 @@
                             {
                                 "dataset": "ss.xpt",
                                 "domain": "SS",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "SQL operator execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    {
+                                        "error": "SQL error in does_not_contain operator",
+                                        "message": "ContainsOperator._handle_target_is_collection() missing 1 required positional argument: 'value_is_literal'"
+                                    }
+                                ]
                             }
                         ],
                         "dataset_import_old": "SUCCESS",
@@ -70974,10 +70905,13 @@
                             }
                         ],
                         "old_vs_sql": {
-                            "equal": true
+                            "dataset_mismatch": false,
+                            "execution_status_mismatch": true,
+                            "number_of_errors_mismatch": false,
+                            "diff": {}
                         },
                         "whitelisted": false,
-                        "sql_overall_result": "success",
+                        "sql_overall_result": "execution_error",
                         "old_overall_result": "success",
                         "validated_results_folder_exists": false,
                         "validation_file": "",
@@ -71555,8 +71489,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "1201001",
                                         "value": {
-                                            "SEUPDES": null,
-                                            "ETCD": "UNPLAN"
+                                            "ETCD": "UNPLAN",
+                                            "SEUPDES": null
                                         }
                                     }
                                 ]
@@ -71956,8 +71890,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC012",
                                         "value": {
-                                            "HOSTTPT": null,
-                                            "HOSTRTPT": "BEFORE"
+                                            "HOSTRTPT": "BEFORE",
+                                            "HOSTTPT": null
                                         }
                                     },
                                     {
@@ -71965,8 +71899,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "HOSTTPT": null,
-                                            "HOSTRTPT": "AFTER"
+                                            "HOSTRTPT": "AFTER",
+                                            "HOSTTPT": null
                                         }
                                     },
                                     {
@@ -71974,8 +71908,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC014",
                                         "value": {
-                                            "HOSTTPT": null,
-                                            "HOSTRTPT": "BEFORE"
+                                            "HOSTRTPT": "BEFORE",
+                                            "HOSTTPT": null
                                         }
                                     },
                                     {
@@ -71983,8 +71917,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC016",
                                         "value": {
-                                            "HOSTTPT": null,
-                                            "HOSTRTPT": "BEFORE"
+                                            "HOSTRTPT": "BEFORE",
+                                            "HOSTTPT": null
                                         }
                                     },
                                     {
@@ -71992,8 +71926,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC017",
                                         "value": {
-                                            "HOSTTPT": null,
-                                            "HOSTRTPT": "BEFORE"
+                                            "HOSTRTPT": "BEFORE",
+                                            "HOSTTPT": null
                                         }
                                     },
                                     {
@@ -72001,8 +71935,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC018",
                                         "value": {
-                                            "HOSTTPT": null,
-                                            "HOSTRTPT": "AFTER"
+                                            "HOSTRTPT": "AFTER",
+                                            "HOSTTPT": null
                                         }
                                     },
                                     {
@@ -72010,8 +71944,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC019",
                                         "value": {
-                                            "HOSTTPT": null,
-                                            "HOSTRTPT": "BEFORE"
+                                            "HOSTRTPT": "BEFORE",
+                                            "HOSTTPT": null
                                         }
                                     },
                                     {
@@ -72019,8 +71953,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC020",
                                         "value": {
-                                            "HOSTTPT": null,
-                                            "HOSTRTPT": "BEFORE"
+                                            "HOSTRTPT": "BEFORE",
+                                            "HOSTTPT": null
                                         }
                                     },
                                     {
@@ -72028,8 +71962,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC021",
                                         "value": {
-                                            "HOSTTPT": null,
-                                            "HOSTRTPT": "BEFORE"
+                                            "HOSTRTPT": "BEFORE",
+                                            "HOSTTPT": null
                                         }
                                     }
                                 ]
@@ -72489,9 +72423,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "DTHDTC": "2013-01-14",
                                             "SSSTRESC": "DEAD",
                                             "SSDTC": "2013-01-13",
+                                            "DTHDTC": "2013-01-14",
                                             "USUBJID": "CDISC002"
                                         }
                                     },
@@ -72500,9 +72434,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "DTHDTC": "2021-05-01",
                                             "SSSTRESC": "DEAD",
                                             "SSDTC": "2021-04-30",
+                                            "DTHDTC": "2021-05-01",
                                             "USUBJID": "CDISC004"
                                         }
                                     },
@@ -72511,9 +72445,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "DTHDTC": "2021-07-02",
                                             "SSSTRESC": "DEAD",
                                             "SSDTC": "2021-05-02",
+                                            "DTHDTC": "2021-07-02",
                                             "USUBJID": "CDISC007"
                                         }
                                     },
@@ -72522,9 +72456,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "DTHDTC": "2021-08-13",
                                             "SSSTRESC": "DEAD",
                                             "SSDTC": "2021-08-12",
+                                            "DTHDTC": "2021-08-13",
                                             "USUBJID": "CDISC009"
                                         }
                                     }
@@ -73931,8 +73865,8 @@
                                         "USUBJID": "CDISC-TEST-099",
                                         "value": {
                                             "AESOC": "Cardiac disorders",
-                                            "AETERM": "PNEUMONIA",
-                                            "AEBODSYS": "Infections and infestations"
+                                            "AEBODSYS": "Infections and infestations",
+                                            "AETERM": "PNEUMONIA"
                                         }
                                     },
                                     {
@@ -73941,8 +73875,8 @@
                                         "USUBJID": "CDISC-TEST-099",
                                         "value": {
                                             "AESOC": "CARDIAC disorders",
-                                            "AETERM": "URINARY TRACT INFECTION",
-                                            "AEBODSYS": "Cardiac disorders"
+                                            "AEBODSYS": "Cardiac disorders",
+                                            "AETERM": "URINARY TRACT INFECTION"
                                         }
                                     },
                                     {
@@ -73951,8 +73885,8 @@
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
                                             "AESOC": "Gastrointestinal disorders",
-                                            "AETERM": "UPSET STOMACH",
-                                            "AEBODSYS": "Musculoskeletal and connective tissue disorders"
+                                            "AEBODSYS": "Musculoskeletal and connective tissue disorders",
+                                            "AETERM": "UPSET STOMACH"
                                         }
                                     },
                                     {
@@ -73961,8 +73895,8 @@
                                         "USUBJID": "CDISC-TEST-100",
                                         "value": {
                                             "AESOC": "Musculoskeletal and connective tissue disorders",
-                                            "AETERM": "BACK PAIN",
-                                            "AEBODSYS": "Musculoskeletal and connective TISSUE disorders"
+                                            "AEBODSYS": "Musculoskeletal and connective TISSUE disorders",
+                                            "AETERM": "BACK PAIN"
                                         }
                                     }
                                 ]
@@ -74066,9 +74000,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "MHBODSYS": null,
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSOC": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": null
                                         }
                                     },
                                     {
@@ -74076,9 +74010,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSOC": "Neurodegenerative Diseases 1",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -74086,9 +74020,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSOC": null,
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -74096,9 +74030,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "MHBODSYS": "Neurodegenerative Diseases",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSOC": "Bodysystem 2",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "Neurodegenerative Diseases"
                                         }
                                     },
                                     {
@@ -74106,9 +74040,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "MHBODSYS": "NEURODEGENERATIVE DISEASES",
+                                            "MHTERM": "ALZHEIMER'S DISEASE",
                                             "MHSOC": "Neurodegenerative Diseases",
-                                            "MHTERM": "ALZHEIMER'S DISEASE"
+                                            "MHBODSYS": "NEURODEGENERATIVE DISEASES"
                                         }
                                     }
                                 ]
@@ -74964,15 +74898,15 @@
                                         "SEQ": 882,
                                         "USUBJID": "CDISC-TEST-055",
                                         "value": {
+                                            "AESMIE": null,
                                             "AESHOSP": null,
-                                            "AESDISAB": null,
                                             "AESOD": null,
+                                            "AESDISAB": null,
+                                            "AESCAN": "N",
                                             "AESCONG": null,
                                             "AESER": null,
-                                            "AESCAN": "N",
-                                            "AESLIFE": null,
-                                            "AESMIE": null,
-                                            "AESDTH": null
+                                            "AESDTH": null,
+                                            "AESLIFE": null
                                         }
                                     },
                                     {
@@ -74980,15 +74914,15 @@
                                         "SEQ": 897,
                                         "USUBJID": "CDISC-TEST-055",
                                         "value": {
+                                            "AESMIE": null,
                                             "AESHOSP": null,
-                                            "AESDISAB": null,
                                             "AESOD": null,
+                                            "AESDISAB": null,
+                                            "AESCAN": null,
                                             "AESCONG": null,
                                             "AESER": null,
-                                            "AESCAN": null,
-                                            "AESLIFE": null,
-                                            "AESMIE": null,
-                                            "AESDTH": " "
+                                            "AESDTH": " ",
+                                            "AESLIFE": null
                                         }
                                     },
                                     {
@@ -74996,15 +74930,15 @@
                                         "SEQ": 899,
                                         "USUBJID": "CDISC-TEST-055",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75012,15 +74946,15 @@
                                         "SEQ": 727,
                                         "USUBJID": "CDISC-TEST-056",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": null,
                                             "AESCONG": " ",
                                             "AESER": "Y",
-                                            "AESCAN": null,
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75028,15 +74962,15 @@
                                         "SEQ": 735,
                                         "USUBJID": "CDISC-TEST-056",
                                         "value": {
+                                            "AESMIE": " ",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": null,
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": " ",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75044,15 +74978,15 @@
                                         "SEQ": 782,
                                         "USUBJID": "CDISC-TEST-149",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": null,
                                             "AESOD": "N",
+                                            "AESDISAB": null,
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75060,15 +74994,15 @@
                                         "SEQ": 783,
                                         "USUBJID": "CDISC-TEST-149",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": " ",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
-                                            "AESDTH": null
+                                            "AESDTH": null,
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75076,15 +75010,15 @@
                                         "SEQ": 839,
                                         "USUBJID": "CDISC-TEST-152",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": null,
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75092,15 +75026,15 @@
                                         "SEQ": 840,
                                         "USUBJID": "CDISC-TEST-152",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": null,
-                                            "AESMIE": "N",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": null
                                         }
                                     },
                                     {
@@ -75108,15 +75042,15 @@
                                         "SEQ": 843,
                                         "USUBJID": "CDISC-TEST-152",
                                         "value": {
+                                            "AESMIE": " ",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": null,
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": " ",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75124,15 +75058,15 @@
                                         "SEQ": 844,
                                         "USUBJID": "CDISC-TEST-152",
                                         "value": {
+                                            "AESMIE": null,
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": null,
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75140,15 +75074,15 @@
                                         "SEQ": 897,
                                         "USUBJID": "CDISC-TEST-155",
                                         "value": {
+                                            "AESMIE": null,
                                             "AESHOSP": null,
-                                            "AESDISAB": null,
                                             "AESOD": null,
+                                            "AESDISAB": null,
+                                            "AESCAN": null,
                                             "AESCONG": null,
                                             "AESER": null,
-                                            "AESCAN": null,
-                                            "AESLIFE": null,
-                                            "AESMIE": null,
-                                            "AESDTH": " "
+                                            "AESDTH": " ",
+                                            "AESLIFE": null
                                         }
                                     }
                                 ]
@@ -75346,15 +75280,15 @@
                                         "SEQ": 727,
                                         "USUBJID": "CDISC-TEST-046",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": null,
                                             "AESCONG": " ",
                                             "AESER": "Y",
-                                            "AESCAN": null,
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75362,15 +75296,15 @@
                                         "SEQ": 735,
                                         "USUBJID": "CDISC-TEST-046",
                                         "value": {
+                                            "AESMIE": " ",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": null,
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": " ",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75378,15 +75312,15 @@
                                         "SEQ": 782,
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": null,
                                             "AESOD": "N",
+                                            "AESDISAB": null,
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75394,15 +75328,15 @@
                                         "SEQ": 783,
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": " ",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
-                                            "AESDTH": null
+                                            "AESDTH": null,
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75410,15 +75344,15 @@
                                         "SEQ": 839,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": null,
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": "N",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75426,15 +75360,15 @@
                                         "SEQ": 840,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
+                                            "AESMIE": "N",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": null,
-                                            "AESMIE": "N",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": null
                                         }
                                     },
                                     {
@@ -75442,15 +75376,15 @@
                                         "SEQ": 843,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
+                                            "AESMIE": " ",
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": null,
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": " ",
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75458,15 +75392,15 @@
                                         "SEQ": 844,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
+                                            "AESMIE": null,
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
-                                            "AESMIE": null,
-                                            "AESDTH": "N"
+                                            "AESDTH": "N",
+                                            "AESLIFE": "N"
                                         }
                                     },
                                     {
@@ -75474,15 +75408,15 @@
                                         "SEQ": 897,
                                         "USUBJID": "CDISC-TEST-055",
                                         "value": {
+                                            "AESMIE": null,
                                             "AESHOSP": null,
-                                            "AESDISAB": null,
                                             "AESOD": null,
+                                            "AESDISAB": null,
+                                            "AESCAN": null,
                                             "AESCONG": null,
                                             "AESER": null,
-                                            "AESCAN": null,
-                                            "AESLIFE": null,
-                                            "AESMIE": null,
-                                            "AESDTH": " "
+                                            "AESDTH": " ",
+                                            "AESLIFE": null
                                         }
                                     }
                                 ]
@@ -75681,13 +75615,13 @@
                                         "USUBJID": "CDISC-TEST-046",
                                         "value": {
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": null,
                                             "AESCONG": " ",
                                             "AESER": "Y",
-                                            "AESCAN": null,
-                                            "AESLIFE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AESMIE": "Not in dataset"
                                         }
                                     },
@@ -75697,13 +75631,13 @@
                                         "USUBJID": "CDISC-TEST-046",
                                         "value": {
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": null,
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AESMIE": "Not in dataset"
                                         }
                                     },
@@ -75713,13 +75647,13 @@
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
                                             "AESHOSP": "N",
-                                            "AESDISAB": null,
                                             "AESOD": "N",
+                                            "AESDISAB": null,
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AESMIE": "Not in dataset"
                                         }
                                     },
@@ -75729,13 +75663,13 @@
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": " ",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
                                             "AESDTH": null,
+                                            "AESLIFE": "N",
                                             "AESMIE": "Not in dataset"
                                         }
                                     },
@@ -75745,13 +75679,13 @@
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
                                             "AESHOSP": null,
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AESMIE": "Not in dataset"
                                         }
                                     },
@@ -75761,13 +75695,13 @@
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": null,
                                             "AESDTH": "N",
+                                            "AESLIFE": null,
                                             "AESMIE": "Not in dataset"
                                         }
                                     },
@@ -75777,13 +75711,13 @@
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": null,
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AESMIE": "Not in dataset"
                                         }
                                     },
@@ -75793,13 +75727,13 @@
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
                                             "AESHOSP": "N",
-                                            "AESDISAB": "N",
                                             "AESOD": "N",
+                                            "AESDISAB": "N",
+                                            "AESCAN": "N",
                                             "AESCONG": "N",
                                             "AESER": "Y",
-                                            "AESCAN": "N",
-                                            "AESLIFE": "N",
                                             "AESDTH": "N",
+                                            "AESLIFE": "N",
                                             "AESMIE": "Not in dataset"
                                         }
                                     },
@@ -75809,13 +75743,13 @@
                                         "USUBJID": "CDISC-TEST-055",
                                         "value": {
                                             "AESHOSP": null,
-                                            "AESDISAB": null,
                                             "AESOD": null,
+                                            "AESDISAB": null,
+                                            "AESCAN": null,
                                             "AESCONG": null,
                                             "AESER": null,
-                                            "AESCAN": null,
-                                            "AESLIFE": null,
                                             "AESDTH": " ",
+                                            "AESLIFE": null,
                                             "AESMIE": "Not in dataset"
                                         }
                                     }
@@ -77906,8 +77840,8 @@
                                         "SEQ": 293,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77915,8 +77849,8 @@
                                         "SEQ": 294,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77924,8 +77858,8 @@
                                         "SEQ": 295,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77933,8 +77867,8 @@
                                         "SEQ": 296,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77942,8 +77876,8 @@
                                         "SEQ": 297,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77951,8 +77885,8 @@
                                         "SEQ": 298,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77960,8 +77894,8 @@
                                         "SEQ": 299,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77969,8 +77903,8 @@
                                         "SEQ": 300,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77978,8 +77912,8 @@
                                         "SEQ": 301,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77987,8 +77921,8 @@
                                         "SEQ": 302,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -77996,8 +77930,8 @@
                                         "SEQ": 303,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78005,8 +77939,8 @@
                                         "SEQ": 304,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78014,8 +77948,8 @@
                                         "SEQ": 305,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78023,8 +77957,8 @@
                                         "SEQ": 306,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78032,8 +77966,8 @@
                                         "SEQ": 307,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78041,8 +77975,8 @@
                                         "SEQ": 308,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78050,8 +77984,8 @@
                                         "SEQ": 309,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78059,8 +77993,8 @@
                                         "SEQ": 310,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78068,8 +78002,8 @@
                                         "SEQ": 311,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78077,8 +78011,8 @@
                                         "SEQ": 312,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78086,8 +78020,8 @@
                                         "SEQ": 313,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78095,8 +78029,8 @@
                                         "SEQ": 314,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78104,8 +78038,8 @@
                                         "SEQ": 315,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78113,8 +78047,8 @@
                                         "SEQ": 316,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78122,8 +78056,8 @@
                                         "SEQ": 317,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78131,8 +78065,8 @@
                                         "SEQ": 318,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78140,8 +78074,8 @@
                                         "SEQ": 319,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78149,8 +78083,8 @@
                                         "SEQ": 320,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78158,8 +78092,8 @@
                                         "SEQ": 321,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78167,8 +78101,8 @@
                                         "SEQ": 322,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -78193,8 +78127,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78202,8 +78136,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78211,8 +78145,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78220,8 +78154,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -78246,8 +78180,8 @@
                                         "SEQ": 31,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78255,8 +78189,8 @@
                                         "SEQ": 32,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78264,8 +78198,8 @@
                                         "SEQ": 33,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78273,8 +78207,8 @@
                                         "SEQ": 65,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78282,8 +78216,8 @@
                                         "SEQ": 66,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78291,8 +78225,8 @@
                                         "SEQ": 67,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78300,8 +78234,8 @@
                                         "SEQ": 98,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78309,8 +78243,8 @@
                                         "SEQ": 99,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78318,8 +78252,8 @@
                                         "SEQ": 100,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78327,8 +78261,8 @@
                                         "SEQ": 111,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78336,8 +78270,8 @@
                                         "SEQ": 121,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78345,8 +78279,8 @@
                                         "SEQ": 31,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78354,8 +78288,8 @@
                                         "SEQ": 32,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78363,8 +78297,8 @@
                                         "SEQ": 33,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78372,8 +78306,8 @@
                                         "SEQ": 68,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78381,8 +78315,8 @@
                                         "SEQ": 69,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78390,8 +78324,8 @@
                                         "SEQ": 70,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78399,8 +78333,8 @@
                                         "SEQ": 104,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78408,8 +78342,8 @@
                                         "SEQ": 105,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78417,8 +78351,8 @@
                                         "SEQ": 106,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78426,8 +78360,8 @@
                                         "SEQ": 120,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78435,8 +78369,8 @@
                                         "SEQ": 131,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -78799,8 +78733,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78808,8 +78742,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78817,8 +78751,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 13.0
+                                            "VISITNUM": 13.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78826,8 +78760,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -78852,8 +78786,8 @@
                                         "SEQ": 31,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78861,8 +78795,8 @@
                                         "SEQ": 32,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78870,8 +78804,8 @@
                                         "SEQ": 33,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78879,8 +78813,8 @@
                                         "SEQ": 65,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78888,8 +78822,8 @@
                                         "SEQ": 66,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78897,8 +78831,8 @@
                                         "SEQ": 67,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78906,8 +78840,8 @@
                                         "SEQ": 98,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78915,8 +78849,8 @@
                                         "SEQ": 99,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78924,8 +78858,8 @@
                                         "SEQ": 100,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78933,8 +78867,8 @@
                                         "SEQ": 111,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78942,8 +78876,8 @@
                                         "SEQ": 121,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78951,8 +78885,8 @@
                                         "SEQ": 31,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78960,8 +78894,8 @@
                                         "SEQ": 32,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78969,8 +78903,8 @@
                                         "SEQ": 33,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78978,8 +78912,8 @@
                                         "SEQ": 68,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78987,8 +78921,8 @@
                                         "SEQ": 69,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -78996,8 +78930,8 @@
                                         "SEQ": 70,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -79005,8 +78939,8 @@
                                         "SEQ": 104,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -79014,8 +78948,8 @@
                                         "SEQ": 105,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -79023,8 +78957,8 @@
                                         "SEQ": 106,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -79032,8 +78966,8 @@
                                         "SEQ": 120,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     },
                                     {
@@ -79041,8 +78975,8 @@
                                         "SEQ": 131,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "SVPRESP": "Y",
-                                            "VISITNUM": 12.0
+                                            "VISITNUM": 12.0,
+                                            "SVPRESP": "Y"
                                         }
                                     }
                                 ]
@@ -82175,8 +82109,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "ALB",
                                         "value": {
-                                            "LBORRES": "NEGATIVE",
-                                            "LBORNRLO": "30"
+                                            "LBORNRLO": "30",
+                                            "LBORRES": "NEGATIVE"
                                         }
                                     },
                                     {
@@ -82184,8 +82118,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "Prot",
                                         "value": {
-                                            "LBORRES": "POSITIVE",
-                                            "LBORNRLO": "POSITIVE"
+                                            "LBORNRLO": "POSITIVE",
+                                            "LBORRES": "POSITIVE"
                                         }
                                     }
                                 ]
@@ -82916,8 +82850,8 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "64",
-                                            "TSPARMCD": "AGEMAX"
+                                            "TSPARMCD": "AGEMAX",
+                                            "TSVAL": "64"
                                         }
                                     }
                                 ]
@@ -82980,8 +82914,8 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "6 months",
-                                            "TSPARMCD": "AGEMAX"
+                                            "TSPARMCD": "AGEMAX",
+                                            "TSVAL": "6 months"
                                         }
                                     }
                                 ]
@@ -83155,8 +83089,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBSTREFC": "ABC",
-                                            "LBSTREFN": null
+                                            "LBSTREFN": null,
+                                            "LBSTREFC": "ABC"
                                         }
                                     }
                                 ]
@@ -85873,8 +85807,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "LBORRES": "CHAR RESULT",
-                                            "LBSTNRHI": 48.0
+                                            "LBSTNRHI": 48.0,
+                                            "LBORRES": "CHAR RESULT"
                                         }
                                     }
                                 ]
@@ -85946,8 +85880,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "ALB",
                                         "value": {
-                                            "LBORRES": "NEGATIVE",
-                                            "LBSTNRHI": "30"
+                                            "LBSTNRHI": "30",
+                                            "LBORRES": "NEGATIVE"
                                         }
                                     },
                                     {
@@ -85955,8 +85889,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "Prot",
                                         "value": {
-                                            "LBORRES": "POSITIVE",
-                                            "LBSTNRHI": "clear"
+                                            "LBSTNRHI": "clear",
+                                            "LBORRES": "POSITIVE"
                                         }
                                     }
                                 ]
@@ -86545,8 +86479,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBTESTCD": "ALB",
-                                            "LBTEST": "Albumin"
+                                            "LBTEST": "Albumin",
+                                            "LBTESTCD": "ALB"
                                         }
                                     },
                                     {
@@ -86554,8 +86488,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBTESTCD": "ALB",
-                                            "LBTEST": "Alkaline Phosphatase"
+                                            "LBTEST": "Alkaline Phosphatase",
+                                            "LBTESTCD": "ALB"
                                         }
                                     },
                                     {
@@ -86563,8 +86497,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBTESTCD": "ALB",
-                                            "LBTEST": "Aspartate Aminotransferase"
+                                            "LBTEST": "Aspartate Aminotransferase",
+                                            "LBTESTCD": "ALB"
                                         }
                                     },
                                     {
@@ -86572,8 +86506,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBTESTCD": "BASO",
-                                            "LBTEST": "Aspartate Aminotransferase"
+                                            "LBTEST": "Aspartate Aminotransferase",
+                                            "LBTESTCD": "BASO"
                                         }
                                     },
                                     {
@@ -86581,8 +86515,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "LBTESTCD": "BASO",
-                                            "LBTEST": "Basophils"
+                                            "LBTEST": "Basophils",
+                                            "LBTESTCD": "BASO"
                                         }
                                     }
                                 ]
@@ -87785,8 +87719,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "ARM": "Zanomaline Low Dose (54 mg)",
-                                            "ARMCD": "ZAN_LOW"
+                                            "ARMCD": "ZAN_LOW",
+                                            "ARM": "Zanomaline Low Dose (54 mg)"
                                         }
                                     },
                                     {
@@ -87794,8 +87728,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "ARM": "Zanomaline High Dose (81 mg)",
-                                            "ARMCD": "ZAN_LOW"
+                                            "ARMCD": "ZAN_LOW",
+                                            "ARM": "Zanomaline High Dose (81 mg)"
                                         }
                                     }
                                 ]
@@ -87812,8 +87746,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "PlaceboA",
-                                            "ARMCD": "PLACEBO"
+                                            "ARMCD": "PLACEBO",
+                                            "ARM": "PlaceboA"
                                         }
                                     },
                                     {
@@ -87821,8 +87755,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "PlaceboB",
-                                            "ARMCD": "PLACEBO"
+                                            "ARMCD": "PLACEBO",
+                                            "ARM": "PlaceboB"
                                         }
                                     },
                                     {
@@ -87830,8 +87764,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "Zanomaline Low Dose (54 mg)1",
-                                            "ARMCD": "ZAN_LOW"
+                                            "ARMCD": "ZAN_LOW",
+                                            "ARM": "Zanomaline Low Dose (54 mg)1"
                                         }
                                     },
                                     {
@@ -87839,8 +87773,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "Zanomaline Low Dose (54 mg)2",
-                                            "ARMCD": "ZAN_LOW"
+                                            "ARMCD": "ZAN_LOW",
+                                            "ARM": "Zanomaline Low Dose (54 mg)2"
                                         }
                                     },
                                     {
@@ -87848,8 +87782,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "Zanomaline High Dose (81 mg)1",
-                                            "ARMCD": "ZAN_HIGH"
+                                            "ARMCD": "ZAN_HIGH",
+                                            "ARM": "Zanomaline High Dose (81 mg)1"
                                         }
                                     },
                                     {
@@ -87857,8 +87791,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "Zanomaline High Dose (81 mg)2",
-                                            "ARMCD": "ZAN_HIGH"
+                                            "ARMCD": "ZAN_HIGH",
+                                            "ARM": "Zanomaline High Dose (81 mg)2"
                                         }
                                     },
                                     {
@@ -87866,8 +87800,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "Zanomaline High Dose (81 mg)3",
-                                            "ARMCD": "ZAN_HIGH"
+                                            "ARMCD": "ZAN_HIGH",
+                                            "ARM": "Zanomaline High Dose (81 mg)3"
                                         }
                                     }
                                 ]
@@ -87884,8 +87818,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "PlaceboA",
-                                            "ARMCD": "PLACEBO"
+                                            "ARMCD": "PLACEBO",
+                                            "ARM": "PlaceboA"
                                         }
                                     },
                                     {
@@ -87893,8 +87827,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "PlaceboB",
-                                            "ARMCD": "PLACEBO"
+                                            "ARMCD": "PLACEBO",
+                                            "ARM": "PlaceboB"
                                         }
                                     },
                                     {
@@ -87902,8 +87836,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "Zanomaline Low Dose (54 mg)1",
-                                            "ARMCD": "ZAN_LOW"
+                                            "ARMCD": "ZAN_LOW",
+                                            "ARM": "Zanomaline Low Dose (54 mg)1"
                                         }
                                     },
                                     {
@@ -87911,8 +87845,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "ARM": "Zanomaline Low Dose (54 mg)2",
-                                            "ARMCD": "ZAN_LOW"
+                                            "ARMCD": "ZAN_LOW",
+                                            "ARM": "Zanomaline Low Dose (54 mg)2"
                                         }
                                     }
                                 ]
@@ -88587,8 +88521,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "DSDECOD": "Future USE OF SAMPLES INFORMED CONSENT OBTAINED",
-                                            "DSTERM": "FUTURE USE OF SAMPLES INFORMED CONSENT OBTAINED"
+                                            "DSTERM": "FUTURE USE OF SAMPLES INFORMED CONSENT OBTAINED",
+                                            "DSDECOD": "Future USE OF SAMPLES INFORMED CONSENT OBTAINED"
                                         }
                                     },
                                     {
@@ -88596,8 +88530,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-203-0003-00001",
                                         "value": {
-                                            "DSDECOD": "STUDY INFORMED CONSENT OBTAINE",
-                                            "DSTERM": "STUDY INFORMED CONSENT OBTAINED"
+                                            "DSTERM": "STUDY INFORMED CONSENT OBTAINED",
+                                            "DSDECOD": "STUDY INFORMED CONSENT OBTAINE"
                                         }
                                     },
                                     {
@@ -88605,8 +88539,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-300-0004-00002",
                                         "value": {
-                                            "DSDECOD": "ADVERSE EVENT",
-                                            "DSTERM": "COMPLETED"
+                                            "DSTERM": "COMPLETED",
+                                            "DSDECOD": "ADVERSE EVENT"
                                         }
                                     }
                                 ]
@@ -88779,9 +88713,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC002",
                                         "value": {
+                                            "CMDTC": "2013-05-20",
                                             "CMENRTPT": "AFTER",
-                                            "CMENTPT": "2013-05-20",
-                                            "CMDTC": "2013-05-20"
+                                            "CMENTPT": "2013-05-20"
                                         }
                                     }
                                 ]
@@ -89615,8 +89549,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
-                                            "EPOCH": null
+                                            "EPOCH": null,
+                                            "DSCAT": "DISPOSITION EVENT"
                                         }
                                     },
                                     {
@@ -89624,8 +89558,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
-                                            "EPOCH": null
+                                            "EPOCH": null,
+                                            "DSCAT": "DISPOSITION EVENT"
                                         }
                                     },
                                     {
@@ -89633,8 +89567,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
-                                            "EPOCH": null
+                                            "EPOCH": null,
+                                            "DSCAT": "DISPOSITION EVENT"
                                         }
                                     },
                                     {
@@ -89642,8 +89576,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-036-0002-00004",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
-                                            "EPOCH": null
+                                            "EPOCH": null,
+                                            "DSCAT": "DISPOSITION EVENT"
                                         }
                                     }
                                 ]
@@ -90135,8 +90069,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "ABC-001-002",
                                         "value": {
-                                            "MBMETHOD": "NOT GRAM STAIN",
                                             "MBTESTCD": "ORGANISM",
+                                            "MBMETHOD": "NOT GRAM STAIN",
                                             "MBSTRESC": "NOT NO GROWTH",
                                             "MBRESCAT": null
                                         }
@@ -90685,6 +90619,13 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
+                                            "$expected_variables": [
+                                                "EXDOSE",
+                                                "EXDOSU",
+                                                "EXDOSFRM",
+                                                "EXSTDTC",
+                                                "EXENDTC"
+                                            ],
                                             "$dataset_variables": [
                                                 "STUDYID",
                                                 "DOMAIN",
@@ -90702,13 +90643,6 @@
                                                 "EXENDTC",
                                                 "EXSTDY",
                                                 "EXENDY"
-                                            ],
-                                            "$expected_variables": [
-                                                "EXDOSE",
-                                                "EXDOSU",
-                                                "EXDOSFRM",
-                                                "EXSTDTC",
-                                                "EXENDTC"
                                             ]
                                         }
                                     }
@@ -90739,6 +90673,11 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
+                                            "$expected_variables": [
+                                                "IDVAR",
+                                                "IDVARVAL",
+                                                "QEVAL"
+                                            ],
                                             "$dataset_variables": [
                                                 "STUDYID",
                                                 "RDOMAIN",
@@ -90748,11 +90687,6 @@
                                                 "QLABEL",
                                                 "QVAL",
                                                 "QORIG",
-                                                "QEVAL"
-                                            ],
-                                            "$expected_variables": [
-                                                "IDVAR",
-                                                "IDVARVAL",
                                                 "QEVAL"
                                             ]
                                         }
@@ -90771,6 +90705,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
+                                            "$expected_variables": [
+                                                "TABRANCH",
+                                                "TATRANS"
+                                            ],
                                             "$dataset_variables": [
                                                 "STUDYID",
                                                 "DOMAIN",
@@ -90781,10 +90719,6 @@
                                                 "ELEMENT",
                                                 "TABRANCH",
                                                 "EPOCH"
-                                            ],
-                                            "$expected_variables": [
-                                                "TABRANCH",
-                                                "TATRANS"
                                             ]
                                         }
                                     }
@@ -91048,8 +90982,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "1.1",
-                                            "TSPARMCD": "RANDQT"
+                                            "TSPARMCD": "RANDQT",
+                                            "TSVAL": "1.1"
                                         }
                                     },
                                     {
@@ -91057,8 +90991,8 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "0",
-                                            "TSPARMCD": "RANDQT"
+                                            "TSPARMCD": "RANDQT",
+                                            "TSVAL": "0"
                                         }
                                     },
                                     {
@@ -91066,8 +91000,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "1.01",
-                                            "TSPARMCD": "RANDQT"
+                                            "TSPARMCD": "RANDQT",
+                                            "TSVAL": "1.01"
                                         }
                                     },
                                     {
@@ -91075,8 +91009,8 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "-0.001",
-                                            "TSPARMCD": "RANDQT"
+                                            "TSPARMCD": "RANDQT",
+                                            "TSVAL": "-0.001"
                                         }
                                     }
                                 ]
@@ -91252,8 +91186,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "QNAM": "RACE1",
-                                            "RACE": "WHITE"
+                                            "RACE": "WHITE",
+                                            "QNAM": "RACE1"
                                         }
                                     },
                                     {
@@ -91261,8 +91195,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "QNAM": "RACE11",
-                                            "RACE": "WHITE"
+                                            "RACE": "WHITE",
+                                            "QNAM": "RACE11"
                                         }
                                     },
                                     {
@@ -91270,8 +91204,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "QNAM": "RACE10",
-                                            "RACE": "WHITE"
+                                            "RACE": "WHITE",
+                                            "QNAM": "RACE10"
                                         }
                                     },
                                     {
@@ -91279,8 +91213,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "QNAM": "RACEA",
-                                            "RACE": "WHITE"
+                                            "RACE": "WHITE",
+                                            "QNAM": "RACEA"
                                         }
                                     },
                                     {
@@ -91288,8 +91222,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC010",
                                         "value": {
-                                            "QNAM": "RACEBL",
-                                            "RACE": "BLACK"
+                                            "RACE": "BLACK",
+                                            "QNAM": "RACEBL"
                                         }
                                     }
                                 ]
@@ -91521,8 +91455,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "-1",
-                                            "TSPARMCD": "ACTSUB"
+                                            "TSPARMCD": "ACTSUB",
+                                            "TSVAL": "-1"
                                         }
                                     },
                                     {
@@ -91530,8 +91464,8 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "0",
-                                            "TSPARMCD": "ACTSUB"
+                                            "TSPARMCD": "ACTSUB",
+                                            "TSVAL": "0"
                                         }
                                     },
                                     {
@@ -91539,8 +91473,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "1.5",
-                                            "TSPARMCD": "ACTSUB"
+                                            "TSPARMCD": "ACTSUB",
+                                            "TSVAL": "1.5"
                                         }
                                     }
                                 ]
@@ -91724,8 +91658,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "FCNTRY",
-                                            "TSVCDREF": "ISO3166-1 alpha-3"
+                                            "TSVCDREF": "ISO3166-1 alpha-3",
+                                            "TSPARMCD": "FCNTRY"
                                         }
                                     },
                                     {
@@ -91733,8 +91667,8 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "FCNTRY",
-                                            "TSVCDREF": "ISO 3166-1alpha-3"
+                                            "TSVCDREF": "ISO 3166-1alpha-3",
+                                            "TSPARMCD": "FCNTRY"
                                         }
                                     },
                                     {
@@ -91742,8 +91676,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "FCNTRY",
-                                            "TSVCDREF": "ISO3166-1alpha-3"
+                                            "TSVCDREF": "ISO3166-1alpha-3",
+                                            "TSPARMCD": "FCNTRY"
                                         }
                                     },
                                     {
@@ -91751,8 +91685,8 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "FCNTRY",
-                                            "TSVCDREF": "ISO 3166 1 alpha 3"
+                                            "TSVCDREF": "ISO 3166 1 alpha 3",
+                                            "TSPARMCD": "FCNTRY"
                                         }
                                     },
                                     {
@@ -91760,8 +91694,8 @@
                                         "SEQ": 5,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "FCNTRY",
-                                            "TSVCDREF": "ISO 3166-1 alpha-"
+                                            "TSVCDREF": "ISO 3166-1 alpha-",
+                                            "TSPARMCD": "FCNTRY"
                                         }
                                     },
                                     {
@@ -91769,8 +91703,8 @@
                                         "SEQ": 6,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "FCNTRY",
-                                            "TSVCDREF": "3166-1 alpha-3"
+                                            "TSVCDREF": "3166-1 alpha-3",
+                                            "TSPARMCD": "FCNTRY"
                                         }
                                     },
                                     {
@@ -91778,8 +91712,8 @@
                                         "SEQ": 7,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "FCNTRY",
-                                            "TSVCDREF": "SO 3166-1 alpha-3"
+                                            "TSVCDREF": "SO 3166-1 alpha-3",
+                                            "TSPARMCD": "FCNTRY"
                                         }
                                     }
                                 ]
@@ -91927,8 +91861,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "-1",
-                                            "TSPARMCD": "PLANSUB"
+                                            "TSPARMCD": "PLANSUB",
+                                            "TSVAL": "-1"
                                         }
                                     },
                                     {
@@ -91936,8 +91870,8 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "0",
-                                            "TSPARMCD": "PLANSUB"
+                                            "TSPARMCD": "PLANSUB",
+                                            "TSVAL": "0"
                                         }
                                     },
                                     {
@@ -91945,8 +91879,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "1.5",
-                                            "TSPARMCD": "PLANSUB"
+                                            "TSPARMCD": "PLANSUB",
+                                            "TSVAL": "1.5"
                                         }
                                     }
                                 ]
@@ -92731,9 +92665,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFSTDTC": "2012-11-30",
                                             "CEDTC": "2014-10",
-                                            "CEDY": 174.0
+                                            "CEDY": 174.0,
+                                            "RFSTDTC": "2012-11-30"
                                         }
                                     },
                                     {
@@ -92741,9 +92675,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "RFSTDTC": "2012-11",
                                             "CEDTC": "2014-10-31",
-                                            "CEDY": 174.0
+                                            "CEDY": 174.0,
+                                            "RFSTDTC": "2012-11"
                                         }
                                     }
                                 ]
@@ -95282,9 +95216,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "MHSOCCD": 7.0,
                                             "MHTERM": "ALZHEIMER'S DISEASE",
-                                            "MHBDSYCD": 2.0
+                                            "MHBDSYCD": 2.0,
+                                            "MHSOCCD": 7.0
                                         }
                                     },
                                     {
@@ -95292,9 +95226,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "MHSOCCD": 8.0,
                                             "MHTERM": "ALZHEIMER'S DISEASE",
-                                            "MHBDSYCD": 3.0
+                                            "MHBDSYCD": 3.0,
+                                            "MHSOCCD": 8.0
                                         }
                                     },
                                     {
@@ -95302,9 +95236,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "MHSOCCD": 9.0,
                                             "MHTERM": "ALZHEIMER'S DISEASE",
-                                            "MHBDSYCD": 4.0
+                                            "MHBDSYCD": 4.0,
+                                            "MHSOCCD": 9.0
                                         }
                                     },
                                     {
@@ -95312,9 +95246,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "MHSOCCD": 10.0,
                                             "MHTERM": "ALZHEIMER'S DISEASE",
-                                            "MHBDSYCD": 5.0
+                                            "MHBDSYCD": 5.0,
+                                            "MHSOCCD": 10.0
                                         }
                                     },
                                     {
@@ -95322,9 +95256,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC008",
                                         "value": {
-                                            "MHSOCCD": 11.0,
                                             "MHTERM": "ALZHEIMER'S DISEASE",
-                                            "MHBDSYCD": 6.0
+                                            "MHBDSYCD": 6.0,
+                                            "MHSOCCD": 11.0
                                         }
                                     }
                                 ]
@@ -95424,9 +95358,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "MHSOCCD": null,
                                             "MHTERM": "ALZHEIMER'S DISEASE",
-                                            "MHBDSYCD": null
+                                            "MHBDSYCD": null,
+                                            "MHSOCCD": null
                                         }
                                     }
                                 ]
@@ -95575,10 +95509,10 @@
                                         "SEQ": 1,
                                         "USUBJID": "015246-300-0004-00002",
                                         "value": {
-                                            "DSSTDTC": "2018-04-17",
                                             "RFICDTC": "2018-04-20",
                                             "DSDECOD": "INFORMED CONSENT OBTAINED",
-                                            "$min_ds_dsstdtc": "2018-04-17"
+                                            "$min_ds_dsstdtc": "2018-04-17",
+                                            "DSSTDTC": "2018-04-17"
                                         }
                                     }
                                 ]
@@ -95725,9 +95659,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC010",
                                         "value": {
-                                            "DSCAT": "PROTOCOL MILESTONE",
                                             "DSDECOD": "RANDOMIZATION CODE ALLOCATED",
-                                            "EPOCH": "FIRST TREATMENT EPOCH"
+                                            "EPOCH": "FIRST TREATMENT EPOCH",
+                                            "DSCAT": "PROTOCOL MILESTONE"
                                         }
                                     }
                                 ]
@@ -96920,8 +96854,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "RFENDTC": "2023-01-02",
-                                            "ACTARM": "Screen Failure"
+                                            "ACTARM": "Screen Failure",
+                                            "RFENDTC": "2023-01-02"
                                         }
                                     },
                                     {
@@ -96929,8 +96863,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-300-0004-00002",
                                         "value": {
-                                            "RFENDTC": "2023-01-02",
-                                            "ACTARM": "Not Assigned"
+                                            "ACTARM": "Not Assigned",
+                                            "RFENDTC": "2023-01-02"
                                         }
                                     }
                                 ]
@@ -97090,10 +97024,10 @@
                                         "SEQ": 1,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "DSSTDTC": "2018-03-06",
                                             "RFICDTC": "2018-05-20",
                                             "DSDECOD": "INFORMED CONSENT OBTAINED",
-                                            "$min_ds_dsstdtc": "2018-03-06"
+                                            "$min_ds_dsstdtc": "2018-03-06",
+                                            "DSSTDTC": "2018-03-06"
                                         }
                                     },
                                     {
@@ -97101,10 +97035,10 @@
                                         "SEQ": 1,
                                         "USUBJID": "015246-888-0008-08888",
                                         "value": {
-                                            "DSSTDTC": "2018-04-06",
                                             "RFICDTC": "2019-08-15",
                                             "DSDECOD": "INFORMED CONSENT OBTAINED",
-                                            "$min_ds_dsstdtc": "2018-04-06"
+                                            "$min_ds_dsstdtc": "2018-04-06",
+                                            "DSSTDTC": "2018-04-06"
                                         }
                                     }
                                 ]
@@ -97589,8 +97523,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "U",
-                                            "TSPARMCD": "ADDON"
+                                            "TSPARMCD": "ADDON",
+                                            "TSVAL": "U"
                                         }
                                     }
                                 ]
@@ -97721,8 +97655,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "U",
-                                            "TSPARMCD": "RANDOM"
+                                            "TSPARMCD": "RANDOM",
+                                            "TSVAL": "U"
                                         }
                                     }
                                 ]
@@ -97864,8 +97798,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
                                             "EPOCH": "TREATMENT",
+                                            "DSCAT": "DISPOSITION EVENT",
                                             "DSSCAT": "Not in dataset"
                                         }
                                     },
@@ -97874,8 +97808,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
                                             "EPOCH": "TREATMENT",
+                                            "DSCAT": "DISPOSITION EVENT",
                                             "DSSCAT": "Not in dataset"
                                         }
                                     }
@@ -97950,8 +97884,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
                                             "EPOCH": "TREATMENT",
+                                            "DSCAT": "DISPOSITION EVENT",
                                             "DSSCAT": "Not in dataset"
                                         }
                                     },
@@ -97960,8 +97894,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
                                             "EPOCH": "TREATMENT",
+                                            "DSCAT": "DISPOSITION EVENT",
                                             "DSSCAT": "Not in dataset"
                                         }
                                     }
@@ -98036,8 +97970,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
                                             "EPOCH": "TREATMENT",
+                                            "DSCAT": "DISPOSITION EVENT",
                                             "DSSCAT": "Not in dataset"
                                         }
                                     },
@@ -98046,8 +97980,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
                                             "EPOCH": "TREATMENT",
+                                            "DSCAT": "DISPOSITION EVENT",
                                             "DSSCAT": "Not in dataset"
                                         }
                                     }
@@ -98284,8 +98218,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QEVAL": null,
-                                            "QORIG": "Assigned"
+                                            "QORIG": "Assigned",
+                                            "QEVAL": null
                                         }
                                     },
                                     {
@@ -98293,8 +98227,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QEVAL": null,
-                                            "QORIG": "Assigned"
+                                            "QORIG": "Assigned",
+                                            "QEVAL": null
                                         }
                                     },
                                     {
@@ -98302,8 +98236,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QEVAL": null,
-                                            "QORIG": "Assigned"
+                                            "QORIG": "Assigned",
+                                            "QEVAL": null
                                         }
                                     },
                                     {
@@ -98311,8 +98245,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QEVAL": null,
-                                            "QORIG": "Assigned"
+                                            "QORIG": "Assigned",
+                                            "QEVAL": null
                                         }
                                     },
                                     {
@@ -98320,8 +98254,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QEVAL": null,
-                                            "QORIG": "Assigned"
+                                            "QORIG": "Assigned",
+                                            "QEVAL": null
                                         }
                                     }
                                 ]
@@ -98338,8 +98272,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC009",
                                         "value": {
-                                            "QEVAL": null,
-                                            "QORIG": "ASSIGNED"
+                                            "QORIG": "ASSIGNED",
+                                            "QEVAL": null
                                         }
                                     }
                                 ]
@@ -98852,8 +98786,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-999-0004-9999",
                                         "value": {
-                                            "RFENDTC": null,
-                                            "ACTARM": "Placebo"
+                                            "ACTARM": "Placebo",
+                                            "RFENDTC": null
                                         }
                                     }
                                 ]
@@ -99728,9 +99662,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-002",
                                         "value": {
-                                            "AGE": 34.0,
+                                            "AGETXT": null,
                                             "AGEU": null,
-                                            "AGETXT": null
+                                            "AGE": 34.0
                                         }
                                     },
                                     {
@@ -99738,9 +99672,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-004",
                                         "value": {
-                                            "AGE": null,
+                                            "AGETXT": "31-34",
                                             "AGEU": null,
-                                            "AGETXT": "31-34"
+                                            "AGE": null
                                         }
                                     }
                                 ]
@@ -99872,9 +99806,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-004",
                                         "value": {
-                                            "AGE": null,
+                                            "AGETXT": null,
                                             "AGEU": "YEARS",
-                                            "AGETXT": null
+                                            "AGE": null
                                         }
                                     }
                                 ]
@@ -100047,9 +99981,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": null,
                                             "TSPARMCD": "STOPRULE",
-                                            "TSGRPID": null
+                                            "TSGRPID": null,
+                                            "TSVAL": null
                                         }
                                     }
                                 ]
@@ -100113,9 +100047,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": null,
                                             "TSPARMCD": "STOPRULE",
-                                            "TSGRPID": "1"
+                                            "TSGRPID": "1",
+                                            "TSVAL": null
                                         }
                                     }
                                 ]
@@ -100179,9 +100113,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": null,
                                             "TSPARMCD": "STOPRULE",
-                                            "TSGRPID": "2"
+                                            "TSGRPID": "2",
+                                            "TSVAL": null
                                         }
                                     }
                                 ]
@@ -101235,9 +101169,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Patients with Probable Mild to Moderate Alzheimers Disease",
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": null,
+                                            "TSVAL": "Patients with Probable Mild to Moderate Alzheimers Disease",
                                             "$HLTSUBJI_Y": 1
                                         }
                                     }
@@ -101303,9 +101237,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Patients with Probable Mild to Moderate Alzheimers Disease",
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": "1",
+                                            "TSVAL": "Patients with Probable Mild to Moderate Alzheimers Disease",
                                             "$HLTSUBJI_Y": 1
                                         }
                                     }
@@ -101415,9 +101349,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Patients with Probable Mild to Moderate Alzheimers Disease",
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": "1",
+                                            "TSVAL": "Patients with Probable Mild to Moderate Alzheimers Disease",
                                             "$HLTSUBJI_Y": 1
                                         }
                                     },
@@ -101426,9 +101360,9 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "HEALTHY",
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": "2",
+                                            "TSVAL": "HEALTHY",
                                             "$HLTSUBJI_Y": 1
                                         }
                                     },
@@ -101437,9 +101371,9 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "HEALTHY",
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": null,
+                                            "TSVAL": "HEALTHY",
                                             "$HLTSUBJI_Y": 1
                                         }
                                     },
@@ -101448,9 +101382,9 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "HEALTHY",
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": "4",
+                                            "TSVAL": "HEALTHY",
                                             "$HLTSUBJI_Y": 2
                                         }
                                     },
@@ -101459,9 +101393,9 @@
                                         "SEQ": 5,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "NOT HEALTHY",
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": "4",
+                                            "TSVAL": "NOT HEALTHY",
                                             "$HLTSUBJI_Y": 2
                                         }
                                     }
@@ -101680,8 +101614,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "PCLAS",
-                                            "TSVCDREF": "MEDRT"
+                                            "TSVCDREF": "MEDRT",
+                                            "TSPARMCD": "PCLAS"
                                         }
                                     }
                                 ]
@@ -102353,9 +102287,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVUPDES": "UNSCHEDULED LABS",
                                             "VISITDY": 24.0,
-                                            "USUBJID": "CDISC001"
+                                            "USUBJID": "CDISC001",
+                                            "SVUPDES": "UNSCHEDULED LABS"
                                         }
                                     }
                                 ]
@@ -102788,8 +102722,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "2023-02-30",
-                                            "TSPARMCD": "DCUTDTC"
+                                            "TSPARMCD": "DCUTDTC",
+                                            "TSVAL": "2023-02-30"
                                         }
                                     }
                                 ]
@@ -102919,8 +102853,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "2023-02-30",
-                                            "TSPARMCD": "SSTDTC"
+                                            "TSPARMCD": "SSTDTC",
+                                            "TSVAL": "2023-02-30"
                                         }
                                     }
                                 ]
@@ -103050,8 +102984,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "2023-02-30",
-                                            "TSPARMCD": "SENDTC"
+                                            "TSPARMCD": "SENDTC",
+                                            "TSVAL": "2023-02-30"
                                         }
                                     }
                                 ]
@@ -104690,10 +104624,10 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC002",
                                         "value": {
+                                            "FADY": 35.0,
                                             "$val_dy": 18,
                                             "FADTC": "2012-12-02",
-                                            "RFSTDTC": "2012-11-15",
-                                            "FADY": 35.0
+                                            "RFSTDTC": "2012-11-15"
                                         }
                                     },
                                     {
@@ -104701,10 +104635,10 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC004",
                                         "value": {
+                                            "FADY": 3.0,
                                             "$val_dy": 5,
                                             "FADTC": "2013-10-12",
-                                            "RFSTDTC": "2013-10-08",
-                                            "FADY": 3.0
+                                            "RFSTDTC": "2013-10-08"
                                         }
                                     },
                                     {
@@ -104712,10 +104646,10 @@
                                         "SEQ": 4,
                                         "USUBJID": "CDISC007",
                                         "value": {
+                                            "FADY": -30.0,
                                             "$val_dy": -34,
                                             "FADTC": "2012-12-02",
-                                            "RFSTDTC": "2013-01-05",
-                                            "FADY": -30.0
+                                            "RFSTDTC": "2013-01-05"
                                         }
                                     },
                                     {
@@ -104723,10 +104657,10 @@
                                         "SEQ": 5,
                                         "USUBJID": "CDISC008",
                                         "value": {
+                                            "FADY": 230.0,
                                             "$val_dy": 206,
                                             "FADTC": "2014-12-02",
-                                            "RFSTDTC": "2014-05-11",
-                                            "FADY": 230.0
+                                            "RFSTDTC": "2014-05-11"
                                         }
                                     }
                                 ]
@@ -104743,10 +104677,10 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "$val_dy": -3,
-                                            "IEDTC": "2022-03-17",
+                                            "RFSTDTC": "2022-03-20",
                                             "IEDY": -4.0,
-                                            "RFSTDTC": "2022-03-20"
+                                            "$val_dy": -3,
+                                            "IEDTC": "2022-03-17"
                                         }
                                     }
                                 ]
@@ -104763,9 +104697,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "RFSTDTC": "2022-03-20",
                                             "$val_dy": 11,
                                             "LBDTC": "2022-03-30",
-                                            "RFSTDTC": "2022-03-20",
                                             "LBDY": 2.0
                                         }
                                     }
@@ -104839,9 +104773,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "RFSTDTC": "2012-11-30",
                                             "$val_dy": 1,
                                             "LBDTC": "2012-11-30",
-                                            "RFSTDTC": "2012-11-30",
                                             "LBDY": 2.0
                                         }
                                     }
@@ -104923,10 +104857,10 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
+                                            "RFSTDTC": "2012-11-30",
                                             "$val_dy": -1,
-                                            "DMDTC": "2012-11-29",
                                             "DMDY": -5.0,
-                                            "RFSTDTC": "2012-11-30"
+                                            "DMDTC": "2012-11-29"
                                         }
                                     }
                                 ]
@@ -105402,9 +105336,9 @@
                                         "USUBJID": null,
                                         "value": {
                                             "TSVAL": null,
+                                            "TSGRPID": null,
                                             "TSPARMCD": "CURTRT",
-                                            "$ADDON_Y": 1,
-                                            "TSGRPID": null
+                                            "$ADDON_Y": 1
                                         }
                                     }
                                 ]
@@ -105470,9 +105404,9 @@
                                         "USUBJID": null,
                                         "value": {
                                             "TSVAL": null,
+                                            "TSGRPID": "DRUG A",
                                             "TSPARMCD": "CURTRT",
-                                            "$ADDON_Y": 1,
-                                            "TSGRPID": "DRUG A"
+                                            "$ADDON_Y": 1
                                         }
                                     }
                                 ]
@@ -105549,9 +105483,9 @@
                                         "USUBJID": null,
                                         "value": {
                                             "TSVAL": null,
+                                            "TSGRPID": "DRUG A",
                                             "TSPARMCD": "CURTRT",
-                                            "$ADDON_Y": 1,
-                                            "TSGRPID": "DRUG A"
+                                            "$ADDON_Y": 1
                                         }
                                     },
                                     {
@@ -105560,9 +105494,9 @@
                                         "USUBJID": null,
                                         "value": {
                                             "TSVAL": null,
+                                            "TSGRPID": null,
                                             "TSPARMCD": "CURTRT",
-                                            "$ADDON_Y": 1,
-                                            "TSGRPID": null
+                                            "$ADDON_Y": 1
                                         }
                                     }
                                 ]
@@ -108322,8 +108256,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 1.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108332,8 +108266,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 1.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108342,8 +108276,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 2.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108352,8 +108286,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 2.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108362,8 +108296,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 3.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108372,8 +108306,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 3.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108382,8 +108316,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 4.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108392,8 +108326,8 @@
                                         "SEQ": 4,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 4.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108402,8 +108336,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 5.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108412,8 +108346,8 @@
                                         "SEQ": 5,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 5.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108422,8 +108356,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 6.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108432,8 +108366,8 @@
                                         "SEQ": 6,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 6.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108442,8 +108376,8 @@
                                         "SEQ": 7,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 7.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108452,8 +108386,8 @@
                                         "SEQ": 7,
                                         "USUBJID": "0001",
                                         "value": {
-                                            "USUBJID": "0001",
                                             "SSSEQ": 7.0,
+                                            "USUBJID": "0001",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108462,8 +108396,8 @@
                                         "SEQ": 14,
                                         "USUBJID": "0002",
                                         "value": {
-                                            "USUBJID": "0002",
                                             "SSSEQ": 14.0,
+                                            "USUBJID": "0002",
                                             "POOLID": "Not in dataset"
                                         }
                                     },
@@ -108472,8 +108406,8 @@
                                         "SEQ": 14,
                                         "USUBJID": "0002",
                                         "value": {
-                                            "USUBJID": "0002",
                                             "SSSEQ": 14.0,
+                                            "USUBJID": "0002",
                                             "POOLID": "Not in dataset"
                                         }
                                     }
@@ -108491,8 +108425,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "AESEQ": 1.0,
                                             "POOLID": "0002",
+                                            "AESEQ": 1.0,
                                             "USUBJID": "Not in dataset"
                                         }
                                     },
@@ -108501,8 +108435,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "AESEQ": 1.0,
                                             "POOLID": "0002",
+                                            "AESEQ": 1.0,
                                             "USUBJID": "Not in dataset"
                                         }
                                     },
@@ -108511,8 +108445,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "AESEQ": 1.0,
                                             "POOLID": "0002",
+                                            "AESEQ": 1.0,
                                             "USUBJID": "Not in dataset"
                                         }
                                     },
@@ -108521,8 +108455,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "AESEQ": 1.0,
                                             "POOLID": "0002",
+                                            "AESEQ": 1.0,
                                             "USUBJID": "Not in dataset"
                                         }
                                     },
@@ -108531,8 +108465,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "AESEQ": 1.0,
                                             "POOLID": "0002",
+                                            "AESEQ": 1.0,
                                             "USUBJID": "Not in dataset"
                                         }
                                     },
@@ -108541,8 +108475,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "AESEQ": 1.0,
                                             "POOLID": "0002",
+                                            "AESEQ": 1.0,
                                             "USUBJID": "Not in dataset"
                                         }
                                     },
@@ -108551,8 +108485,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "AESEQ": 1.0,
                                             "POOLID": "0002",
+                                            "AESEQ": 1.0,
                                             "USUBJID": "Not in dataset"
                                         }
                                     }
@@ -109229,8 +109163,8 @@
                                         "USUBJID": "CDISC007",
                                         "value": {
                                             "RFSTDTC": "2013-01-05",
-                                            "CMSTDTC": "2013-02-18",
                                             "$val_stdy": 45,
+                                            "CMSTDTC": "2013-02-18",
                                             "CMSTDY": null
                                         }
                                     },
@@ -109240,8 +109174,8 @@
                                         "USUBJID": "CDISC008",
                                         "value": {
                                             "RFSTDTC": "2014-05-11",
-                                            "CMSTDTC": "2013-02-18",
                                             "$val_stdy": -447,
+                                            "CMSTDTC": "2013-02-18",
                                             "CMSTDY": 45.0
                                         }
                                     },
@@ -109251,8 +109185,8 @@
                                         "USUBJID": "CDISC010",
                                         "value": {
                                             "RFSTDTC": "2013-09-21",
-                                            "CMSTDTC": "2011-07-15",
                                             "$val_stdy": -799,
+                                            "CMSTDTC": "2011-07-15",
                                             "CMSTDY": -511.0
                                         }
                                     }
@@ -109463,9 +109397,9 @@
                                         "USUBJID": "001",
                                         "value": {
                                             "RFSTDTC": "2022-03-20",
-                                            "AEENDTC": "2022-03-19",
                                             "AEENDY": -2.0,
-                                            "$val_endy": -1
+                                            "$val_endy": -1,
+                                            "AEENDTC": "2022-03-19"
                                         }
                                     },
                                     {
@@ -109474,9 +109408,9 @@
                                         "USUBJID": "001",
                                         "value": {
                                             "RFSTDTC": "2022-03-20",
-                                            "AEENDTC": "2022-03-20",
                                             "AEENDY": 0.0,
-                                            "$val_endy": 1
+                                            "$val_endy": 1,
+                                            "AEENDTC": "2022-03-20"
                                         }
                                     }
                                 ]
@@ -109703,10 +109637,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": null,
+                                            "$HLTSUBJI_N": 1,
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": null,
-                                            "$HLTSUBJI_N": 1
+                                            "TSVAL": null
                                         }
                                     }
                                 ]
@@ -109782,10 +109716,10 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": null,
+                                            "$HLTSUBJI_N": 1,
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": "2",
-                                            "$HLTSUBJI_N": 1
+                                            "TSVAL": null
                                         }
                                     },
                                     {
@@ -109793,10 +109727,10 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": null,
+                                            "$HLTSUBJI_N": 1,
                                             "TSPARMCD": "TDIGRP",
                                             "TSGRPID": "3",
-                                            "$HLTSUBJI_N": 1
+                                            "TSVAL": null
                                         }
                                     }
                                 ]
@@ -110014,8 +109948,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "redacted",
-                                            "TSPARMCD": "ADAPT"
+                                            "TSPARMCD": "ADAPT",
+                                            "TSVAL": "redacted"
                                         }
                                     }
                                 ]
@@ -110145,8 +110079,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "TDIGRP",
-                                            "TSVCDREF": null
+                                            "TSVCDREF": null,
+                                            "TSPARMCD": "TDIGRP"
                                         }
                                     }
                                 ]
@@ -110209,8 +110143,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "INDIC",
-                                            "TSVCDREF": null
+                                            "TSVCDREF": null,
+                                            "TSPARMCD": "INDIC"
                                         }
                                     }
                                 ]
@@ -110282,8 +110216,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "INDIC",
-                                            "TSVCDREF": "SNO"
+                                            "TSVCDREF": "SNO",
+                                            "TSPARMCD": "INDIC"
                                         }
                                     },
                                     {
@@ -110291,8 +110225,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "TDIGRP",
-                                            "TSVCDREF": "MED"
+                                            "TSVCDREF": "MED",
+                                            "TSPARMCD": "TDIGRP"
                                         }
                                     }
                                 ]
@@ -111824,10 +111758,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TEENRL": "END OF TREATMENT",
+                                            "ETCD": "E001",
                                             "TESTRL": "FIRST DOSE OF HUMAN INSULIN",
                                             "ELEMENT": "HUMAN INSULIN",
-                                            "ETCD": "E001",
+                                            "TEENRL": "END OF TREATMENT",
                                             "TEDUR": "Not in dataset"
                                         }
                                     },
@@ -111836,10 +111770,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TEENRL": "END OF TREATMENT",
+                                            "ETCD": "E002",
                                             "TESTRL": "FIRST DOSE OF HUMAN INSULIN",
                                             "ELEMENT": "HUMAN INSULIN",
-                                            "ETCD": "E002",
+                                            "TEENRL": "END OF TREATMENT",
                                             "TEDUR": "Not in dataset"
                                         }
                                     },
@@ -111848,10 +111782,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TEENRL": null,
+                                            "ETCD": "E006",
                                             "TESTRL": "INFORMED CONSENT SIGNED2",
                                             "ELEMENT": "Y",
-                                            "ETCD": "E006",
+                                            "TEENRL": null,
                                             "TEDUR": "Not in dataset"
                                         }
                                     },
@@ -111860,10 +111794,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TEENRL": null,
+                                            "ETCD": "E006",
                                             "TESTRL": "INFORMED CONSENT SIGNED2",
                                             "ELEMENT": "Y",
-                                            "ETCD": "E006",
+                                            "TEENRL": null,
                                             "TEDUR": "Not in dataset"
                                         }
                                     },
@@ -111872,10 +111806,10 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TEENRL": null,
+                                            "ETCD": "E007",
                                             "TESTRL": "INFORMED CONSENT SIGNED2",
                                             "ELEMENT": "Y",
-                                            "ETCD": "E007",
+                                            "TEENRL": null,
                                             "TEDUR": "Not in dataset"
                                         }
                                     }
@@ -111990,8 +111924,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TESTRL": "FIRST DOSE OF HUMAN INSULIN",
                                             "TEDUR": "P26W",
+                                            "TESTRL": "FIRST DOSE OF HUMAN INSULIN",
                                             "ELEMENT": "HUMAN INSULIN",
                                             "ETCD": "E001",
                                             "TEENRL": "Not in dataset"
@@ -112002,8 +111936,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TESTRL": "FIRST DOSE OF HUMAN INSULIN",
                                             "TEDUR": "P26W",
+                                            "TESTRL": "FIRST DOSE OF HUMAN INSULIN",
                                             "ELEMENT": "HUMAN INSULIN",
                                             "ETCD": "E002",
                                             "TEENRL": "Not in dataset"
@@ -112014,8 +111948,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TESTRL": "INFORMED CONSENT SIGNED2",
                                             "TEDUR": "P2W",
+                                            "TESTRL": "INFORMED CONSENT SIGNED2",
                                             "ELEMENT": "Y",
                                             "ETCD": "E006",
                                             "TEENRL": "Not in dataset"
@@ -112026,8 +111960,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TESTRL": "INFORMED CONSENT SIGNED2",
                                             "TEDUR": "P2W",
+                                            "TESTRL": "INFORMED CONSENT SIGNED2",
                                             "ELEMENT": "Y",
                                             "ETCD": "E006",
                                             "TEENRL": "Not in dataset"
@@ -112038,8 +111972,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "TESTRL": "INFORMED CONSENT SIGNED2",
                                             "TEDUR": "P2W",
+                                            "TESTRL": "INFORMED CONSENT SIGNED2",
                                             "ELEMENT": "Y",
                                             "ETCD": "E007",
                                             "TEENRL": "Not in dataset"
@@ -112299,9 +112233,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": null,
                                             "TSPARMCD": "OBJPRIM",
-                                            "TSGRPID": "EFFICACY"
+                                            "TSGRPID": "EFFICACY",
+                                            "TSVAL": null
                                         }
                                     },
                                     {
@@ -112309,9 +112243,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "To assess the dose-dependent improvement in subject depression. Improved scores on the Patient Health Questionnaire(PHQ-9) and the Hamilton Depression Rating Scale(HAMD 17) will indicate improvements,",
                                             "TSPARMCD": "OUTMSPRI",
-                                            "TSGRPID": "EFFICACY"
+                                            "TSGRPID": "EFFICACY",
+                                            "TSVAL": "To assess the dose-dependent improvement in subject depression. Improved scores on the Patient Health Questionnaire(PHQ-9) and the Hamilton Depression Rating Scale(HAMD 17) will indicate improvements,"
                                         }
                                     },
                                     {
@@ -112319,9 +112253,9 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "To assess the dose-dependent improvements in satisfaction with subjects' lives as a whole. Improved scores on the Satisfaction With Life Survery (SWLS) will indicate improvements.",
                                             "TSPARMCD": "OUTMSPRI",
-                                            "TSGRPID": "EFFICACY"
+                                            "TSGRPID": "EFFICACY",
+                                            "TSVAL": "To assess the dose-dependent improvements in satisfaction with subjects' lives as a whole. Improved scores on the Satisfaction With Life Survery (SWLS) will indicate improvements."
                                         }
                                     },
                                     {
@@ -112329,9 +112263,9 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "To assess the dose-dependent improvements in subject memory and learning. Improved scores on the Auditory Verbal Learning Test (AVLT-REY) will indicate improvements.",
                                             "TSPARMCD": "OUTMSPRI",
-                                            "TSGRPID": "EFFICACY"
+                                            "TSGRPID": "EFFICACY",
+                                            "TSVAL": "To assess the dose-dependent improvements in subject memory and learning. Improved scores on the Auditory Verbal Learning Test (AVLT-REY) will indicate improvements."
                                         }
                                     }
                                 ]
@@ -112528,8 +112462,8 @@
                                         "value": {
                                             "STUDYID": "TEST",
                                             "USUBJID": "001",
-                                            "SEQ": "Not in dataset",
                                             "POOLID": "Not in dataset",
+                                            "SEQ": "Not in dataset",
                                             "DOMAIN": "Not in dataset"
                                         }
                                     }
@@ -112547,11 +112481,11 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "DOMAIN": "LB",
                                             "STUDYID": "ABC123",
+                                            "DOMAIN": "LB",
                                             "LBSEQ": 1.0,
-                                            "USUBJID": "Not in dataset",
-                                            "POOLID": "Not in dataset"
+                                            "POOLID": "Not in dataset",
+                                            "USUBJID": "Not in dataset"
                                         }
                                     }
                                 ]
@@ -112568,9 +112502,9 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
+                                            "DOMAIN": "EC",
                                             "ECSEQ": 1.0,
                                             "USUBJID": "CDISC001",
-                                            "DOMAIN": "EC",
                                             "STUDYID": "Not in dataset",
                                             "POOLID": "Not in dataset"
                                         }
@@ -112589,9 +112523,9 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
+                                            "DOMAIN": "FA",
                                             "STUDYID": "ABC123",
                                             "POOLID": "ABC123-0201",
-                                            "DOMAIN": "FA",
                                             "FASEQ": "Not in dataset",
                                             "USUBJID": "Not in dataset"
                                         }
@@ -112792,8 +112726,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
-                                            "EPOCH": "FU"
+                                            "EPOCH": "FU",
+                                            "DSCAT": "DISPOSITION EVENT"
                                         }
                                     },
                                     {
@@ -112801,8 +112735,8 @@
                                         "SEQ": null,
                                         "USUBJID": "015246-076-0003-00003",
                                         "value": {
-                                            "DSCAT": "DISPOSITION EVENT",
-                                            "EPOCH": "FU"
+                                            "EPOCH": "FU",
+                                            "DSCAT": "DISPOSITION EVENT"
                                         }
                                     }
                                 ]
@@ -112928,8 +112862,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "0",
-                                            "TSPARMCD": "NARMS"
+                                            "TSPARMCD": "NARMS",
+                                            "TSVAL": "0"
                                         }
                                     }
                                 ]
@@ -112990,8 +112924,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "zero",
-                                            "TSPARMCD": "NARMS"
+                                            "TSPARMCD": "NARMS",
+                                            "TSVAL": "zero"
                                         }
                                     }
                                 ]
@@ -113681,8 +113615,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC-TEST-001",
                                         "value": {
-                                            "QNAM": "AESOSP",
-                                            "AESMIE": null
+                                            "AESMIE": null,
+                                            "QNAM": "AESOSP"
                                         }
                                     },
                                     {
@@ -113690,8 +113624,8 @@
                                         "SEQ": 29,
                                         "USUBJID": "CDISC-TEST-002",
                                         "value": {
-                                            "QNAM": "AESOSP",
-                                            "AESMIE": "N"
+                                            "AESMIE": "N",
+                                            "QNAM": "AESOSP"
                                         }
                                     }
                                 ]
@@ -114151,9 +114085,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
+                                            "AEOUT": "NOT RECOVERED/NOT RESOLVED",
                                             "AEENDTC": "2006-10-20",
-                                            "AETERM": "Headache",
-                                            "AEOUT": "NOT RECOVERED/NOT RESOLVED"
+                                            "AETERM": "Headache"
                                         }
                                     }
                                 ]
@@ -114301,8 +114235,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "RFXSTDTC": "2018-02-20T09:40",
-                                            "RFICDTC": "2019-03-20"
+                                            "RFICDTC": "2019-03-20",
+                                            "RFXSTDTC": "2018-02-20T09:40"
                                         }
                                     },
                                     {
@@ -114310,8 +114244,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "RFXSTDTC": "2018-02-20T09:40",
-                                            "RFICDTC": "2018-02-20T11:50"
+                                            "RFICDTC": "2018-02-20T11:50",
+                                            "RFXSTDTC": "2018-02-20T09:40"
                                         }
                                     },
                                     {
@@ -114319,8 +114253,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "RFXSTDTC": "2018-02-20",
-                                            "RFICDTC": "2018-02-20T09:50"
+                                            "RFICDTC": "2018-02-20T09:50",
+                                            "RFXSTDTC": "2018-02-20"
                                         }
                                     }
                                 ]
@@ -114461,9 +114395,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC002",
                                         "value": {
+                                            "AEOUT": "RECOVERED/RESOLVED",
                                             "AEENDTC": null,
-                                            "AETERM": "Vomiting",
-                                            "AEOUT": "RECOVERED/RESOLVED"
+                                            "AETERM": "Vomiting"
                                         }
                                     },
                                     {
@@ -114471,9 +114405,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
+                                            "AEOUT": "RECOVERED/RESOLVED",
                                             "AEENDTC": null,
-                                            "AETERM": "Headache",
-                                            "AEOUT": "RECOVERED/RESOLVED"
+                                            "AETERM": "Headache"
                                         }
                                     }
                                 ]
@@ -114540,9 +114474,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC002",
                                         "value": {
+                                            "AEOUT": "RECOVERED/RESOLVED",
                                             "AEENDTC": null,
-                                            "AETERM": "Vomiting",
-                                            "AEOUT": "RECOVERED/RESOLVED"
+                                            "AETERM": "Vomiting"
                                         }
                                     }
                                 ]
@@ -114636,17 +114570,13 @@
                             {
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
-                                "execution_status": "success",
-                                "execution_message": "When the death flag in DM is set to \"Y\", a record is not present in DS domain with DSDECOD= \"DEATH\"",
+                                "execution_status": "execution_error",
+                                "execution_message": "SQL operator execution error",
                                 "number_errors": 1,
                                 "errors": [
                                     {
-                                        "row": null,
-                                        "SEQ": null,
-                                        "USUBJID": null,
-                                        "value": {
-                                            "USUBJID": "CDISC002"
-                                        }
+                                        "error": "SQL error in does_not_contain operator",
+                                        "message": "ContainsOperator._handle_target_is_collection() missing 1 required positional argument: 'value_is_literal'"
                                     }
                                 ]
                             },
@@ -114689,10 +114619,13 @@
                             }
                         ],
                         "old_vs_sql": {
-                            "equal": true
+                            "dataset_mismatch": false,
+                            "execution_status_mismatch": true,
+                            "number_of_errors_mismatch": false,
+                            "diff": {}
                         },
                         "whitelisted": false,
-                        "sql_overall_result": "success",
+                        "sql_overall_result": "execution_error",
                         "old_overall_result": "success",
                         "validated_results_folder_exists": false,
                         "validation_file": "",
@@ -114717,10 +114650,15 @@
                             {
                                 "dataset": "ds.xpt",
                                 "domain": "DS",
-                                "execution_status": "success",
-                                "execution_message": null,
-                                "number_errors": 0,
-                                "errors": []
+                                "execution_status": "execution_error",
+                                "execution_message": "SQL operator execution error",
+                                "number_errors": 1,
+                                "errors": [
+                                    {
+                                        "error": "SQL error in does_not_contain operator",
+                                        "message": "ContainsOperator._handle_target_is_collection() missing 1 required positional argument: 'value_is_literal'"
+                                    }
+                                ]
                             },
                             {
                                 "dataset": "dm.xpt",
@@ -114752,10 +114690,13 @@
                             }
                         ],
                         "old_vs_sql": {
-                            "equal": true
+                            "dataset_mismatch": false,
+                            "execution_status_mismatch": true,
+                            "number_of_errors_mismatch": false,
+                            "diff": {}
                         },
                         "whitelisted": false,
-                        "sql_overall_result": "success",
+                        "sql_overall_result": "execution_error",
                         "old_overall_result": "success",
                         "validated_results_folder_exists": false,
                         "validation_file": "",
@@ -115140,9 +115081,9 @@
                                         "SEQ": 120,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115150,9 +115091,9 @@
                                         "SEQ": 121,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115160,9 +115101,9 @@
                                         "SEQ": 122,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115170,9 +115111,9 @@
                                         "SEQ": 123,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115180,9 +115121,9 @@
                                         "SEQ": 256,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115190,9 +115131,9 @@
                                         "SEQ": 257,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115200,9 +115141,9 @@
                                         "SEQ": 258,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115210,9 +115151,9 @@
                                         "SEQ": 259,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115220,9 +115161,9 @@
                                         "SEQ": 392,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST4",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -115230,9 +115171,9 @@
                                         "SEQ": 393,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST4",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -115240,9 +115181,9 @@
                                         "SEQ": 394,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST4",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -115250,9 +115191,9 @@
                                         "SEQ": 395,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST4",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -115260,9 +115201,9 @@
                                         "SEQ": 120,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115270,9 +115211,9 @@
                                         "SEQ": 121,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115280,9 +115221,9 @@
                                         "SEQ": 122,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115290,9 +115231,9 @@
                                         "SEQ": 123,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115300,9 +115241,9 @@
                                         "SEQ": 256,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115310,9 +115251,9 @@
                                         "SEQ": 257,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115320,9 +115261,9 @@
                                         "SEQ": 258,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115330,9 +115271,9 @@
                                         "SEQ": 259,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115340,9 +115281,9 @@
                                         "SEQ": 120,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115350,9 +115291,9 @@
                                         "SEQ": 121,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115360,9 +115301,9 @@
                                         "SEQ": 122,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115370,9 +115311,9 @@
                                         "SEQ": 123,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115380,9 +115321,9 @@
                                         "SEQ": 256,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115390,9 +115331,9 @@
                                         "SEQ": 257,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115400,9 +115341,9 @@
                                         "SEQ": 258,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115410,9 +115351,9 @@
                                         "SEQ": 259,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115420,9 +115361,9 @@
                                         "SEQ": 528,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST5",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -115430,9 +115371,9 @@
                                         "SEQ": 529,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "31 MIN POST5",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -115440,9 +115381,9 @@
                                         "SEQ": 530,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "32 MIN POST5",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -115450,9 +115391,9 @@
                                         "SEQ": 531,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "33 MIN POST5",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     }
                                 ]
@@ -115806,9 +115747,9 @@
                                         "SEQ": 120,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115816,9 +115757,9 @@
                                         "SEQ": 121,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115826,9 +115767,9 @@
                                         "SEQ": 122,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115836,9 +115777,9 @@
                                         "SEQ": 123,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115846,9 +115787,9 @@
                                         "SEQ": 256,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115856,9 +115797,9 @@
                                         "SEQ": 257,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115866,9 +115807,9 @@
                                         "SEQ": 258,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST5",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115876,9 +115817,9 @@
                                         "SEQ": 259,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115886,9 +115827,9 @@
                                         "SEQ": 392,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "35 MIN POST4",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115896,9 +115837,9 @@
                                         "SEQ": 393,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST4",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115906,9 +115847,9 @@
                                         "SEQ": 394,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST4",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115916,9 +115857,9 @@
                                         "SEQ": 395,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "FTTPTNUM": 2.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST4",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 2.0
                                         }
                                     },
                                     {
@@ -115926,9 +115867,9 @@
                                         "SEQ": 120,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115936,9 +115877,9 @@
                                         "SEQ": 121,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -115946,9 +115887,9 @@
                                         "SEQ": 122,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 2.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 2.0
                                         }
                                     },
                                     {
@@ -115956,9 +115897,9 @@
                                         "SEQ": 123,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 2.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 2.0
                                         }
                                     },
                                     {
@@ -115966,9 +115907,9 @@
                                         "SEQ": 256,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115976,9 +115917,9 @@
                                         "SEQ": 257,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 3.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 3.0
                                         }
                                     },
                                     {
@@ -115986,9 +115927,9 @@
                                         "SEQ": 258,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -115996,9 +115937,9 @@
                                         "SEQ": 259,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -116006,9 +115947,9 @@
                                         "SEQ": 120,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -116016,9 +115957,9 @@
                                         "SEQ": 121,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -116026,9 +115967,9 @@
                                         "SEQ": 256,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 3.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 3.0
                                         }
                                     },
                                     {
@@ -116036,9 +115977,9 @@
                                         "SEQ": 257,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -116046,9 +115987,9 @@
                                         "SEQ": 258,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -116056,9 +115997,9 @@
                                         "SEQ": 259,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 4.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST4",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 4.0
                                         }
                                     },
                                     {
@@ -116066,9 +116007,9 @@
                                         "SEQ": 528,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 2.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST5",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 2.0
                                         }
                                     },
                                     {
@@ -116076,9 +116017,9 @@
                                         "SEQ": 529,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "31 MIN POST5",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -116086,9 +116027,9 @@
                                         "SEQ": 530,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "32 MIN POST5",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     },
                                     {
@@ -116096,9 +116037,9 @@
                                         "SEQ": 531,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "FTTPTNUM": 1.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "33 MIN POST5",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 1.0
                                         }
                                     }
                                 ]
@@ -116585,8 +116526,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -116595,8 +116536,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
-                                            "FTTPT": "30 MIN POST1"
+                                            "FTTPT": "30 MIN POST1",
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -116605,8 +116546,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 13.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 13.0
                                         }
                                     },
                                     {
@@ -116615,8 +116556,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -116625,8 +116566,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF3",
-                                            "FTTPTNUM": 20.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 20.0
                                         }
                                     },
                                     {
@@ -116635,8 +116576,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF3",
-                                            "FTTPTNUM": 20.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 20.0
                                         }
                                     },
                                     {
@@ -116645,8 +116586,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF3",
-                                            "FTTPTNUM": 29.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 29.0
                                         }
                                     },
                                     {
@@ -116655,8 +116596,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF4",
-                                            "FTTPTNUM": 21.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 21.0
                                         }
                                     },
                                     {
@@ -116665,8 +116606,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF5",
-                                            "FTTPTNUM": 30.0,
-                                            "FTTPT": "30 MIN POST2"
+                                            "FTTPT": "30 MIN POST2",
+                                            "FTTPTNUM": 30.0
                                         }
                                     },
                                     {
@@ -116675,8 +116616,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF5",
-                                            "FTTPTNUM": 30.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 30.0
                                         }
                                     },
                                     {
@@ -116685,8 +116626,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF5",
-                                            "FTTPTNUM": 35.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 35.0
                                         }
                                     },
                                     {
@@ -116695,8 +116636,8 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF5",
-                                            "FTTPTNUM": 30.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 30.0
                                         }
                                     },
                                     {
@@ -116705,8 +116646,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 11.0,
-                                            "FTTPT": "30 MIN POST2"
+                                            "FTTPT": "30 MIN POST2",
+                                            "FTTPTNUM": 11.0
                                         }
                                     },
                                     {
@@ -116715,8 +116656,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 11.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 11.0
                                         }
                                     },
                                     {
@@ -116725,8 +116666,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 11.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 11.0
                                         }
                                     },
                                     {
@@ -116735,8 +116676,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 15.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 15.0
                                         }
                                     },
                                     {
@@ -116745,8 +116686,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF4",
-                                            "FTTPTNUM": 27.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 27.0
                                         }
                                     },
                                     {
@@ -116755,8 +116696,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF4",
-                                            "FTTPTNUM": 21.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 21.0
                                         }
                                     },
                                     {
@@ -116765,8 +116706,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 22.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 22.0
                                         }
                                     },
                                     {
@@ -116775,8 +116716,8 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 25.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 25.0
                                         }
                                     },
                                     {
@@ -116785,8 +116726,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -116795,8 +116736,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -116805,8 +116746,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": null,
-                                            "FTTPTNUM": 12.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 12.0
                                         }
                                     },
                                     {
@@ -116815,8 +116756,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": null,
-                                            "FTTPTNUM": 16.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 16.0
                                         }
                                     },
                                     {
@@ -116825,8 +116766,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 22.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 22.0
                                         }
                                     },
                                     {
@@ -116835,8 +116776,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 28.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 28.0
                                         }
                                     },
                                     {
@@ -116845,8 +116786,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 23.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 23.0
                                         }
                                     },
                                     {
@@ -116855,8 +116796,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 23.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 23.0
                                         }
                                     },
                                     {
@@ -116865,8 +116806,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF6",
-                                            "FTTPTNUM": 31.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 31.0
                                         }
                                     },
                                     {
@@ -116875,8 +116816,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF6",
-                                            "FTTPTNUM": 36.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 36.0
                                         }
                                     },
                                     {
@@ -116885,8 +116826,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF6",
-                                            "FTTPTNUM": 31.0,
-                                            "FTTPT": "30 MIN POST"
+                                            "FTTPT": "30 MIN POST",
+                                            "FTTPTNUM": 31.0
                                         }
                                     },
                                     {
@@ -116895,8 +116836,8 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF6",
-                                            "FTTPTNUM": 31.0,
-                                            "FTTPT": "30 MIN POST3"
+                                            "FTTPT": "30 MIN POST3",
+                                            "FTTPTNUM": 31.0
                                         }
                                     }
                                 ]
@@ -117370,9 +117311,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -117381,9 +117322,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST1",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -117392,9 +117333,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 13.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 13.0
                                         }
                                     },
                                     {
@@ -117403,9 +117344,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -117414,9 +117355,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF3",
-                                            "FTTPTNUM": 20.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 20.0
                                         }
                                     },
                                     {
@@ -117425,9 +117366,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF3",
-                                            "FTTPTNUM": 20.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 20.0
                                         }
                                     },
                                     {
@@ -117436,9 +117377,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF3",
-                                            "FTTPTNUM": 29.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 29.0
                                         }
                                     },
                                     {
@@ -117447,9 +117388,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF4",
-                                            "FTTPTNUM": 21.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 21.0
                                         }
                                     },
                                     {
@@ -117458,9 +117399,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF5",
-                                            "FTTPTNUM": 30.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 30.0
                                         }
                                     },
                                     {
@@ -117469,9 +117410,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF5",
-                                            "FTTPTNUM": 30.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 30.0
                                         }
                                     },
                                     {
@@ -117480,9 +117421,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF5",
-                                            "FTTPTNUM": 35.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 35.0
                                         }
                                     },
                                     {
@@ -117491,9 +117432,9 @@
                                         "USUBJID": "CDISC001",
                                         "value": {
                                             "FTTPTREF": "REF5",
-                                            "FTTPTNUM": 30.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 30.0
                                         }
                                     },
                                     {
@@ -117502,9 +117443,9 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 11.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST2",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 11.0
                                         }
                                     },
                                     {
@@ -117513,9 +117454,9 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 11.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 11.0
                                         }
                                     },
                                     {
@@ -117524,9 +117465,9 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 11.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 11.0
                                         }
                                     },
                                     {
@@ -117535,9 +117476,9 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 15.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 15.0
                                         }
                                     },
                                     {
@@ -117546,9 +117487,9 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF4",
-                                            "FTTPTNUM": 27.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 27.0
                                         }
                                     },
                                     {
@@ -117557,9 +117498,9 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF4",
-                                            "FTTPTNUM": 21.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 21.0
                                         }
                                     },
                                     {
@@ -117568,9 +117509,9 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 22.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 22.0
                                         }
                                     },
                                     {
@@ -117579,9 +117520,9 @@
                                         "USUBJID": "CDISC002",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 25.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 25.0
                                         }
                                     },
                                     {
@@ -117590,9 +117531,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -117601,9 +117542,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 10.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 10.0
                                         }
                                     },
                                     {
@@ -117612,9 +117553,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": null,
-                                            "FTTPTNUM": 12.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 12.0
                                         }
                                     },
                                     {
@@ -117623,9 +117564,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": null,
-                                            "FTTPTNUM": 16.0,
+                                            "VISITNUM": 2.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 2.0
+                                            "FTTPTNUM": 16.0
                                         }
                                     },
                                     {
@@ -117634,9 +117575,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF1",
-                                            "FTTPTNUM": 22.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 22.0
                                         }
                                     },
                                     {
@@ -117645,9 +117586,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 28.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 28.0
                                         }
                                     },
                                     {
@@ -117656,9 +117597,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 23.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 23.0
                                         }
                                     },
                                     {
@@ -117667,9 +117608,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF2",
-                                            "FTTPTNUM": 23.0,
+                                            "VISITNUM": 8.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 8.0
+                                            "FTTPTNUM": 23.0
                                         }
                                     },
                                     {
@@ -117678,9 +117619,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF6",
-                                            "FTTPTNUM": 31.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 31.0
                                         }
                                     },
                                     {
@@ -117689,9 +117630,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF6",
-                                            "FTTPTNUM": 36.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 36.0
                                         }
                                     },
                                     {
@@ -117700,9 +117641,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF6",
-                                            "FTTPTNUM": 31.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 31.0
                                         }
                                     },
                                     {
@@ -117711,9 +117652,9 @@
                                         "USUBJID": "CDISC003",
                                         "value": {
                                             "FTTPTREF": "REF6",
-                                            "FTTPTNUM": 31.0,
+                                            "VISITNUM": 201.0,
                                             "FTTPT": "30 MIN POST3",
-                                            "VISITNUM": 201.0
+                                            "FTTPTNUM": 31.0
                                         }
                                     }
                                 ]
@@ -118741,8 +118682,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "DTHDTC": null,
-                                            "DTHFL": "Y"
+                                            "DTHFL": "Y",
+                                            "DTHDTC": null
                                         }
                                     }
                                 ]
@@ -119315,8 +119256,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "SMSTDY": 100.0,
-                                            "SMENDY": 50.0
+                                            "SMENDY": 50.0,
+                                            "SMSTDY": 100.0
                                         }
                                     }
                                 ]
@@ -119333,8 +119274,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SEENDY": 1430.0,
-                                            "SESTDY": 1435.0
+                                            "SESTDY": 1435.0,
+                                            "SEENDY": 1430.0
                                         }
                                     }
                                 ]
@@ -119705,8 +119646,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "CMSTTPT": "2013-05-19",
                                             "CMSTRTPT": null,
+                                            "CMSTTPT": "2013-05-19",
                                             "CMDTC": "2013-05-20"
                                         }
                                     },
@@ -119715,8 +119656,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "CMSTTPT": "2013-05-10",
                                             "CMSTRTPT": "ONGOING",
+                                            "CMSTTPT": "2013-05-10",
                                             "CMDTC": "2013-05-20"
                                         }
                                     },
@@ -119725,8 +119666,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "CMSTTPT": "2013-05-10",
                                             "CMSTRTPT": "ONGOING",
+                                            "CMSTTPT": "2013-05-10",
                                             "CMDTC": "2013-05-20"
                                         }
                                     },
@@ -119735,8 +119676,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "CMSTTPT": "2013-05-10",
                                             "CMSTRTPT": "POST",
+                                            "CMSTTPT": "2013-05-10",
                                             "CMDTC": "2013-05-20"
                                         }
                                     },
@@ -119745,8 +119686,8 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "CMSTTPT": "2013-05-10",
                                             "CMSTRTPT": "UNK",
+                                            "CMSTTPT": "2013-05-10",
                                             "CMDTC": "2013-05-20"
                                         }
                                     }
@@ -119764,9 +119705,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "MHDTC": "2013-05-20",
                                             "MHSTTPT": "2013-02-18",
-                                            "MHSTRTPT": "ONGOING"
+                                            "MHSTRTPT": "ONGOING",
+                                            "MHDTC": "2013-05-20"
                                         }
                                     },
                                     {
@@ -119774,9 +119715,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "MHDTC": "2013-05-20",
                                             "MHSTTPT": "2007-04-20",
-                                            "MHSTRTPT": "ONGOING"
+                                            "MHSTRTPT": "ONGOING",
+                                            "MHDTC": "2013-05-20"
                                         }
                                     },
                                     {
@@ -119784,9 +119725,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "MHDTC": "2013-05-20",
                                             "MHSTTPT": "2012-05-20",
-                                            "MHSTRTPT": "ONGOING"
+                                            "MHSTRTPT": "ONGOING",
+                                            "MHDTC": "2013-05-20"
                                         }
                                     },
                                     {
@@ -119794,9 +119735,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC012",
                                         "value": {
-                                            "MHDTC": "2013-05-03",
                                             "MHSTTPT": "2013-05-02",
-                                            "MHSTRTPT": null
+                                            "MHSTRTPT": null,
+                                            "MHDTC": "2013-05-03"
                                         }
                                     },
                                     {
@@ -119804,9 +119745,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "MHDTC": "2013-05-04",
                                             "MHSTTPT": "2013-04-04",
-                                            "MHSTRTPT": null
+                                            "MHSTRTPT": null,
+                                            "MHDTC": "2013-05-04"
                                         }
                                     }
                                 ]
@@ -120774,8 +120715,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "RFSTDTC": "2018-04-17T09:25",
-                                            "RFICDTC": "2018-05"
+                                            "RFICDTC": "2018-05",
+                                            "RFSTDTC": "2018-04-17T09:25"
                                         }
                                     },
                                     {
@@ -120783,8 +120724,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "RFSTDTC": "2018-04-18T09:30",
-                                            "RFICDTC": "2018-04-22"
+                                            "RFICDTC": "2018-04-22",
+                                            "RFSTDTC": "2018-04-18T09:30"
                                         }
                                     },
                                     {
@@ -120792,8 +120733,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC005",
                                         "value": {
-                                            "RFSTDTC": "2018-04-18T09:30",
-                                            "RFICDTC": "2019"
+                                            "RFICDTC": "2019",
+                                            "RFSTDTC": "2018-04-18T09:30"
                                         }
                                     }
                                 ]
@@ -120941,8 +120882,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFXSTDTC": "2019-02-20T11:50",
-                                            "RFXENDTC": "2019-02-20T10:38"
+                                            "RFXENDTC": "2019-02-20T10:38",
+                                            "RFXSTDTC": "2019-02-20T11:50"
                                         }
                                     },
                                     {
@@ -120950,8 +120891,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "RFXSTDTC": "2018-08-18T09:30",
-                                            "RFXENDTC": "2018-07-18T11:15"
+                                            "RFXENDTC": "2018-07-18T11:15",
+                                            "RFXSTDTC": "2018-08-18T09:30"
                                         }
                                     },
                                     {
@@ -120959,8 +120900,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "RFXSTDTC": "2018-04-17",
-                                            "RFXENDTC": "2018-04"
+                                            "RFXENDTC": "2018-04",
+                                            "RFXSTDTC": "2018-04-17"
                                         }
                                     }
                                 ]
@@ -121135,8 +121076,8 @@
                                         "SEQ": 735,
                                         "USUBJID": "CDISC-TEST-046",
                                         "value": {
-                                            "AESOCCD": 10029205.0,
-                                            "AESOC": "Nervous system disorders"
+                                            "AESOC": "Nervous system disorders",
+                                            "AESOCCD": 10029205.0
                                         }
                                     },
                                     {
@@ -121144,8 +121085,8 @@
                                         "SEQ": 782,
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
-                                            "AESOCCD": 10029206.0,
-                                            "AESOC": "Nervous system disorders"
+                                            "AESOC": "Nervous system disorders",
+                                            "AESOCCD": 10029206.0
                                         }
                                     },
                                     {
@@ -121153,8 +121094,8 @@
                                         "SEQ": 783,
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
-                                            "AESOCCD": null,
-                                            "AESOC": "Nervous system disorders"
+                                            "AESOC": "Nervous system disorders",
+                                            "AESOCCD": null
                                         }
                                     },
                                     {
@@ -121162,8 +121103,8 @@
                                         "SEQ": 839,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AESOCCD": 10029205.0,
-                                            "AESOC": "Nervous system disorders"
+                                            "AESOC": "Nervous system disorders",
+                                            "AESOCCD": 10029205.0
                                         }
                                     },
                                     {
@@ -121171,8 +121112,8 @@
                                         "SEQ": 840,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AESOCCD": 10047065.0,
-                                            "AESOC": "Vascular disorders"
+                                            "AESOC": "Vascular disorders",
+                                            "AESOCCD": 10047065.0
                                         }
                                     },
                                     {
@@ -121180,8 +121121,8 @@
                                         "SEQ": 843,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AESOCCD": 10047065.0,
-                                            "AESOC": null
+                                            "AESOC": null,
+                                            "AESOCCD": 10047065.0
                                         }
                                     }
                                 ]
@@ -121581,8 +121522,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "SVENDTC": "2018-02-20T16:31:00",
-                                            "SVSTDTC": "2018-02-20T16:38"
+                                            "SVSTDTC": "2018-02-20T16:38",
+                                            "SVENDTC": "2018-02-20T16:31:00"
                                         }
                                     }
                                 ]
@@ -121599,8 +121540,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "AEENDTC": "2018-06-14",
-                                            "AESTDTC": "2019"
+                                            "AESTDTC": "2019",
+                                            "AEENDTC": "2018-06-14"
                                         }
                                     }
                                 ]
@@ -122080,8 +122021,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFPENDTC": "2022-01-19",
-                                            "CEDTC": "2022-01-20"
+                                            "CEDTC": "2022-01-20",
+                                            "RFPENDTC": "2022-01-19"
                                         }
                                     }
                                 ]
@@ -122537,8 +122478,8 @@
                                         "SEQ": 735,
                                         "USUBJID": "CDISC-TEST-046",
                                         "value": {
-                                            "AEBODSYS": "Nervous system disorders",
-                                            "AEBDSYCD": 10029205.0
+                                            "AEBDSYCD": 10029205.0,
+                                            "AEBODSYS": "Nervous system disorders"
                                         }
                                     },
                                     {
@@ -122546,8 +122487,8 @@
                                         "SEQ": 782,
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
-                                            "AEBODSYS": "Nervous system disorders",
-                                            "AEBDSYCD": 10029206.0
+                                            "AEBDSYCD": 10029206.0,
+                                            "AEBODSYS": "Nervous system disorders"
                                         }
                                     },
                                     {
@@ -122555,8 +122496,8 @@
                                         "SEQ": 783,
                                         "USUBJID": "CDISC-TEST-049",
                                         "value": {
-                                            "AEBODSYS": "Nervous system disorders",
-                                            "AEBDSYCD": null
+                                            "AEBDSYCD": null,
+                                            "AEBODSYS": "Nervous system disorders"
                                         }
                                     },
                                     {
@@ -122564,8 +122505,8 @@
                                         "SEQ": 839,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AEBODSYS": "Nervous system disorders",
-                                            "AEBDSYCD": 10029205.0
+                                            "AEBDSYCD": 10029205.0,
+                                            "AEBODSYS": "Nervous system disorders"
                                         }
                                     },
                                     {
@@ -122573,8 +122514,8 @@
                                         "SEQ": 840,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AEBODSYS": "Vascular disorders",
-                                            "AEBDSYCD": 10047065.0
+                                            "AEBDSYCD": 10047065.0,
+                                            "AEBODSYS": "Vascular disorders"
                                         }
                                     },
                                     {
@@ -122582,8 +122523,8 @@
                                         "SEQ": 843,
                                         "USUBJID": "CDISC-TEST-052",
                                         "value": {
-                                            "AEBODSYS": null,
-                                            "AEBDSYCD": 10047065.0
+                                            "AEBDSYCD": 10047065.0,
+                                            "AEBODSYS": null
                                         }
                                     }
                                 ]
@@ -123162,8 +123103,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Y ",
-                                            "TSVALCD": "C494888"
+                                            "TSVALCD": "C494888",
+                                            "TSVAL": "Y "
                                         }
                                     },
                                     {
@@ -123171,8 +123112,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Adenocarcinom a of pancreas ",
-                                            "TSVALCD": "C494888"
+                                            "TSVALCD": "C494888",
+                                            "TSVAL": "Adenocarcinom a of pancreas "
                                         }
                                     },
                                     {
@@ -123180,8 +123121,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Y ",
-                                            "TSVALCD": "C49488 "
+                                            "TSVALCD": "C49488 ",
+                                            "TSVAL": "Y "
                                         }
                                     },
                                     {
@@ -123189,8 +123130,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Adenocarcinom a of pancreas ",
-                                            "TSVALCD": "700423003"
+                                            "TSVALCD": "700423003",
+                                            "TSVAL": "Adenocarcinom a of pancreas "
                                         }
                                     }
                                 ]
@@ -123271,8 +123212,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "N",
-                                            "TSVALCD": "C49488 "
+                                            "TSVALCD": "C49488 ",
+                                            "TSVAL": "N"
                                         }
                                     },
                                     {
@@ -123280,8 +123221,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Y ",
-                                            "TSVALCD": "C49488 "
+                                            "TSVALCD": "C49488 ",
+                                            "TSVAL": "Y "
                                         }
                                     },
                                     {
@@ -123289,8 +123230,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Adenocarcinom a of pancreas ",
-                                            "TSVALCD": "700423003"
+                                            "TSVALCD": "700423003",
+                                            "TSVAL": "Adenocarcinom a of pancreas "
                                         }
                                     }
                                 ]
@@ -123460,8 +123401,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "04/01/2015",
-                                            "TSPARMCD": "AGEMIN"
+                                            "TSPARMCD": "AGEMIN",
+                                            "TSVAL": "04/01/2015"
                                         }
                                     },
                                     {
@@ -123469,8 +123410,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "100",
-                                            "TSPARMCD": "AGEMIN"
+                                            "TSPARMCD": "AGEMIN",
+                                            "TSVAL": "100"
                                         }
                                     },
                                     {
@@ -123478,8 +123419,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "string",
-                                            "TSPARMCD": "AGEMIN"
+                                            "TSPARMCD": "AGEMIN",
+                                            "TSVAL": "string"
                                         }
                                     }
                                 ]
@@ -123545,8 +123486,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "P40Y",
-                                            "TSPARMCD": "AGEMIN"
+                                            "TSPARMCD": "AGEMIN",
+                                            "TSVAL": "P40Y"
                                         }
                                     }
                                 ]
@@ -123648,8 +123589,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "string",
-                                            "TSPARMCD": "LENGTH"
+                                            "TSPARMCD": "LENGTH",
+                                            "TSVAL": "string"
                                         }
                                     },
                                     {
@@ -123657,8 +123598,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "100",
-                                            "TSPARMCD": "LENGTH"
+                                            "TSPARMCD": "LENGTH",
+                                            "TSVAL": "100"
                                         }
                                     },
                                     {
@@ -123666,8 +123607,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "10-22-2011 11:16:32",
-                                            "TSPARMCD": "LENGTH"
+                                            "TSPARMCD": "LENGTH",
+                                            "TSVAL": "10-22-2011 11:16:32"
                                         }
                                     }
                                 ]
@@ -123733,8 +123674,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "P1D",
-                                            "TSPARMCD": "LENGTH"
+                                            "TSPARMCD": "LENGTH",
+                                            "TSVAL": "P1D"
                                         }
                                     }
                                 ]
@@ -123868,8 +123809,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "TRT",
                                             "$trt_count": 1,
+                                            "TSPARMCD": "TRT",
                                             "$rand_count": "Not in dataset"
                                         }
                                     }
@@ -123964,8 +123905,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "TRT",
                                             "$trt_count": 1,
+                                            "TSPARMCD": "TRT",
                                             "$rand_count": "Not in dataset"
                                         }
                                     },
@@ -123974,8 +123915,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "RAND",
                                             "$trt_count": 1,
+                                            "TSPARMCD": "RAND",
                                             "$rand_count": "Not in dataset"
                                         }
                                     }
@@ -124005,8 +123946,8 @@
                                                 "SEQ": 1,
                                                 "USUBJID": null,
                                                 "value": {
-                                                    "TSPARMCD": "TRT",
                                                     "$trt_count": 1,
+                                                    "TSPARMCD": "TRT",
                                                     "$rand_count": "Not in dataset"
                                                 }
                                             }
@@ -124027,8 +123968,8 @@
                                                 "SEQ": 1,
                                                 "USUBJID": null,
                                                 "value": {
-                                                    "TSPARMCD": "RAND",
                                                     "$trt_count": 1,
+                                                    "TSPARMCD": "RAND",
                                                     "$rand_count": "Not in dataset"
                                                 }
                                             }
@@ -124166,8 +124107,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "\t\tStudy Data Technical Conformance Guide v4.4",
-                                            "TSPARMCD": "FDATCHSS"
+                                            "TSPARMCD": "FDATCHSS",
+                                            "TSVAL": "\t\tStudy Data Technical Conformance Guide v4.4"
                                         }
                                     },
                                     {
@@ -124175,8 +124116,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "\t\tStudy Data Technical Conformance Guide v4.4",
-                                            "TSPARMCD": "FDATCHSS"
+                                            "TSPARMCD": "FDATCHSS",
+                                            "TSVAL": "\t\tStudy Data Technical Conformance Guide v4.4"
                                         }
                                     }
                                 ]
@@ -124324,8 +124265,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "COMPTRT",
-                                            "TSVCDREF": null
+                                            "TSVCDREF": null,
+                                            "TSPARMCD": "COMPTRT"
                                         }
                                     },
                                     {
@@ -124333,8 +124274,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "CURTRT",
-                                            "TSVCDREF": null
+                                            "TSVCDREF": null,
+                                            "TSPARMCD": "CURTRT"
                                         }
                                     },
                                     {
@@ -124342,8 +124283,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSPARMCD": "TRT",
-                                            "TSVCDREF": "ISO 8601"
+                                            "TSVCDREF": "ISO 8601",
+                                            "TSPARMCD": "TRT"
                                         }
                                     }
                                 ]
@@ -124487,10 +124428,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "TSPARMCD": "AGE",
                                             "TSVAL": "NonEmpty",
-                                            "$agetxt_count": 1,
                                             "$age_count": 1,
-                                            "TSPARMCD": "AGE"
+                                            "$agetxt_count": 1
                                         }
                                     },
                                     {
@@ -124498,10 +124439,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "TSPARMCD": "AGETXT",
                                             "TSVAL": "NonEmpty",
-                                            "$agetxt_count": 1,
                                             "$age_count": 1,
-                                            "TSPARMCD": "AGETXT"
+                                            "$agetxt_count": 1
                                         }
                                     }
                                 ]
@@ -124973,8 +124914,8 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "test",
-                                            "TSPARMCD": "ACTSUB"
+                                            "TSPARMCD": "ACTSUB",
+                                            "TSVAL": "test"
                                         }
                                     }
                                 ]
@@ -125154,9 +125095,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "TSPARMCD": "CRMDUR",
                                             "TSVAL": null,
-                                            "$crmdur_count": 1,
-                                            "TSPARMCD": "CRMDUR"
+                                            "$crmdur_count": 1
                                         }
                                     }
                                 ]
@@ -125729,9 +125670,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "NonEmpty",
-                                            "TSPARMCD": "INTMODEL",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "INTMODEL"
                                         }
                                     },
                                     {
@@ -125739,9 +125680,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "N",
-                                            "TSPARMCD": "INTTYPE",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "INTTYPE"
                                         }
                                     },
                                     {
@@ -125749,9 +125690,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "asdf",
-                                            "TSPARMCD": "PCLASS",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "PCLASS"
                                         }
                                     },
                                     {
@@ -125759,9 +125700,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "NOT",
-                                            "TSPARMCD": "STYPE",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "STYPE"
                                         }
                                     },
                                     {
@@ -125769,9 +125710,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "46",
-                                            "TSPARMCD": "AGE",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "AGE"
                                         }
                                     },
                                     {
@@ -125779,9 +125720,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "2021-12-02 00:00:00",
-                                            "TSPARMCD": "DCUTDTC",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "DCUTDTC"
                                         }
                                     },
                                     {
@@ -125789,9 +125730,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "25",
-                                            "TSPARMCD": "DOSE",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "DOSE"
                                         }
                                     },
                                     {
@@ -125799,9 +125740,9 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "50",
-                                            "TSPARMCD": "DOSE",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "DOSE"
                                         }
                                     },
                                     {
@@ -125809,9 +125750,9 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "10",
-                                            "TSPARMCD": "DOSE",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "DOSE"
                                         }
                                     },
                                     {
@@ -125819,9 +125760,9 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "20",
-                                            "TSPARMCD": "DOSE",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "DOSE"
                                         }
                                     },
                                     {
@@ -125829,9 +125770,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 0,
                                             "TSVAL": "CAPSULE",
-                                            "TSPARMCD": "DOSFRM",
-                                            "$STYPE_INTERVENTIONAL": 0
+                                            "TSPARMCD": "DOSFRM"
                                         }
                                     }
                                 ]
@@ -125905,9 +125846,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 1,
                                             "TSVAL": null,
-                                            "TSPARMCD": "INTTYPE",
-                                            "$STYPE_INTERVENTIONAL": 1
+                                            "TSPARMCD": "INTTYPE"
                                         }
                                     },
                                     {
@@ -125915,9 +125856,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 1,
                                             "TSVAL": null,
-                                            "TSPARMCD": "PCLASS",
-                                            "$STYPE_INTERVENTIONAL": 1
+                                            "TSPARMCD": "PCLASS"
                                         }
                                     }
                                 ]
@@ -126081,9 +126022,9 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
+                                            "$STYPE_INTERVENTIONAL": 1,
                                             "TSVAL": "NonEmpty",
-                                            "TSPARMCD": "INTMODEL",
-                                            "$STYPE_INTERVENTIONAL": 1
+                                            "TSPARMCD": "INTMODEL"
                                         }
                                     }
                                 ]
@@ -126294,10 +126235,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Y",
                                             "TSPARMCD": "HLTSUBJI",
-                                            "$INDIC": 0,
+                                            "TSVAL": "Y",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126306,10 +126247,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": null,
                                             "TSPARMCD": "INDIC",
-                                            "$INDIC": 0,
+                                            "TSVAL": null,
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126318,10 +126259,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "N",
                                             "TSPARMCD": "ADDON",
-                                            "$INDIC": 0,
+                                            "TSVAL": "N",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126330,10 +126271,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "P75Y",
                                             "TSPARMCD": "AGEMAX",
-                                            "$INDIC": 0,
+                                            "TSVAL": "P75Y",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126342,10 +126283,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Database Lock",
                                             "TSPARMCD": "DCUTDESC",
-                                            "$INDIC": 0,
+                                            "TSVAL": "Database Lock",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126354,10 +126295,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "2021-12-02 00:00:00",
                                             "TSPARMCD": "DCUTDTC",
-                                            "$INDIC": 0,
+                                            "TSVAL": "2021-12-02 00:00:00",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126366,10 +126307,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "25",
                                             "TSPARMCD": "DOSE",
-                                            "$INDIC": 0,
+                                            "TSVAL": "25",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126378,10 +126319,10 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "50",
                                             "TSPARMCD": "DOSE",
-                                            "$INDIC": 0,
+                                            "TSVAL": "50",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126390,10 +126331,10 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "10",
                                             "TSPARMCD": "DOSE",
-                                            "$INDIC": 0,
+                                            "TSVAL": "10",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126402,10 +126343,10 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "20",
                                             "TSPARMCD": "DOSE",
-                                            "$INDIC": 0,
+                                            "TSVAL": "20",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126414,10 +126355,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "CAPSULE",
                                             "TSPARMCD": "DOSFRM",
-                                            "$INDIC": 0,
+                                            "TSVAL": "CAPSULE",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     }
@@ -126607,10 +126548,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Y",
                                             "TSPARMCD": "HLTSUBJI",
-                                            "$INDIC": 0,
+                                            "TSVAL": "Y",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126619,10 +126560,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": null,
                                             "TSPARMCD": "INDIC",
-                                            "$INDIC": 0,
+                                            "TSVAL": null,
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126631,10 +126572,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "N",
                                             "TSPARMCD": "ADDON",
-                                            "$INDIC": 0,
+                                            "TSVAL": "N",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126643,10 +126584,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "P75Y",
                                             "TSPARMCD": "AGEMAX",
-                                            "$INDIC": 0,
+                                            "TSVAL": "P75Y",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126655,10 +126596,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Database Lock",
                                             "TSPARMCD": "DCUTDESC",
-                                            "$INDIC": 0,
+                                            "TSVAL": "Database Lock",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126667,10 +126608,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "2021-12-02 00:00:00",
                                             "TSPARMCD": "DCUTDTC",
-                                            "$INDIC": 0,
+                                            "TSVAL": "2021-12-02 00:00:00",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126679,10 +126620,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "25",
                                             "TSPARMCD": "DOSE",
-                                            "$INDIC": 0,
+                                            "TSVAL": "25",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126691,10 +126632,10 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "50",
                                             "TSPARMCD": "DOSE",
-                                            "$INDIC": 0,
+                                            "TSVAL": "50",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126703,10 +126644,10 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "10",
                                             "TSPARMCD": "DOSE",
-                                            "$INDIC": 0,
+                                            "TSVAL": "10",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126715,10 +126656,10 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "20",
                                             "TSPARMCD": "DOSE",
-                                            "$INDIC": 0,
+                                            "TSVAL": "20",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     },
@@ -126727,10 +126668,10 @@
                                         "SEQ": 1,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "CAPSULE",
                                             "TSPARMCD": "DOSFRM",
-                                            "$INDIC": 0,
+                                            "TSVAL": "CAPSULE",
                                             "$HLTSUBJI": 1,
+                                            "$INDIC": 0,
                                             "TSVALNF": null
                                         }
                                     }
@@ -126850,8 +126791,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IETESTCD": "INCL01",
-                                            "IETEST": "Has disease under study"
+                                            "IETEST": "Has disease under study",
+                                            "IETESTCD": "INCL01"
                                         }
                                     },
                                     {
@@ -126859,8 +126800,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IETESTCD": "INCL01",
-                                            "IETEST": "Age 21 or greater"
+                                            "IETEST": "Age 21 or greater",
+                                            "IETESTCD": "INCL01"
                                         }
                                     },
                                     {
@@ -126868,8 +126809,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IETESTCD": "EXCL01",
-                                            "IETEST": "Pregnant or lactating"
+                                            "IETEST": "Pregnant or lactating",
+                                            "IETESTCD": "EXCL01"
                                         }
                                     },
                                     {
@@ -126877,8 +126818,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IETESTCD": "INCL01",
-                                            "IETEST": "Has disease under study"
+                                            "IETEST": "Has disease under study",
+                                            "IETESTCD": "INCL01"
                                         }
                                     },
                                     {
@@ -126886,8 +126827,8 @@
                                         "SEQ": null,
                                         "USUBJID": null,
                                         "value": {
-                                            "IETESTCD": null,
-                                            "IETEST": "Pregnant or lactating"
+                                            "IETEST": "Pregnant or lactating",
+                                            "IETESTCD": null
                                         }
                                     }
                                 ]
@@ -127053,8 +126994,8 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "OIPARM": "Genotype",
-                                            "OIPARMCD": null
+                                            "OIPARMCD": null,
+                                            "OIPARM": "Genotype"
                                         }
                                     },
                                     {
@@ -127062,8 +127003,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "OIPARM": "Genotype",
-                                            "OIPARMCD": "GENTYPE"
+                                            "OIPARMCD": "GENTYPE",
+                                            "OIPARM": "Genotype"
                                         }
                                     },
                                     {
@@ -127071,8 +127012,8 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
-                                            "OIPARM": null,
-                                            "OIPARMCD": "SUBTYPE"
+                                            "OIPARMCD": "SUBTYPE",
+                                            "OIPARM": null
                                         }
                                     },
                                     {
@@ -127080,8 +127021,8 @@
                                         "SEQ": 5,
                                         "USUBJID": null,
                                         "value": {
-                                            "OIPARM": "Subtype",
-                                            "OIPARMCD": "SUBTYPE"
+                                            "OIPARMCD": "SUBTYPE",
+                                            "OIPARM": "Subtype"
                                         }
                                     }
                                 ]
@@ -127604,9 +127545,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RELREC.FAOBJ": "ERYTHEMA",
+                                            "CMTRT": "HYDROCORTISONE, TOPICAL",
                                             "CMDECOD": null,
-                                            "CMTRT": "HYDROCORTISONE, TOPICAL"
+                                            "RELREC.FAOBJ": "ERYTHEMA"
                                         }
                                     }
                                 ]
@@ -127728,9 +127669,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RELREC.FAOBJ": "ASPIRINA",
+                                            "CMTRT": "ASPIRIN",
                                             "CMDECOD": null,
-                                            "CMTRT": "ASPIRIN"
+                                            "RELREC.FAOBJ": "ASPIRINA"
                                         }
                                     },
                                     {
@@ -127738,9 +127679,9 @@
                                         "SEQ": 3,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RELREC.FAOBJ": "ERYTHEMA",
+                                            "CMTRT": "HYDROCORTISONE, TOPICAL",
                                             "CMDECOD": null,
-                                            "CMTRT": "HYDROCORTISONE, TOPICAL"
+                                            "RELREC.FAOBJ": "ERYTHEMA"
                                         }
                                     }
                                 ]
@@ -128286,8 +128227,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "RFCSTDTC": "2020-04-20T09:40",
-                                            "RFCENDTC": "2019-04-20T10:38"
+                                            "RFCENDTC": "2019-04-20T10:38",
+                                            "RFCSTDTC": "2020-04-20T09:40"
                                         }
                                     },
                                     {
@@ -128295,8 +128236,8 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "RFCSTDTC": "2018-08-18",
-                                            "RFCENDTC": "2018-07-18"
+                                            "RFCENDTC": "2018-07-18",
+                                            "RFCSTDTC": "2018-08-18"
                                         }
                                     }
                                 ]
@@ -128714,8 +128655,8 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "CMSTTPT": "2013-05-20",
                                             "CMSTRTPT": null,
+                                            "CMSTTPT": "2013-05-20",
                                             "CMDTC": "2013-05-20"
                                         }
                                     }
@@ -128733,9 +128674,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "MHDTC": "2013-05-20",
                                             "MHSTTPT": "2013-05-20",
-                                            "MHSTRTPT": "ONGOING"
+                                            "MHSTRTPT": "ONGOING",
+                                            "MHDTC": "2013-05-20"
                                         }
                                     },
                                     {
@@ -128743,9 +128684,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "MHDTC": "2013-05-20",
                                             "MHSTTPT": "2013-05-20",
-                                            "MHSTRTPT": "AFTER"
+                                            "MHSTRTPT": "AFTER",
+                                            "MHDTC": "2013-05-20"
                                         }
                                     },
                                     {
@@ -128753,9 +128694,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC006",
                                         "value": {
-                                            "MHDTC": "2013-05-20",
                                             "MHSTTPT": "2013-05-20",
-                                            "MHSTRTPT": "ONGOING"
+                                            "MHSTRTPT": "ONGOING",
+                                            "MHDTC": "2013-05-20"
                                         }
                                     },
                                     {
@@ -128763,9 +128704,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC007",
                                         "value": {
-                                            "MHDTC": "2013-05-20",
                                             "MHSTTPT": "2013-05-20",
-                                            "MHSTRTPT": "ONGOING"
+                                            "MHSTRTPT": "ONGOING",
+                                            "MHDTC": "2013-05-20"
                                         }
                                     },
                                     {
@@ -128773,9 +128714,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC012",
                                         "value": {
-                                            "MHDTC": "2013-05-03",
                                             "MHSTTPT": "2013-05-03",
-                                            "MHSTRTPT": "AFTER"
+                                            "MHSTRTPT": "AFTER",
+                                            "MHDTC": "2013-05-03"
                                         }
                                     },
                                     {
@@ -128783,9 +128724,9 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC013",
                                         "value": {
-                                            "MHDTC": "2013-05-04",
                                             "MHSTTPT": "2013-05-04",
-                                            "MHSTRTPT": null
+                                            "MHSTRTPT": null,
+                                            "MHDTC": "2013-05-04"
                                         }
                                     }
                                 ]
@@ -128979,9 +128920,9 @@
                                         "SEQ": 2,
                                         "USUBJID": "CDISC001",
                                         "value": {
+                                            "RELREC.FAOBJ": "ERROR",
                                             "AEDECOD": null,
-                                            "AETERM": "FATIGUE",
-                                            "RELREC.FAOBJ": "ERROR"
+                                            "AETERM": "FATIGUE"
                                         }
                                     }
                                 ]
@@ -129246,8 +129187,8 @@
                                         "SEQ": 1,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "AEDECOD": "TEST",
-                                            "RELREC.FAOBJ": "ERYTHEMA"
+                                            "RELREC.FAOBJ": "ERYTHEMA",
+                                            "AEDECOD": "TEST"
                                         }
                                     }
                                 ]
@@ -133222,9 +133163,6 @@
                                         "SEQ": null,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "QNAM": "LBCLSIG",
-                                            "STUDYID": "CDISC-PILOT-01",
-                                            "USUBJID": "S001",
                                             "$model_variables": [
                                                 "STUDYID",
                                                 "DOMAIN",
@@ -133390,7 +133328,10 @@
                                                 "LBDETECT",
                                                 "LBPTFL",
                                                 "LBPDUR"
-                                            ]
+                                            ],
+                                            "STUDYID": "CDISC-PILOT-01",
+                                            "QNAM": "LBCLSIG",
+                                            "USUBJID": "S001"
                                         }
                                     },
                                     {
@@ -133398,9 +133339,6 @@
                                         "SEQ": null,
                                         "USUBJID": "S001",
                                         "value": {
-                                            "QNAM": "LBSTAT",
-                                            "STUDYID": "CDISC-PILOT-01",
-                                            "USUBJID": "S001",
                                             "$model_variables": [
                                                 "STUDYID",
                                                 "DOMAIN",
@@ -133566,7 +133504,10 @@
                                                 "LBDETECT",
                                                 "LBPTFL",
                                                 "LBPDUR"
-                                            ]
+                                            ],
+                                            "STUDYID": "CDISC-PILOT-01",
+                                            "QNAM": "LBSTAT",
+                                            "USUBJID": "S001"
                                         }
                                     }
                                 ]
@@ -133599,9 +133540,6 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "QNAM": "AESEV",
-                                            "STUDYID": "CDISCPILOT01",
-                                            "USUBJID": "CDISC001",
                                             "$model_variables": [
                                                 "STUDYID",
                                                 "DOMAIN",
@@ -133723,7 +133661,10 @@
                                                 "AEDETECT",
                                                 "AEPTFL",
                                                 "AEPDUR"
-                                            ]
+                                            ],
+                                            "STUDYID": "CDISCPILOT01",
+                                            "QNAM": "AESEV",
+                                            "USUBJID": "CDISC001"
                                         }
                                     },
                                     {
@@ -133731,9 +133672,6 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC002",
                                         "value": {
-                                            "QNAM": "AEPRESP",
-                                            "STUDYID": "CDISCPILOT01",
-                                            "USUBJID": "CDISC002",
                                             "$model_variables": [
                                                 "STUDYID",
                                                 "DOMAIN",
@@ -133855,7 +133793,10 @@
                                                 "AEDETECT",
                                                 "AEPTFL",
                                                 "AEPDUR"
-                                            ]
+                                            ],
+                                            "STUDYID": "CDISCPILOT01",
+                                            "QNAM": "AEPRESP",
+                                            "USUBJID": "CDISC002"
                                         }
                                     }
                                 ]
@@ -134048,9 +133989,6 @@
                                                 "SEQ": null,
                                                 "USUBJID": "S001",
                                                 "value": {
-                                                    "QNAM": "LBCLSIG",
-                                                    "STUDYID": "CDISC-PILOT-01",
-                                                    "USUBJID": "S001",
                                                     "$model_variables": [
                                                         "STUDYID",
                                                         "DOMAIN",
@@ -134216,7 +134154,10 @@
                                                         "LBDETECT",
                                                         "LBPTFL",
                                                         "LBPDUR"
-                                                    ]
+                                                    ],
+                                                    "STUDYID": "CDISC-PILOT-01",
+                                                    "QNAM": "LBCLSIG",
+                                                    "USUBJID": "S001"
                                                 }
                                             }
                                         },
@@ -134400,9 +134341,6 @@
                                                 "SEQ": null,
                                                 "USUBJID": "S001",
                                                 "value": {
-                                                    "QNAM": "LBSTAT",
-                                                    "STUDYID": "CDISC-PILOT-01",
-                                                    "USUBJID": "S001",
                                                     "$model_variables": [
                                                         "STUDYID",
                                                         "DOMAIN",
@@ -134568,7 +134506,10 @@
                                                         "LBDETECT",
                                                         "LBPTFL",
                                                         "LBPDUR"
-                                                    ]
+                                                    ],
+                                                    "STUDYID": "CDISC-PILOT-01",
+                                                    "QNAM": "LBSTAT",
+                                                    "USUBJID": "S001"
                                                 }
                                             }
                                         }
@@ -134712,9 +134653,6 @@
                                                 "SEQ": null,
                                                 "USUBJID": "CDISC001",
                                                 "value": {
-                                                    "QNAM": "AESEV",
-                                                    "STUDYID": "CDISCPILOT01",
-                                                    "USUBJID": "CDISC001",
                                                     "$model_variables": [
                                                         "STUDYID",
                                                         "DOMAIN",
@@ -134836,7 +134774,10 @@
                                                         "AEDETECT",
                                                         "AEPTFL",
                                                         "AEPDUR"
-                                                    ]
+                                                    ],
+                                                    "STUDYID": "CDISCPILOT01",
+                                                    "QNAM": "AESEV",
+                                                    "USUBJID": "CDISC001"
                                                 }
                                             }
                                         },
@@ -134976,9 +134917,6 @@
                                                 "SEQ": null,
                                                 "USUBJID": "CDISC002",
                                                 "value": {
-                                                    "QNAM": "AEPRESP",
-                                                    "STUDYID": "CDISCPILOT01",
-                                                    "USUBJID": "CDISC002",
                                                     "$model_variables": [
                                                         "STUDYID",
                                                         "DOMAIN",
@@ -135100,7 +135038,10 @@
                                                         "AEDETECT",
                                                         "AEPTFL",
                                                         "AEPDUR"
-                                                    ]
+                                                    ],
+                                                    "STUDYID": "CDISCPILOT01",
+                                                    "QNAM": "AEPRESP",
+                                                    "USUBJID": "CDISC002"
                                                 }
                                             }
                                         }
@@ -135454,11 +135395,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201001",
                                         "value": {
+                                            "SE.TAETORD": 1.0,
                                             "TAETORD": 3.0,
-                                            "SEENDTC": "2018-08-13",
-                                            "SESTDTC": "2018-06-29",
                                             "SVSTDTC": "2018-06-29",
-                                            "SE.TAETORD": 1.0
+                                            "SEENDTC": "2018-08-13",
+                                            "SESTDTC": "2018-06-29"
                                         }
                                     },
                                     {
@@ -135466,11 +135407,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201001",
                                         "value": {
+                                            "SE.TAETORD": 1.0,
                                             "TAETORD": 2.0,
-                                            "SEENDTC": "2018-08-13",
-                                            "SESTDTC": "2018-06-29",
                                             "SVSTDTC": "2018-08-12",
-                                            "SE.TAETORD": 1.0
+                                            "SEENDTC": "2018-08-13",
+                                            "SESTDTC": "2018-06-29"
                                         }
                                     },
                                     {
@@ -135478,11 +135419,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201001",
                                         "value": {
+                                            "SE.TAETORD": 2.0,
                                             "TAETORD": 3.0,
-                                            "SEENDTC": "2019-05-13",
-                                            "SESTDTC": "2018-08-13",
                                             "SVSTDTC": "2018-08-14",
-                                            "SE.TAETORD": 2.0
+                                            "SEENDTC": "2019-05-13",
+                                            "SESTDTC": "2018-08-13"
                                         }
                                     },
                                     {
@@ -135490,11 +135431,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201001",
                                         "value": {
+                                            "SE.TAETORD": 2.0,
                                             "TAETORD": 1.0,
-                                            "SEENDTC": "2019-05-13",
-                                            "SESTDTC": "2018-08-13",
                                             "SVSTDTC": "2018-08-28",
-                                            "SE.TAETORD": 2.0
+                                            "SEENDTC": "2019-05-13",
+                                            "SESTDTC": "2018-08-13"
                                         }
                                     },
                                     {
@@ -135502,11 +135443,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201001",
                                         "value": {
+                                            "SE.TAETORD": 3.0,
                                             "TAETORD": 1.0,
-                                            "SEENDTC": "2020-03-22",
-                                            "SESTDTC": "2019-05-13",
                                             "SVSTDTC": "2019-05-20",
-                                            "SE.TAETORD": 3.0
+                                            "SEENDTC": "2020-03-22",
+                                            "SESTDTC": "2019-05-13"
                                         }
                                     },
                                     {
@@ -135514,11 +135455,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201001",
                                         "value": {
+                                            "SE.TAETORD": 3.0,
                                             "TAETORD": 2.0,
-                                            "SEENDTC": "2020-03-22",
-                                            "SESTDTC": "2019-05-13",
                                             "SVSTDTC": "2019-07-22",
-                                            "SE.TAETORD": 3.0
+                                            "SEENDTC": "2020-03-22",
+                                            "SESTDTC": "2019-05-13"
                                         }
                                     },
                                     {
@@ -135526,11 +135467,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201002",
                                         "value": {
+                                            "SE.TAETORD": 1.0,
                                             "TAETORD": 3.0,
-                                            "SEENDTC": "2019-01-07T06:10",
-                                            "SESTDTC": "2018-11-20",
                                             "SVSTDTC": "2018-11-20",
-                                            "SE.TAETORD": 1.0
+                                            "SEENDTC": "2019-01-07T06:10",
+                                            "SESTDTC": "2018-11-20"
                                         }
                                     },
                                     {
@@ -135538,11 +135479,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201002",
                                         "value": {
+                                            "SE.TAETORD": 1.0,
                                             "TAETORD": 2.0,
-                                            "SEENDTC": "2019-01-07T06:10",
-                                            "SESTDTC": "2018-11-20",
                                             "SVSTDTC": "2019-01-06",
-                                            "SE.TAETORD": 1.0
+                                            "SEENDTC": "2019-01-07T06:10",
+                                            "SESTDTC": "2018-11-20"
                                         }
                                     },
                                     {
@@ -135550,11 +135491,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201002",
                                         "value": {
+                                            "SE.TAETORD": 2.0,
                                             "TAETORD": 1.0,
-                                            "SEENDTC": "2022-01-04",
-                                            "SESTDTC": "2019-01-07T06:10",
                                             "SVSTDTC": "2019-01-07T6:10",
-                                            "SE.TAETORD": 2.0
+                                            "SEENDTC": "2022-01-04",
+                                            "SESTDTC": "2019-01-07T06:10"
                                         }
                                     },
                                     {
@@ -135562,11 +135503,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201002",
                                         "value": {
+                                            "SE.TAETORD": 2.0,
                                             "TAETORD": 7.0,
-                                            "SEENDTC": "2022-01-04",
-                                            "SESTDTC": "2019-01-07T06:10",
                                             "SVSTDTC": "2019-04-22",
-                                            "SE.TAETORD": 2.0
+                                            "SEENDTC": "2022-01-04",
+                                            "SESTDTC": "2019-01-07T06:10"
                                         }
                                     },
                                     {
@@ -135574,11 +135515,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201002",
                                         "value": {
+                                            "SE.TAETORD": 2.0,
                                             "TAETORD": 8.0,
-                                            "SEENDTC": "2022-01-04",
-                                            "SESTDTC": "2019-01-07T06:10",
                                             "SVSTDTC": "2019-04-29",
-                                            "SE.TAETORD": 2.0
+                                            "SEENDTC": "2022-01-04",
+                                            "SESTDTC": "2019-01-07T06:10"
                                         }
                                     },
                                     {
@@ -135586,11 +135527,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201002",
                                         "value": {
+                                            "SE.TAETORD": 2.0,
                                             "TAETORD": 9.0,
-                                            "SEENDTC": "2022-01-04",
-                                            "SESTDTC": "2019-01-07T06:10",
                                             "SVSTDTC": "2020-04-06",
-                                            "SE.TAETORD": 2.0
+                                            "SEENDTC": "2022-01-04",
+                                            "SESTDTC": "2019-01-07T06:10"
                                         }
                                     },
                                     {
@@ -135598,11 +135539,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201003",
                                         "value": {
+                                            "SE.TAETORD": 1.0,
                                             "TAETORD": 2.0,
-                                            "SEENDTC": "2019-02-06",
-                                            "SESTDTC": "2019-01-10",
                                             "SVSTDTC": "2019-02-05",
-                                            "SE.TAETORD": 1.0
+                                            "SEENDTC": "2019-02-06",
+                                            "SESTDTC": "2019-01-10"
                                         }
                                     },
                                     {
@@ -135610,11 +135551,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201003",
                                         "value": {
+                                            "SE.TAETORD": 2.0,
                                             "TAETORD": 5.0,
-                                            "SEENDTC": "2019-04-24",
-                                            "SESTDTC": "2019-02-06",
                                             "SVSTDTC": "2019-02-07",
-                                            "SE.TAETORD": 2.0
+                                            "SEENDTC": "2019-04-24",
+                                            "SESTDTC": "2019-02-06"
                                         }
                                     },
                                     {
@@ -135622,11 +135563,11 @@
                                         "SEQ": null,
                                         "USUBJID": "1201003",
                                         "value": {
+                                            "SE.TAETORD": 2.0,
                                             "TAETORD": 1.0,
-                                            "SEENDTC": "2019-04-24",
-                                            "SESTDTC": "2019-02-06",
                                             "SVSTDTC": "2019-04-12",
-                                            "SE.TAETORD": 2.0
+                                            "SEENDTC": "2019-04-24",
+                                            "SESTDTC": "2019-02-06"
                                         }
                                     }
                                 ]
@@ -136158,8 +136099,8 @@
                                         "SEQ": 2,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "INV",
                                             "TSPARMCD": "EXTTIND",
+                                            "TSVAL": "INV",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136168,8 +136109,8 @@
                                         "SEQ": 3,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Other",
                                             "TSPARMCD": "FCNTRY",
+                                            "TSVAL": "Other",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136178,8 +136119,8 @@
                                         "SEQ": 4,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "PINF",
                                             "TSPARMCD": "FCNTRY",
+                                            "TSVAL": "PINF",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136188,8 +136129,8 @@
                                         "SEQ": 7,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "DER",
                                             "TSPARMCD": "INDIC",
+                                            "TSVAL": "DER",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136198,8 +136139,8 @@
                                         "SEQ": 8,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "UNK",
                                             "TSPARMCD": "INTMODEL",
+                                            "TSVAL": "UNK",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136208,8 +136149,8 @@
                                         "SEQ": 9,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "ASKU",
                                             "TSPARMCD": "INTTYPE",
+                                            "TSVAL": "ASKU",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136218,8 +136159,8 @@
                                         "SEQ": 10,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "NAV",
                                             "TSPARMCD": "LENGTH",
+                                            "TSVAL": "NAV",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136228,8 +136169,8 @@
                                         "SEQ": 11,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Nask",
                                             "TSPARMCD": "NARMS",
+                                            "TSVAL": "Nask",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136238,8 +136179,8 @@
                                         "SEQ": 12,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "QS",
                                             "TSPARMCD": "NCOHORT",
+                                            "TSVAL": "QS",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136248,8 +136189,8 @@
                                         "SEQ": 13,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "TRC",
                                             "TSPARMCD": "OBJPRIM",
+                                            "TSVAL": "TRC",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136258,8 +136199,8 @@
                                         "SEQ": 14,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "msk",
                                             "TSPARMCD": "OBJSEC",
+                                            "TSVAL": "msk",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136268,8 +136209,8 @@
                                         "SEQ": 15,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "No INFORMATION",
                                             "TSPARMCD": "EXTTIND",
+                                            "TSVAL": "No INFORMATION",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136278,8 +136219,8 @@
                                         "SEQ": 16,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Invalid",
                                             "TSPARMCD": "FCNTRY",
+                                            "TSVAL": "Invalid",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136288,8 +136229,8 @@
                                         "SEQ": 17,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Other",
                                             "TSPARMCD": "FDATCHSP",
+                                            "TSVAL": "Other",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136298,8 +136239,8 @@
                                         "SEQ": 18,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Positive infinity",
                                             "TSPARMCD": "HLTSUBJI",
+                                            "TSVAL": "Positive infinity",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136308,8 +136249,8 @@
                                         "SEQ": 19,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Negative infinity",
                                             "TSPARMCD": "INDIC",
+                                            "TSVAL": "Negative infinity",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136318,8 +136259,8 @@
                                         "SEQ": 20,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Unencoded",
                                             "TSPARMCD": "INTMODEL",
+                                            "TSVAL": "Unencoded",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136328,8 +136269,8 @@
                                         "SEQ": 21,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Derived",
                                             "TSPARMCD": "INTTYPE",
+                                            "TSVAL": "Derived",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136338,8 +136279,8 @@
                                         "SEQ": 22,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Unknown",
                                             "TSPARMCD": "LENGTH",
+                                            "TSVAL": "Unknown",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136348,8 +136289,8 @@
                                         "SEQ": 23,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Asked but unknown",
                                             "TSPARMCD": "NARMS",
+                                            "TSVAL": "Asked but unknown",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136358,8 +136299,8 @@
                                         "SEQ": 24,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Temporarily unavailable",
                                             "TSPARMCD": "NCOHORT",
+                                            "TSVAL": "Temporarily unavailable",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136368,8 +136309,8 @@
                                         "SEQ": 26,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "SUFFICIENT QUANTITY",
                                             "TSPARMCD": "OBJPRIM",
+                                            "TSVAL": "SUFFICIENT QUANTITY",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136378,8 +136319,8 @@
                                         "SEQ": 27,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Trace",
                                             "TSPARMCD": "OBJSEC",
+                                            "TSVAL": "Trace",
                                             "TSVALNF": null
                                         }
                                     },
@@ -136388,8 +136329,8 @@
                                         "SEQ": 28,
                                         "USUBJID": null,
                                         "value": {
-                                            "TSVAL": "Masked",
                                             "TSPARMCD": "OBJSEC",
+                                            "TSVAL": "Masked",
                                             "TSVALNF": null
                                         }
                                     }
@@ -136908,9 +136849,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC001",
                                         "value": {
-                                            "DTHDTC": "2006-04-01",
+                                            "AEOUT": "FATAL",
                                             "AEENDTC": "2005-09-09",
-                                            "AEOUT": "FATAL"
+                                            "DTHDTC": "2006-04-01"
                                         }
                                     },
                                     {
@@ -136918,9 +136859,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC003",
                                         "value": {
-                                            "DTHDTC": "2006-03-19",
+                                            "AEOUT": "FATAL",
                                             "AEENDTC": null,
-                                            "AEOUT": "FATAL"
+                                            "DTHDTC": "2006-03-19"
                                         }
                                     },
                                     {
@@ -136928,9 +136869,9 @@
                                         "SEQ": null,
                                         "USUBJID": "CDISC004",
                                         "value": {
-                                            "DTHDTC": "2018-10-24",
+                                            "AEOUT": "FATAL",
                                             "AEENDTC": "2018-10-24T11:13",
-                                            "AEOUT": "FATAL"
+                                            "DTHDTC": "2018-10-24"
                                         }
                                     }
                                 ]


### PR DESCRIPTION
Add regex sorting option - a regex pattern can be specified in the rule which will be used in regexp_match and cast to int before being used to sort. Useful for sorting by numerics found in strings in numeric order.

Also enabled functionality for lists in 'within' clause.

Ran regression - massive changes due to output order swapping, but hopefully won't change again going forward.