### PR TITLE
feat: add strict incremental sort to target_is_sorted_by op

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/target_is_sorted_by_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/target_is_sorted_by_operator.py
@@ -40,6 +40,9 @@ class TargetIsSortedByOperator(BaseSqlOperator):
                     - name: Column name to sort by
                     - sort_order: "ASC" or "DESC"
                     - null_position: "first" or "last"
+                - strict_incremental_ordering: (optional, default False) If True,
+                    checks that target values equal their 1-based row position within
+                    each group when ordered by comparator (e.g. 1 2 3 or 01 02 03).
 
         Returns:
             Boolean series indicating if each record meets the sorting condition
@@ -50,6 +53,7 @@ class TargetIsSortedByOperator(BaseSqlOperator):
         within = val if isinstance(val, list) else [val]
         within = [self.replace_prefix(val) for val in within]
         comparators = other_value["comparator"]
+        strict_incremental = other_value.get("strict_incremental_ordering", False)
 
         if not all([target, within, comparators]):
             raise ValueError("Missing required parameters: target, within, or comparator")
@@ -61,7 +65,9 @@ class TargetIsSortedByOperator(BaseSqlOperator):
             null_pos = comp["null_position"]
             comparator_parts.append(f"{name}_{order}_{null_pos}")
 
-        cache_key = f"{target}_is_sorted_by_{'_'.join(comparator_parts)}_within_{'_'.join(val for val in within)}"
+        strict_suffix = "_strict_incremental" if strict_incremental else ""
+        within_key = "_".join(val for val in within)
+        cache_key = f"{target}_is_sorted_by_{'_'.join(comparator_parts)}_within_{within_key}{strict_suffix}"
 
         def sql(table_name, column_name):
 
@@ -69,6 +75,40 @@ class TargetIsSortedByOperator(BaseSqlOperator):
             target_sql = (
                 target_sql if not regex_sort else f"CAST((regexp_match({target_sql}, '{regex_sort}'))[1] AS INTEGER)"
             )
+
+            if strict_incremental:
+                strict_order_parts = []
+                for comp in comparators:
+                    comp_name = self.replace_prefix(comp["name"])
+                    comp_sql = self._column_sql(comp_name, alias=False)
+                    sort_order = comp["sort_order"].upper()
+                    null_pos = comp["null_position"].upper()
+                    order_part = f"{comp_sql} {sort_order}"
+                    order_part += " NULLS FIRST" if null_pos == "FIRST" else " NULLS LAST"
+                    strict_order_parts.append(order_part)
+
+                order_by_clause = ", ".join(strict_order_parts)
+                partition_by_clause = ", ".join(f"{self._column_sql(val, alias=False)}" for val in within)
+
+                return f"""
+            WITH strict_check AS (
+                SELECT
+                    id,
+                    CASE WHEN {target_sql} IS NULL THEN 0 ELSE CAST({target_sql} AS INTEGER) END AS target_int,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY {partition_by_clause}
+                        ORDER BY {order_by_clause}
+                    ) AS expected_val
+                FROM {table_name}
+            )
+            UPDATE {table_name} t
+            SET {column_name} = (
+                SELECT
+                CASE WHEN {target_sql} IS NULL THEN true ELSE target_int = expected_val END
+                FROM strict_check
+                WHERE id = t.id
+            )
+            """
 
             # Build CTEs for each individual comparator check
             comparator_ctes = []
@@ -82,10 +122,7 @@ class TargetIsSortedByOperator(BaseSqlOperator):
 
                 # Build ORDER BY for this specific comparator
                 order_part = f"{comp_sql} {sort_order}"
-                if null_pos == "FIRST":
-                    order_part += " NULLS FIRST"
-                else:
-                    order_part += " NULLS LAST"
+                order_part += " NULLS FIRST" if null_pos == "FIRST" else " NULLS LAST"
 
                 comparator_columns.append(f"{comp_sql} AS comp_{i}_val")
 

--- a/cdisc_rules_engine/enums/optional_condition_parameters.py
+++ b/cdisc_rules_engine/enums/optional_condition_parameters.py
@@ -16,3 +16,4 @@ class OptionalConditionParameters(BaseEnum):
     CASE_INSENSITIVE = "case_insensitive"
     FILTER_ATTRIBUTE = "filter_attribute"
     FILTER_VALUE = "filter_value"
+    STRICT_INCREMENTAL_ORDERING = "strict_incremental_ordering"


### PR DESCRIPTION
Some rules require not just ordering but strict incremental ordering (ie 1, 2, 3 etc), so I have added this functionality