### PR TITLE
fix: exdict ops null handling

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/base_sql_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/base_sql_operator.py
@@ -219,6 +219,7 @@ class BaseSqlOperator:
         prefix: Optional[int] = None,
         suffix: Optional[int] = None,
         alias: bool = True,
+        null_return: bool = False,
     ) -> str:
         if column == DATASET_NAME:
             dataset_name = self.dataset_metadata.name
@@ -229,6 +230,8 @@ class BaseSqlOperator:
             return self._constant_sql(dataset_name, lowercase=lowercase)
 
         if not self._exists(column):
+            if null_return:
+                return "NULL"
             raise ColumnNotFoundError(
                 column_name=column,
                 table_id=self.table_id,
@@ -236,10 +239,8 @@ class BaseSqlOperator:
             )
 
         query = self.sql_data_service.pgi.schema.get_column_hash(self.table_id, column)
-
         # Prepend the table alias
-        if alias:
-            query = f"{CHECK_OPERATOR_TABLE_ALIAS}.{query}"
+        query = f"{CHECK_OPERATOR_TABLE_ALIAS}.{query}" if alias else query
 
         # TODO: Throwing this temporarily, so we can determine which errors
         # are actually postgres errors and which are just rules which run on

--- a/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_code_reference_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_code_reference_operator.py
@@ -25,9 +25,11 @@ class ValidExDictCodeReferenceOperator(BaseSqlOperator):
             if filter_attribute == "class":
                 filter_conditions.append(f"('{filter_value}' IN (level_1, level_2, level_3, level_4))")
 
-            whodrug_condition = f"WHEN {self._column_sql(target_column, alias=False)} = 'MULTIPLE' THEN TRUE"
+            whodrug_condition = (
+                f"WHEN {self._column_sql(target_column, alias=False, null_return=True)} = 'MULTIPLE' THEN TRUE"
+            )
 
-        cast_expr = f"CAST({self._column_sql(target_column, alias=False)} AS TEXT)"
+        cast_expr = f"CAST({self._column_sql(target_column, alias=False, null_return=True)} AS TEXT)"
         code_expr = "term_code"
         if case_insensitive:
             cast_expr = f"LOWER({cast_expr})"

--- a/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_code_term_pair_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_code_term_pair_operator.py
@@ -34,17 +34,19 @@ class ValidExDictCodeTermPairsOperator(BaseSqlOperator):
             if filter_attribute == "class":
                 filter_conditions.append(f"('{filter_value}' IN (level_1, level_2, level_3, level_4))")
 
-            whodrug_condition = f"WHEN {self._column_sql(target_column, alias=False)} = 'MULTIPLE' THEN TRUE"
+            whodrug_condition = (
+                f"WHEN {self._column_sql(target_column, alias=False, null_return=True)} = 'MULTIPLE' THEN TRUE"
+            )
 
         if case_insensitive:
             comp_expr = f"""
-            LOWER(term_code) = LOWER(CAST({self._column_sql(code_column, alias=False)} AS TEXT))
-            AND LOWER(term_name) = LOWER(CAST({self._column_sql(term_column, alias=False)} AS TEXT))
+            LOWER(term_code) = LOWER(CAST({self._column_sql(code_column, alias=False, null_return=True)} AS TEXT))
+            AND LOWER(term_name) = LOWER(CAST({self._column_sql(term_column, alias=False, null_return=True)} AS TEXT))
             """
         else:
             comp_expr = f"""
-            term_code = CAST({self._column_sql(code_column, alias=False)} AS TEXT)
-            AND term_name = CAST({self._column_sql(term_column, alias=False)} AS TEXT)
+            term_code = CAST({self._column_sql(code_column, alias=False, null_return=True)} AS TEXT)
+            AND term_name = CAST({self._column_sql(term_column, alias=False, null_return=True)} AS TEXT)
             """
 
         query = f"""

--- a/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_term_reference_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_valid_external_dict_term_reference_operator.py
@@ -26,9 +26,11 @@ class ValidExDictTermReferenceOperator(BaseSqlOperator):
             if filter_attribute == "class":
                 filter_conditions.append(f"('{filter_value}' IN (level_1, level_2, level_3, level_4))")
 
-            whodrug_condition = f"WHEN {self._column_sql(target_column, alias=False)} = 'MULTIPLE' THEN TRUE"
+            whodrug_condition = (
+                f"WHEN {self._column_sql(target_column, alias=False, null_return=True)} = 'MULTIPLE' THEN TRUE"
+            )
 
-        cast_expr = f"CAST({self._column_sql(target_column, alias=False)} AS TEXT)"
+        cast_expr = f"CAST({self._column_sql(target_column, alias=False, null_return=True)} AS TEXT)"
         term_expr = "TRIM(regexp_split_to_table(term_name, '[,;]'))"
         if case_insensitive:
             cast_expr = f"LOWER({cast_expr})"

--- a/cdisc_rules_engine/check_operators/sql/is_valid_whodrug_level_reference_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_valid_whodrug_level_reference_operator.py
@@ -16,7 +16,7 @@ class ValidWHODrugLevelReferenceOperator(BaseSqlOperator):
 
         query = f"""
             CASE
-                WHEN CAST({self._column_sql(target_column, alias=False)} AS TEXT) IN (
+                WHEN CAST({self._column_sql(target_column, alias=False, null_return=True)} AS TEXT) IN (
                     {union_query}
                 ) THEN TRUE
                 ELSE FALSE


### PR DESCRIPTION
Added an optional default False null_return param to _column_sql, which, when True, returns NULL instead of ColumnNotFoundError (this allows the operator to complete even when the value is missing)