### PR TITLE
fix: param-handling collection output return full list

### DIFF
--- a/cdisc_rules_engine/models/sql_venmo_result_handler.py
+++ b/cdisc_rules_engine/models/sql_venmo_result_handler.py
@@ -347,7 +347,7 @@ class SqlVenmoResultHandler(BaseActions):
             self.data_service.pgi.execute_sql(query)
             result_rows = self.data_service.pgi.fetch_all()
             if result_rows and len(result_rows) > 0:
-                return result_rows[0].get("value")
+                return [row.get("value") for row in result_rows if row.get("value") is not None]
             return None
         except Exception as e:
             return f"Query error: {str(e)}"


### PR DESCRIPTION
Previously _execute_query_for_collection_value was called through _evaluate_parameterized_collection, and only returned the first value of the collection. 

The grouped distinct operation uses parameters and the entire collection output is required. I'm not sure why we would ever only need to return the first value of a collection result, so I've adjusted the function. There are no failing tests or broken rules that I can identify with this change.