### PR TITLE
feat: improved target/comparator handling by IsContainedByOperator operator

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/is_contained_by_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_contained_by_operator.py
@@ -16,10 +16,12 @@ class IsContainedByOperator(BaseSqlOperator):
         Returns True if target value exists in the comparator collection/column and is not null/empty.
         Returns False if target value is null, empty, or not found in comparator.
 
-        Handles three types of comparators:
+        Handles these types of comparators:
         1. List of literal values - check if target is in the list
-        2. Column name (when value_is_literal=False) - checks if target value exists anywhere in the comparator column
-        3. Single literal value - checks direct equality with the target
+        2. Operation variable (collection) - check if target is in the operation result set
+        3. Operation variable (constant) - checks direct equality with the target
+        4. Column name (when value_is_literal=False) - checks if target value exists anywhere in the comparator column
+        5. Single literal value - checks direct equality with the target
         """
         target = other_value.get("target")
         value_is_literal = other_value.get("value_is_literal", False)
@@ -40,12 +42,15 @@ class IsContainedByOperator(BaseSqlOperator):
         target_column = self.replace_prefix(target)
         column = self._column_sql(target_column, lowercase=self.case_insensitive, prefix=prefix, suffix=suffix)
 
-        if isinstance(comparator, list) or (isinstance(comparator, str) and comparator in self.operation_variables):
+        if isinstance(comparator, list):
             comparator_sql = self._collection_sql(comparator, lowercase=self.case_insensitive)
 
             def sql():
                 return f"""NOT ({self._is_empty_sql(target_column)})
                           AND {column} IN {comparator_sql}"""
+
+        elif isinstance(comparator, str) and comparator in self.operation_variables:
+            return self._handle_operation_variable_comparator(target_column, column, comparator)
 
         elif isinstance(comparator, str) and not value_is_literal and self._exists(comparator):
             comparator_sql = self._column_sql(comparator, lowercase=self.case_insensitive, alias=False)
@@ -66,6 +71,40 @@ class IsContainedByOperator(BaseSqlOperator):
                     "value_is_literal": True,
                 }
             )
+
+        return self._do_check_operator(sql)
+
+    def _handle_operation_variable_comparator(self, target_column, column, comparator):
+        """Handle when comparator is an operation variable."""
+        variable = self.operation_variables[comparator]
+
+        if variable.type == "constant":
+            return self._handle_constant_variable_comparator(target_column, column, comparator)
+        elif variable.type == "collection":
+            return self._handle_collection_variable_comparator(target_column, column, comparator)
+        else:
+            raise ValueError(
+                f"Unsupported operation variable type: {variable.type} "
+                f"for variable {comparator}. Expected 'collection' or 'constant'."
+            )
+
+    def _handle_collection_variable_comparator(self, target_column, column, comparator):
+        """Handle collection type operation variable comparator."""
+
+        def sql():
+            comparator_sql = self._collection_sql(comparator, lowercase=self.case_insensitive)
+            return f"""NOT ({self._is_empty_sql(target_column)})
+                      AND {column} IN {comparator_sql}"""
+
+        return self._do_check_operator(sql)
+
+    def _handle_constant_variable_comparator(self, target_column, column, comparator):
+        """Handle constant type operation variable comparator."""
+
+        def sql():
+            comparator_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
+            return f"""NOT ({self._is_empty_sql(target_column)})
+                      AND {column} = {comparator_sql}"""
 
         return self._do_check_operator(sql)
 

--- a/cdisc_rules_engine/check_operators/sql/is_contained_by_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_contained_by_operator.py
@@ -1,5 +1,4 @@
 from .base_sql_operator import BaseSqlOperator
-from .equal_to_operator import EqualToOperator
 
 
 class IsContainedByOperator(BaseSqlOperator):
@@ -11,7 +10,7 @@ class IsContainedByOperator(BaseSqlOperator):
 
     def execute_operator(self, other_value):
         """
-        Checks if the target column values are contained within the comparator.
+        Checks if the target column/array values are contained within the comparator.
 
         Returns True if target value exists in the comparator collection/column and is not null/empty.
         Returns False if target value is null, empty, or not found in comparator.
@@ -30,114 +29,113 @@ class IsContainedByOperator(BaseSqlOperator):
         prefix = other_value.get("prefix", None)
         suffix = other_value.get("suffix", None)
 
-        if isinstance(target, str) and target in self.operation_variables:
-            target_var = self.operation_variables[target]
+        is_target_list = isinstance(target, list)
+        is_target_collection = (
+            isinstance(target, str)
+            and target in self.operation_variables
+            and self.operation_variables[target].type == "collection"
+        )
 
