### PR TITLE
co: Latest Available External Dictionary Version

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/is_latest_available_exdict_version.py
+++ b/cdisc_rules_engine/check_operators/sql/is_latest_available_exdict_version.py
@@ -1,0 +1,69 @@
+from .base_sql_operator import BaseSqlOperator
+
+
+WHODRUG_RELEASE_DATES = {}
+MEDDRA_RELEASE_DATES = {
+    "29.0": "2026-03-01",
+    "28.1": "2025-09-01",
+    "28.0": "2025-03-01",
+    "27.1": "2024-09-01",
+    "27.0": "2024-03-01",
+    "26.1": "2023-09-01",
+    "26.0": "2023-03-01",
+    "25.1": "2022-09-01",
+    "25.0": "2022-03-01",
+    "24.1": "2021-09-01",
+    "24.0": "2021-03-01",
+    "23.1": "2020-09-01",
+}
+MEDRT_RELEASE_DATES = {}
+LOINC_RELEASE_DATES = {}
+SNOMED_RELEASE_DATES = {}
+UNII_RELEASE_DATES = {}
+
+EXDICT_MAPPINGS = {
+    "meddra": MEDDRA_RELEASE_DATES,
+    "whodrug": WHODRUG_RELEASE_DATES,
+    "medrt": MEDRT_RELEASE_DATES,
+    "loinc": LOINC_RELEASE_DATES,
+    "snomed": SNOMED_RELEASE_DATES,
+    "unii": UNII_RELEASE_DATES,
+}
+
+
+class IsLatestAvailableExDictVersionOperator(BaseSqlOperator):
+    def execute_operator(self, other_value):
+
+        target = self.replace_prefix(other_value.get("target"))
+        version = other_value.get("version")
+        value_is_literal = other_value.get("value_is_literal", False)
+
+        version_sql = None
+
+        if not value_is_literal:
+            if version in self.operation_variables:
+                version_sql = self._process_constant_operation_variable(version)
+            elif self._exists(version):
+                version_sql = self.replace_prefix(version.lower())
+        else:
+            version_sql = self._handle_string_constant(version, lowercase=False)
+
+        external_dictionary_type = other_value.get("external_dictionary_type")
+
+        version_mapping = EXDICT_MAPPINGS.get(external_dictionary_type.lower())
+        if not version_mapping:
+            raise Exception(f"Unsupported external dictionary type: {external_dictionary_type}")
+
+        target_date_sql = f"CAST({self._column_sql(target, alias=False)} AS TIMESTAMP)"
+
+        sorted_versions = sorted(version_mapping.items(), key=lambda x: x[1], reverse=True)
+
+        effective_version_sql = "CASE"
+        for ver, release_date in sorted_versions:
+            effective_version_sql += f" WHEN {target_date_sql} >= CAST('{release_date}' AS TIMESTAMP) THEN '{ver}'"
+        effective_version_sql += " ELSE NULL END"
+
+        def sql():
+            return f"({effective_version_sql}) = {version_sql}"
+
+        return self._do_check_operator(sql)

--- a/cdisc_rules_engine/check_operators/sql/postgresql_operators.py
+++ b/cdisc_rules_engine/check_operators/sql/postgresql_operators.py
@@ -52,6 +52,7 @@ from .suffix_matches_regex_operator import SuffixMatchesRegexOperator
 from .target_is_sorted_by_operator import TargetIsSortedByOperator
 from .value_has_multiple_references_operator import ValueHasMultipleReferencesOperator
 from .variable_metadata_equal_to_operator import VariableMetadataEqualToOperator
+from .is_latest_available_exdict_version import IsLatestAvailableExDictVersionOperator
 
 MEDDRA_CODE_SUFFIX_MAP = {
     "BDSYCD": "SOC",
@@ -298,6 +299,10 @@ class PostgresQLOperators(BaseType):
         ),
         "is_not_valid_snomed_code_term_pair": lambda data: NotOperator(
             data, lambda d: ValidExDictCodeTermPairsOperator(d, StaticTables.SNOMED_TABLE_NAME.value)
+        ),
+        "is_latest_available_external_dictionary_version": lambda data: IsLatestAvailableExDictVersionOperator(data),
+        "is_not_latest_available_external_dictionary_version": lambda data: NotOperator(
+            data, lambda d: IsLatestAvailableExDictVersionOperator(d)
         ),
     }
 

--- a/cdisc_rules_engine/enums/optional_condition_parameters.py
+++ b/cdisc_rules_engine/enums/optional_condition_parameters.py
@@ -16,5 +16,6 @@ class OptionalConditionParameters(BaseEnum):
     CASE_INSENSITIVE = "case_insensitive"
     FILTER_ATTRIBUTE = "filter_attribute"
     FILTER_VALUE = "filter_value"
+    STRICT_INCREMENTAL_ORDERING = "strict_incremental_ordering"
     EXTERNAL_DICTIONARY_TYPE = "external_dictionary_type"
     VERSION = "version"

--- a/cdisc_rules_engine/enums/optional_condition_parameters.py
+++ b/cdisc_rules_engine/enums/optional_condition_parameters.py
@@ -16,4 +16,5 @@ class OptionalConditionParameters(BaseEnum):
     CASE_INSENSITIVE = "case_insensitive"
     FILTER_ATTRIBUTE = "filter_attribute"
     FILTER_VALUE = "filter_value"
-    STRICT_INCREMENTAL_ORDERING = "strict_incremental_ordering"
+    EXTERNAL_DICTIONARY_TYPE = "external_dictionary_type"
+    VERSION = "version"

--- a/tests/unit/sql/test_check_operators/test_sql_latest_available_exdict.py
+++ b/tests/unit/sql/test_check_operators/test_sql_latest_available_exdict.py
@@ -1,0 +1,45 @@
+import pytest
+
+from .helpers import assert_series_equals, create_sql_operators
+from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
+
+
+@pytest.mark.parametrize(
+    "data,target,version,value_is_literal,external_dictionary_type,expected_result",
+    [
+        (
+            {"target": ["2025-11-02", "2026-03-01"]},
+            "target",
+            "28.1",
+            True,
+            "meddra",
+            [True, False],
+        ),
+        (
+            {"target": ["2025-11-02", "2026-03-01"]},
+            "target",
+            "$version",
+            False,
+            "meddra",
+            [True, False],
+        ),
+    ],
+)
+def test_sql_latest_available_exdict(
+    data, target, version, value_is_literal, external_dictionary_type, expected_result
+):
+    sql_ops = create_sql_operators(
+        data,
+        extra_operation_variables={
+            "$version": SqlOperationResult(query="SELECT '28.1' AS value", type="constant", subtype="Char")
+        },
+    )
+    result = sql_ops.is_latest_available_external_dictionary_version(
+        {
+            "target": target,
+            "version": version,
+            "value_is_literal": value_is_literal,
+            "external_dictionary_type": external_dictionary_type,
+        }
+    )
+    assert_series_equals(result, expected_result)


### PR DESCRIPTION
Operator off the back of authoring the rule "FB0301" which requires knowledge of previous release dates of external dictionaries.

Checks if the version of an external dictionary used is the latest available version based on the target date.

I did need to hardcode the release dates and version of Meddra for this. I investigated into potentially using an API for this, but the Meddra release dates and version are all available online publicly, so there's no need.

Do suggest a potentially simpler/cleaner way to store and access these release dates for the operator.