### PR TITLE
feat: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 3
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 14 # used to protect against package tainting attacks
+  - package-ecosystem: "pip"
+    directory: "/"
+    open-pull-requests-limit: 3
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
This PR enables dependabot on the repository for github actions and pip packages