### PR TITLE
fix: functionality for FB1101

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/base_sql_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/base_sql_operator.py
@@ -489,7 +489,7 @@ class BaseSqlOperator:
             raise ValueError(f"Variable {target} does not exist.")
 
         if variable.type != "constant":
-            raise ValueError(f"Variable {target} is not a constant.")
+            return f"(NOT EXISTS (SELECT 1 FROM ({variable.query}) AS op))"
 
         # Handle parameterized constants
         query = variable.query

--- a/cdisc_rules_engine/check_operators/sql/empty_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/empty_operator.py
@@ -8,9 +8,6 @@ class EmptyOperator(BaseSqlOperator):
         column = self.replace_prefix(other_value.get("target"))
 
         def sql():
-            if self.sql_data_service.pgi.schema.get_column(self.table_id, column) is None:
-                return "TRUE"
-
             return self._is_empty_sql(column)
 
         return self._do_check_operator(sql)

--- a/cdisc_rules_engine/models/sql_operation_params.py
+++ b/cdisc_rules_engine/models/sql_operation_params.py
@@ -32,6 +32,8 @@ class SqlOperationParams:
     subtract: str = None
     external_dictionary_type: str = None
     codelist: str = None
+    domain_class: str = None
+    case_sensitive: bool = True
 
     # standard_substandard: str = None
     # attribute_name: str = None

--- a/cdisc_rules_engine/sql_operations/minus.py
+++ b/cdisc_rules_engine/sql_operations/minus.py
@@ -10,6 +10,7 @@ class SqlMinusOperation(SqlBaseOperation):
         """
         domain = self.params.domain
         dataset_id = self.data_service.pgi.schema.get_table_hash(domain)
+        case_sensitive = self.params.case_sensitive
 
         name_param = self.params.name
         subtract_param = self.params.subtract
@@ -17,10 +18,12 @@ class SqlMinusOperation(SqlBaseOperation):
         name_query = self._resolve_param(name_param, domain, dataset_id)
         subtract_query = self._resolve_param(subtract_param, domain, dataset_id)
 
+        case_value = "UPPER(value)" if not case_sensitive else "value"
+
         query = f"""
-            SELECT value FROM ({name_query}) AS name_q
+            SELECT {case_value} AS value FROM ({name_query}) AS name_q
             EXCEPT
-            SELECT value FROM ({subtract_query}) AS subtract_q
+            SELECT {case_value} AS value FROM ({subtract_query}) AS subtract_q
         """
 
         return SqlOperationResult(query=query, type="collection", subtype="Char")

--- a/cdisc_rules_engine/sql_operations/standard_domains.py
+++ b/cdisc_rules_engine/sql_operations/standard_domains.py
@@ -7,7 +7,16 @@ class SqlStandardDomainsOperation(SqlBaseOperation):
         """
         Return a list of the standard domains
         """
+        domain_class = self.params.domain_class if self.params.domain_class else None
+
         standard_domains = list(self.params.standards_context.get_standard_metadata().get("domains", {}))
+
+        if domain_class:
+            standard_domains = [
+                domain
+                for domain in standard_domains
+                if self.params.standards_context.get_domain_class(domain) == domain_class
+            ]
 
         query = self._format_variable_list_to_query(vars=standard_domains, unique=True, ordered=True)
 

--- a/cdisc_rules_engine/standards/base_standards_context.py
+++ b/cdisc_rules_engine/standards/base_standards_context.py
@@ -34,6 +34,10 @@ class BaseStandardsContext(ABC):
         pass
 
     @abstractmethod
+    def get_domain_class(self, domain: str):
+        pass
+
+    @abstractmethod
     def get_model_metadata(self):
         pass
 

--- a/cdisc_rules_engine/standards/default_standards_context.py
+++ b/cdisc_rules_engine/standards/default_standards_context.py
@@ -29,6 +29,9 @@ class DefaultStandardsContext(BaseStandardsContext):
     def get_domain_variables(self, domain: str):
         return []
 
+    def get_domain_class(self, domain: str):
+        return []
+
     def get_model_metadata(self):
         return []
 

--- a/cdisc_rules_engine/standards/sdtm_standards_context.py
+++ b/cdisc_rules_engine/standards/sdtm_standards_context.py
@@ -136,6 +136,14 @@ class SdtmStandardsContext(BaseStandardsContext):
                 return variables_metadata
         return []
 
+    def get_domain_class(self, domain: str):
+        domain_details = self.get_domain_metadata(domain)
+        if domain_details:
+            parent_class = domain_details.get("_links", {}).get("parentClass", {})
+            if parent_class:
+                return convert_library_class_name_to_ct_class(parent_class.get("title"))
+        return None
+
     def get_model_metadata(self):
         model_metadata = self.library_metadata.model_metadata
         return model_metadata

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -71,6 +71,8 @@ class SQLRuleProcessor:
                 subtract=operation.get("subtract"),
                 external_dictionary_type=operation.get("external_dictionary_type"),
                 codelist=operation.get("codelist"),
+                domain_class=operation.get("domain_class"),
+                case_sensitive=operation.get("case_sensitive", True),
             )
 
             operation = SqlOperationsFactory.get_service(rule_name, params=params, data_service=data_service)

--- a/tests/unit/sql/test_check_operators/test_sql_string_comparison.py
+++ b/tests/unit/sql/test_check_operators/test_sql_string_comparison.py
@@ -8,7 +8,7 @@ from .helpers import assert_series_equals, create_sql_operators
     [
         ({"target": ["Att", "", None]}, [False, True, True]),
         ({"target": [1, 2, None]}, [False, False, True]),
-        ({"other": [1, 2, None]}, [True, True, True]),
+        ({"other": [1, 2, None]}, [False, False, False]),
     ],
 )
 def test_empty(data, expected_result):


### PR DESCRIPTION
Lots of small changes in this PR, all related:
- allow class filtering in get_standard_domains
- add case param to minus
- adjust empty to skip if column not present (NOTE - this causes a few verified rules to fail; after discussion with Els, the majority only need test data adjustments. One needs a small rule change. Will raise PR for this soon in contrib repo)