-            if target_var.type == "collection":
-                if isinstance(comparator, str) and not value_is_literal and comparator in self.operation_variables:
-                    return self._handle_collection_vs_collection(target, comparator)
-                elif isinstance(comparator, list):
-                    return self._handle_collection_vs_list(target, comparator)
+        if is_target_list or is_target_collection:
+            return self._handle_array_target(target, comparator, value_is_literal, is_target_list)
 
-        target_column = self.replace_prefix(target)
-        column = self._column_sql(target_column, lowercase=self.case_insensitive, prefix=prefix, suffix=suffix)
+        target_sql, target_empty_sql = self._get_scalar_target_sql(target, prefix, suffix)
+        return self._handle_scalar_target(target_sql, target_empty_sql, comparator, value_is_literal)
 
+    def _get_scalar_target_sql(self, target, prefix, suffix):
+        target_name = self.replace_prefix(target)
+
+        if self._exists(target_name):
+            target_sql = self._column_sql(target_name, lowercase=self.case_insensitive, prefix=prefix, suffix=suffix)
+            target_empty_sql = self._is_empty_sql(target_name)
+        else:
+            base_target_sql = self._constant_sql(target_name, lowercase=self.case_insensitive)
+            if prefix is not None:
+                base_target_sql = f"LEFT({base_target_sql}, {prefix})"
+            if suffix is not None:
+                base_target_sql = f"RIGHT({base_target_sql}, {suffix})"
+
+            target_sql = base_target_sql
+            target_empty_sql = "FALSE" if target_name else "TRUE"
+
+        return target_sql, target_empty_sql
+
+    def _handle_scalar_target(self, target_sql, target_empty_sql, comparator, value_is_literal):
         if isinstance(comparator, list):
+            if not comparator:
+                return self._do_check_operator(lambda: "FALSE")
             comparator_sql = self._collection_sql(comparator, lowercase=self.case_insensitive)
-
-            def sql():
-                return f"""NOT ({self._is_empty_sql(target_column)})
-                          AND {column} IN {comparator_sql}"""
+            return self._do_check_operator(lambda: f"NOT ({target_empty_sql}) AND {target_sql} IN {comparator_sql}")
 
         elif isinstance(comparator, str) and comparator in self.operation_variables:
-            return self._handle_operation_variable_comparator(target_column, column, comparator)
+            var = self.operation_variables[comparator]
+            if var.type == "constant":
+                comp_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
+                return self._do_check_operator(lambda: f"NOT ({target_empty_sql}) AND {target_sql} = {comp_sql}")
+            else:
+                comp_sql = self._collection_sql(comparator, lowercase=self.case_insensitive)
+                return self._do_check_operator(lambda: f"NOT ({target_empty_sql}) AND {target_sql} IN {comp_sql}")
 
-        elif isinstance(comparator, str) and not value_is_literal and self._exists(comparator):
-            comparator_sql = self._column_sql(comparator, lowercase=self.case_insensitive, alias=False)
+        elif isinstance(comparator, str) and not value_is_literal and self._exists(self.replace_prefix(comparator)):
+            comp_col = self.replace_prefix(comparator)
+            comp_sql = self._column_sql(comp_col, lowercase=self.case_insensitive, alias=False)
+            comp_empty = self._is_empty_sql(comp_col, alias=False)
 
             def sql():
