### PR TITLE
fix: value_is_literal not part of check to handle 'contains' CO where target = operation

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/contains_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/contains_operator.py
@@ -20,7 +20,7 @@ class ContainsOperator(BaseSqlOperator):
 
         if target in self.operation_variables:
             target_var = self.operation_variables[target]
-            if target_var.type == "collection" and value_is_literal:
+            if target_var.type == "collection":
                 return self._handle_target_is_collection(target, comparator, value_is_literal)
 
         target_column = self.replace_prefix(target)


### PR DESCRIPTION
Within the 'contains' check operator, value_is_literal should not be a part of the conditional to handle cases where params.target is an operation as the handle case function already handles value_is_literal on its own.