### PR TITLE
feat: add define check to exists

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/exists_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/exists_operator.py
@@ -7,7 +7,6 @@ class ExistsOperator(BaseSqlOperator):
     def execute_operator(self, other_value):
         target_column = self.replace_prefix(other_value.get("target"))
         if target_column == "define.xml":
-            print(self.sql_data_service.define_xml_path)
             return self._do_check_operator(lambda: "TRUE" if self.sql_data_service.define_xml_path else "FALSE")
         result = target_column in self.operation_variables or self._exists(target_column)
         return self._do_check_operator(lambda: "TRUE" if result else "FALSE")

--- a/cdisc_rules_engine/check_operators/sql/exists_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/exists_operator.py
@@ -6,5 +6,8 @@ class ExistsOperator(BaseSqlOperator):
 
     def execute_operator(self, other_value):
         target_column = self.replace_prefix(other_value.get("target"))
+        if target_column == "define.xml":
+            print(self.sql_data_service.define_xml_path)
+            return self._do_check_operator(lambda: "TRUE" if self.sql_data_service.define_xml_path else "FALSE")
         result = target_column in self.operation_variables or self._exists(target_column)
         return self._do_check_operator(lambda: "TRUE" if result else "FALSE")


### PR DESCRIPTION
If 'define.xml' is used as the name for an 'exists' check in a rule, it will return the existence of the define_xml_path - required for TRC1736b