### PR TITLE
feat: codelist param in get-countries operation

### DIFF
--- a/cdisc_rules_engine/models/sql_operation_params.py
+++ b/cdisc_rules_engine/models/sql_operation_params.py
@@ -31,11 +31,11 @@ class SqlOperationParams:
     attribute_name: str = None
     subtract: str = None
     external_dictionary_type: str = None
+    codelist: str = None
 
     # standard_substandard: str = None
     # attribute_name: str = None
     # case_sensitive: bool = True
-    # codelist: str = None
     # codelist_code: str = None
     # codelists: list = None
     # ct_package: list = None

--- a/cdisc_rules_engine/sql_operations/get_countries.py
+++ b/cdisc_rules_engine/sql_operations/get_countries.py
@@ -515,6 +515,11 @@ GENC_COUNTRY_CODES = [
     {"country_name": "Zimbabwe", "alpha_2": "ZW", "alpha_3": "ZWE"},
 ]
 
+CT_ATTRIBUTE_MAP = {
+    "ISO 3166": ISO_3166_COUNTRY_CODES,
+    "GENC": GENC_COUNTRY_CODES,
+}
+
 
 class SqlGetCountriesOperation(SqlBaseOperation):
 
@@ -526,12 +531,16 @@ class SqlGetCountriesOperation(SqlBaseOperation):
                 f"Invalid attribute name: {attribute}. Must be one of {list(ISO_3166_COUNTRY_CODES[0].keys())}"
             )
 
-        iso_names = {entry["country_name"] for entry in ISO_3166_COUNTRY_CODES}
-        master_list = ISO_3166_COUNTRY_CODES + [
-            entry for entry in GENC_COUNTRY_CODES if entry["country_name"] not in iso_names
-        ]
+        # we assume codelist is a string for now
+        if self.params.codelist not in CT_ATTRIBUTE_MAP:
+            iso_names = {entry["country_name"] for entry in ISO_3166_COUNTRY_CODES}
+            result_list = ISO_3166_COUNTRY_CODES + [
+                entry for entry in GENC_COUNTRY_CODES if entry["country_name"] not in iso_names
+            ]
+        else:
+            result_list = CT_ATTRIBUTE_MAP[self.params.codelist]
 
-        attribute_list = list({entry[attribute] for entry in master_list})
+        attribute_list = list({entry[attribute] for entry in result_list})
         query = self._format_variable_list_to_query(vars=attribute_list)
 
         return SqlOperationResult(query=query, type="collection", subtype="Char")


### PR DESCRIPTION
allows an optional param for "get_countries" to pass a literal string so that only certain standards of country lists can be extracted instead of the entire combined set.