### PR TITLE
fix: special-purpose datasets mapping

### DIFF
--- a/cdisc_rules_engine/utilities/utils.py
+++ b/cdisc_rules_engine/utilities/utils.py
@@ -327,7 +327,7 @@ def get_dictionary_path(directory_path: str, file_name: str) -> str:
 
 
 def convert_library_class_name_to_ct_class(class_name: str):
-    conversions = {"special-purpose": SPECIAL_PURPOSE}
+    conversions = {"special-purpose": SPECIAL_PURPOSE, "special-purpose datasets": SPECIAL_PURPOSE}
     return conversions.get(class_name.lower(), class_name.upper())
 
 


### PR DESCRIPTION
In sdtmig 3.3 the class name is (sometimes? always?) stored as Special-Purpose Datasets, rather than just Special-Purpose. This mapping addition avoids errors when looking for the Special Purpose class in 3.3