### PR TITLE
fix: Allow Rule Operations on Rule Type Tables

### DIFF
--- a/cdisc_rules_engine/sql_rules_engine.py
+++ b/cdisc_rules_engine/sql_rules_engine.py
@@ -215,7 +215,11 @@ class SQLRulesEngine:
 
         # Apply any operations
         operation_variables = SQLRuleProcessor.perform_rule_operations(
-            rule_copy, dataset_metadata, data_service=self.data_service, standards_context=self.standards_context
+            rule_copy,
+            dataset_id,
+            dataset_metadata,
+            data_service=self.data_service,
+            standards_context=self.standards_context,
         )
 
         # Translator between venmo and the check operators

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -25,6 +25,7 @@ class SQLRuleProcessor:
     @staticmethod
     def perform_rule_operations(
         rule: dict,
+        dataset_id: str,
         dataset_metadata: BaseDatasetMetadata,
         data_service: PostgresQLDataService,
         standards_context: BaseStandardsContext,
@@ -47,7 +48,9 @@ class SQLRuleProcessor:
 
             # change -- pattern to domain name
             target_variable: str = operation.get("name", None)
-            operation_domain: str = operation.get("domain", dataset_metadata.domain)
+            operation_domain: str = operation.get(
+                "domain", dataset_id if dataset_id != dataset_metadata.name else dataset_metadata.domain
+            )
             if target_variable:
                 target_variable = standards_context.replace_domain_code(dataset_metadata, target_variable)
 


### PR DESCRIPTION
Allow custom rule type tables to be the target of rule operations. Without fix, rule operation domain param is required to target the rule type table, which in some cases, would require hardcoding "dm_value_check_var_metadata" as the domain param. 
This allows the dataset_id (the actual assigned table by the rule type) to be used instead of the dataset_metadata.domain (the original dataset before rule type changes) which then means the domain param isn't needed for custom rule types.