-                return f"""NOT ({self._is_empty_sql(target_column)})
-                          AND {column} IN (
-                              SELECT DISTINCT {comparator_sql}
+                return f"""NOT ({target_empty_sql})
+                          AND {target_sql} IN (
+                              SELECT DISTINCT {comp_sql}
                               FROM {self._table_sql()}
-                              WHERE NOT ({self._is_empty_sql(comparator, alias=False)})
+                              WHERE NOT ({comp_empty})
                           )"""
 
+            return self._do_check_operator(sql)
+
         else:
-            return EqualToOperator(self.original_data, case_insensitive=self.case_insensitive).execute_operator(
-                {
-                    "target": target,
-                    "comparator": comparator,
-                    "value_is_literal": True,
-                }
-            )
+            comp_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
+            return self._do_check_operator(lambda: f"NOT ({target_empty_sql}) AND {target_sql} = {comp_sql}")
 
-        return self._do_check_operator(sql)
-
-    def _handle_operation_variable_comparator(self, target_column, column, comparator):
-        """Handle when comparator is an operation variable."""
-        variable = self.operation_variables[comparator]
-
-        if variable.type == "constant":
-            return self._handle_constant_variable_comparator(target_column, column, comparator)
-        elif variable.type == "collection":
-            return self._handle_collection_variable_comparator(target_column, column, comparator)
+    def _handle_array_target(self, target, comparator, value_is_literal, is_target_list):
+        if is_target_list:
+            if not target:
+                return self._do_check_operator(lambda: "FALSE")
+            values = ", ".join(f"({self._constant_sql(v, lowercase=self.case_insensitive)})" for v in target)
+            target_table_sql = f"(VALUES {values})"
         else:
-            raise ValueError(
-                f"Unsupported operation variable type: {variable.type} "
-                f"for variable {comparator}. Expected 'collection' or 'constant'."
-            )
+            target_table_sql = self._collection_sql(target, lowercase=self.case_insensitive)
 
-    def _handle_collection_variable_comparator(self, target_column, column, comparator):
-        """Handle collection type operation variable comparator."""
+        if isinstance(comparator, list):
+            if not comparator:
+                return self._do_check_operator(lambda: "FALSE")
+            comp_values = ", ".join(f"({self._constant_sql(v, lowercase=self.case_insensitive)})" for v in comparator)
+            comp_table_sql = f"(VALUES {comp_values})"
+
+        elif isinstance(comparator, str) and comparator in self.operation_variables:
+            var = self.operation_variables[comparator]
+            if var.type == "collection":
+                comp_table_sql = self._collection_sql(comparator, lowercase=self.case_insensitive)
+            else:
+                comp_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
+                comp_table_sql = f"(VALUES ({comp_sql}))"
+
+        elif isinstance(comparator, str) and not value_is_literal and self._exists(self.replace_prefix(comparator)):
+            comp_col = self.replace_prefix(comparator)
+            comp_sql = self._column_sql(comp_col, lowercase=self.case_insensitive, alias=False)
+            comp_empty = self._is_empty_sql(comp_col, alias=False)
+            comp_table_sql = f"(SELECT DISTINCT {comp_sql} FROM {self._table_sql()} WHERE NOT ({comp_empty}))"
+
+        else:
+            comp_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
+            comp_table_sql = f"(VALUES ({comp_sql}))"
 
         def sql():
-            comparator_sql = self._collection_sql(comparator, lowercase=self.case_insensitive)
-            return f"""NOT ({self._is_empty_sql(target_column)})
-                      AND {column} IN {comparator_sql}"""
-
-        return self._do_check_operator(sql)
-
-    def _handle_constant_variable_comparator(self, target_column, column, comparator):
-        """Handle constant type operation variable comparator."""
-
-        def sql():
-            comparator_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
-            return f"""NOT ({self._is_empty_sql(target_column)})
-                      AND {column} = {comparator_sql}"""
-
-        return self._do_check_operator(sql)
-
-    def _handle_collection_vs_collection(self, target, comparator):
-        def sql():
-            target_sql = self._collection_sql(target, lowercase=self.case_insensitive)
-            comparator_sql = self._collection_sql(comparator, lowercase=self.case_insensitive)
-
             return f"""NOT EXISTS (
-                SELECT 1 FROM {target_sql} AS target_vals(t_val)
+                SELECT 1 FROM {target_table_sql} AS target_vals(t_val)
                 WHERE target_vals.t_val IS NOT NULL AND target_vals.t_val != ''
                 AND NOT EXISTS (
-                    SELECT 1 FROM {comparator_sql} AS comp_vals(c_val)
+                    SELECT 1 FROM {comp_table_sql} AS comp_vals(c_val)
                     WHERE comp_vals.c_val IS NOT NULL AND comp_vals.c_val != ''
                     AND comp_vals.c_val = target_vals.t_val
-                )
-            )"""
-
-        return self._do_check_operator(sql)
-
-    def _handle_collection_vs_list(self, target_collection, comparator_list):
-        def sql():
-            target_sql = self._collection_sql(target_collection, lowercase=self.case_insensitive)
-            values_sql = ", ".join(
-                f"({self._constant_sql(v, lowercase=self.case_insensitive)})" for v in comparator_list
-            )
-
-            return f"""NOT EXISTS (
-                SELECT 1 FROM {target_sql} AS target_vals(t_val)
-                WHERE target_vals.t_val IS NOT NULL AND target_vals.t_val != ''
-                AND NOT EXISTS (
-                    SELECT 1 FROM (VALUES {values_sql}) AS comp_vals(c_val)
-                    WHERE comp_vals.c_val = target_vals.t_val
                 )
             )"""
 


### PR DESCRIPTION
Goal: improving and extending target/comparator handling by IsContainedByOperator operator.
- adding target as a literal value list 
- fixing comparator as a literal value list (falls back to failing EqualToOperator when target is literal value string)
- bugfixes

Fixed a bug that caused mishandling of the comparator as operation constant case, which was handled by the same branch as the comparator as list case. Added comparator handling methods along the lines of other operators.

Will add more commits after draft PR is reviewed.