### PR TITLE
feat: param for operations running over rule type tables

### DIFF
--- a/cdisc_rules_engine/models/sql_operation_params.py
+++ b/cdisc_rules_engine/models/sql_operation_params.py
@@ -32,6 +32,8 @@ class SqlOperationParams:
     subtract: str = None
     external_dictionary_type: str = None
     codelist: str = None
+    table: str = None
+    use_rule_type_table: str = None
 
     # standard_substandard: str = None
     # attribute_name: str = None

--- a/cdisc_rules_engine/sql_operations/numeric_operation.py
+++ b/cdisc_rules_engine/sql_operations/numeric_operation.py
@@ -13,13 +13,14 @@ class SqlNumericOperation(SqlBaseOperation):
         self.function = function
 
     def _execute_operation(self):
-        dataset_id = self.data_service.pgi.schema.get_table_hash(self.params.domain)
+        table = self.params.table if self.params.use_rule_type_table else self.params.domain
+        dataset_id = self.data_service.pgi.schema.get_table_hash(table)
 
         # Special case for counting size of whole dataset
         if self.params.target is None:
             column_id = "*"
         else:
-            column_id = self.data_service.pgi.schema.get_column_hash(self.params.domain, self.params.target)
+            column_id = self.data_service.pgi.schema.get_column_hash(table, self.params.target)
 
         where_clause = self.construct_where_clause()
 
@@ -27,9 +28,7 @@ class SqlNumericOperation(SqlBaseOperation):
             query = f"SELECT {self.function}({column_id}) AS value FROM {dataset_id} {where_clause}"
             return SqlOperationResult(query=query, type="constant", subtype="Num")
         else:
-            grouping_columns = [
-                self.data_service.pgi.schema.get_column(self.params.domain, group) for group in self.params.grouping
-            ]
+            grouping_columns = [self.data_service.pgi.schema.get_column(table, group) for group in self.params.grouping]
 
             where_conditions = []
             params = {}

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -49,6 +49,7 @@ class SQLRuleProcessor:
             # change -- pattern to domain name
             target_variable: str = operation.get("name", None)
             operation_domain: str = operation.get("domain", dataset_metadata.domain)
+            operation_table = dataset_id
             if target_variable:
                 target_variable = standards_context.replace_domain_code(dataset_metadata, target_variable)
 
@@ -71,6 +72,8 @@ class SQLRuleProcessor:
                 subtract=operation.get("subtract"),
                 external_dictionary_type=operation.get("external_dictionary_type"),
                 codelist=operation.get("codelist"),
+                table=operation_table,
+                use_rule_type_table=operation.get("use_rule_type_table", False),
             )
 
             operation = SqlOperationsFactory.get_service(rule_name, params=params, data_service=data_service)


### PR DESCRIPTION
Some rules need to run operations over tables produced by the rule type. Just changing the domain breaks other functions, so I've added a 'table' param (aka dataset_id) that only gets used if use_rule_type_table param is set to true in the rule.

I've enabled this for the numeric operators since so far I have only encountered that use case but will enable for other operators going forward - it makes sense to distinguish domain and table in general across the engine.