### PR TITLE
feat: Contains + Empty co refactor

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/contains_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/contains_operator.py
@@ -11,41 +11,84 @@ class ContainsOperator(BaseSqlOperator):
     def execute_operator(self, other_value):
         """
         Checks if the comparator value is a substring of the target column values.
-        Also handles cases where the target is a collection operation variable.
+        Also handles cases where the target is a collection operation variable or a literal value list.
         Returns True if the comparator is found as a substring within the target column.
         """
         target = other_value.get("target")
         value_is_literal = other_value.get("value_is_literal", False)
         comparator = other_value.get("comparator")
 
-        if target in self.operation_variables:
-            target_var = self.operation_variables[target]
-            if target_var.type == "collection":
-                return self._handle_target_is_collection(target, comparator, value_is_literal)
+        is_target_list = isinstance(target, list)
+        is_target_collection = (
+            isinstance(target, str)
+            and target in self.operation_variables
+            and self.operation_variables[target].type == "collection"
+        )
 
-        target_column = self.replace_prefix(target)
+        if is_target_list or is_target_collection:
+            return self._handle_array_target(target, comparator, value_is_literal, is_target_list)
 
-        if isinstance(comparator, str) and comparator in self.operation_variables:
-            return self._handle_operation_variable_comparator(target_column, comparator)
-        elif isinstance(comparator, list):
-            return self._handle_list_comparator(target_column, comparator)
-        elif value_is_literal:
-            return self._handle_literal_value(target_column, comparator)
-        elif isinstance(comparator, str) and self._exists(comparator):
-            return self._handle_column_comparator(target_column, comparator)
-        elif isinstance(comparator, str):
-            # String literals when not explicitly marked as literal
-            return self._handle_literal_value(target_column, comparator)
+        target_sql, target_empty_sql = self._get_scalar_target_sql(target)
+        return self._handle_scalar_target(target_sql, target_empty_sql, target, comparator, value_is_literal)
+
+    def _get_scalar_target_sql(self, target):
+        target_name = self.replace_prefix(target)
+
+        if self._exists(target_name):
+            target_sql = self._column_sql(target_name, lowercase=self.case_insensitive)
+            target_empty_sql = self._is_empty_sql(target_name)
         else:
-            return self._handle_invalid_comparator(target_column, comparator)
+            target_sql = self._constant_sql(target_name, lowercase=self.case_insensitive)
+            target_empty_sql = "FALSE" if target_name else "TRUE"
 
-    def _handle_list_comparator(self, target_column, comparator):
-        """Handle when comparator is a list."""
+        return target_sql, target_empty_sql
+
+    def _handle_scalar_target(self, target_sql, target_empty_sql, target_raw, comparator, value_is_literal):
+        if isinstance(comparator, str) and comparator in self.operation_variables:
+            return self._handle_operation_variable_comparator(target_sql, target_empty_sql, comparator)
+        elif isinstance(comparator, list):
+            if not comparator:
+                return self._do_check_operator(lambda: "FALSE")
+            return self._handle_list_comparator(target_sql, target_empty_sql, comparator)
+        elif isinstance(comparator, str) and not value_is_literal and self._exists(self.replace_prefix(comparator)):
+            return self._handle_column_comparator(target_sql, target_empty_sql, comparator)
+        elif isinstance(comparator, str):
+            return self._handle_literal_value(target_sql, target_empty_sql, comparator)
+        else:
+            target_name = self.replace_prefix(target_raw)
+            raise ValueError(
+                f"Invalid comparator type for contains operation on column '{target_name}'. "
+                f"Expected list, column name, or operation variable, but got: {type(comparator).__name__}"
+            )
+
+    def _handle_array_target(self, target, comparator, value_is_literal, is_target_list):
+        if is_target_list:
+            if not target:
+                return self._do_check_operator(lambda: "FALSE")
+            values = ", ".join(f"({self._constant_sql(v, lowercase=self.case_insensitive)})" for v in target)
+            target_table_sql = f"(VALUES {values})"
+        else:
+            target_table_sql = self._collection_sql(target, lowercase=self.case_insensitive)
 
         def sql():
-            target_sql = self._column_sql(target_column, lowercase=self.case_insensitive)
+            if value_is_literal:
+                comparator_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
+            else:
+                comparator_sql = self._sql(
+                    comparator, lowercase=self.case_insensitive, value_is_literal=value_is_literal
+                )
+
+            return f"""EXISTS (
+                        SELECT 1 FROM {target_table_sql} AS collection_values(value)
+                        WHERE collection_values.value = {comparator_sql}
+                    )"""
+
+        return self._do_check_operator(sql)
+
+    def _handle_list_comparator(self, target_sql, target_empty_sql, comparator):
+        def sql():
             values_sql = ", ".join(f"({self._constant_sql(v, lowercase=self.case_insensitive)})" for v in comparator)
-            return f"""NOT ({self._is_empty_sql(target_column)})
+            return f"""NOT ({target_empty_sql})
                       AND EXISTS (
                           SELECT 1 FROM (VALUES {values_sql}) AS list_values(value)
                           WHERE list_values.value != ''
@@ -54,92 +97,54 @@ class ContainsOperator(BaseSqlOperator):
 
         return self._do_check_operator(sql)
 
-    def _handle_operation_variable_comparator(self, target_column, comparator):
-        """Handle when comparator is an operation variable."""
+    def _handle_operation_variable_comparator(self, target_sql, target_empty_sql, comparator):
         variable = self.operation_variables[comparator]
 
         if variable.type == "constant":
-            return self._handle_constant_variable(target_column, comparator)
+
+            def sql():
+                comparator_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
+                return f"""NOT ({target_empty_sql})
+                          AND {comparator_sql} != ''
+                          AND {target_sql} LIKE '%' || {comparator_sql} || '%'"""
+
+            return self._do_check_operator(sql)
+
         elif variable.type == "collection":
-            return self._handle_collection_variable(target_column, comparator)
+
+            def sql():
+                collection_sql = self._collection_sql(comparator, lowercase=self.case_insensitive)
+                return f"""NOT ({target_empty_sql})
+                          AND EXISTS (
+                              SELECT 1 FROM {collection_sql} AS collection_values(value)
+                              WHERE collection_values.value != ''
+                              AND {target_sql} LIKE '%' || collection_values.value || '%'
+                          )"""
+
+            return self._do_check_operator(sql)
+
         else:
             raise ValueError(
                 f"Unsupported operation variable type: {variable.type} "
                 f"for variable {comparator}. Expected 'collection' or 'constant'."
             )
 
-    def _handle_collection_variable(self, target_column, comparator):
-        """Handle collection type operation variable."""
-
-        def sql():
-            target_sql = self._column_sql(target_column, lowercase=self.case_insensitive)
-            collection_sql = self._collection_sql(comparator, lowercase=self.case_insensitive)
-            return f"""NOT ({self._is_empty_sql(target_column)})
-                      AND EXISTS (
-                          SELECT 1 FROM {collection_sql} AS collection_values(value)
-                          WHERE collection_values.value != ''
-                          AND {target_sql} LIKE '%' || collection_values.value || '%'
-                      )"""
-
-        return self._do_check_operator(sql)
-
-    def _handle_constant_variable(self, target_column, comparator):
-        """Handle constant type operation variable."""
-
-        def sql():
-            target_sql = self._column_sql(target_column, lowercase=self.case_insensitive)
-            comparator_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
-            return f"""NOT ({self._is_empty_sql(target_column)})
-                      AND {comparator_sql} != ''
-                      AND {target_sql} LIKE '%' || {comparator_sql} || '%'"""
-
-        return self._do_check_operator(sql)
-
-    def _handle_column_comparator(self, target_column, comparator):
-        """Handle when comparator is a column name."""
+    def _handle_column_comparator(self, target_sql, target_empty_sql, comparator):
         comparator_column = self.replace_prefix(comparator)
 
         def sql():
             comparator_sql = self._column_sql(comparator_column, lowercase=self.case_insensitive)
-            target_sql = self._column_sql(target_column, lowercase=self.case_insensitive)
-            return f"""NOT ({self._is_empty_sql(target_column)})
+            return f"""NOT ({target_empty_sql})
                       AND NOT ({self._is_empty_sql(comparator_column)})
                       AND {target_sql} LIKE '%' || {comparator_sql} || '%'"""
 
         return self._do_check_operator(sql)
 
-    def _handle_literal_value(self, target_column, comparator):
-        """Handle single literal value case."""
-
+    def _handle_literal_value(self, target_sql, target_empty_sql, comparator):
         def sql():
             comparator_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
-            target_sql = self._column_sql(target_column, lowercase=self.case_insensitive)
-            return f"""NOT ({self._is_empty_sql(target_column)})
+            return f"""NOT ({target_empty_sql})
                       AND {comparator_sql} != ''
                       AND {target_sql} LIKE '%' || {comparator_sql} || '%'"""
-
-        return self._do_check_operator(sql)
-
-    def _handle_invalid_comparator(self, target_column, comparator):
-        """Handle invalid comparator types."""
-        raise ValueError(
-            f"Invalid comparator type for contains operation on column '{target_column}'. "
-            f"Expected list, column name, or operation variable, but got: {type(comparator).__name__}"
-        )
-
-    def _handle_target_is_collection(self, target_variable, comparator, value_is_literal):
-        """Handle when the target is a collection operation variable."""
-
-        def sql():
-            collection_sql = self._collection_sql(target_variable, lowercase=self.case_insensitive)
-            if value_is_literal:
-                comparator_sql = self._constant_sql(comparator, lowercase=self.case_insensitive)
-            else:
-                comparator_sql = self._sql(comparator, lowercase=self.case_insensitive)
-
-            return f"""EXISTS (
-                        SELECT 1 FROM {collection_sql} AS collection_values(value)
-                        WHERE collection_values.value = {comparator_sql}
-                    )"""
 
         return self._do_check_operator(sql)

--- a/cdisc_rules_engine/check_operators/sql/empty_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/empty_operator.py
@@ -5,9 +5,32 @@ class EmptyOperator(BaseSqlOperator):
     """Operator for checking if values are empty/null."""
 
     def execute_operator(self, other_value):
-        column = self.replace_prefix(other_value.get("target"))
+        target = other_value.get("target")
+        if isinstance(target, str):
+            if target in self.operation_variables:
+                target_var = self.operation_variables[target]
+                if target_var.type == "collection":
 
-        def sql():
-            return self._is_empty_sql(column)
+                    def sql():
+                        return f"NOT ({self._is_empty_sql(target)})"
 
-        return self._do_check_operator(sql)
+                else:
+                    raise ValueError(f"Target is an operation variable but not a collection type: {target}")
+            else:
+                column = self.replace_prefix(target)
+                if self._exists(column):
+
+                    def sql():
+                        return self._is_empty_sql(column)
+
+                else:
+
+                    def sql():
+                        return "FALSE"
+
+                return self._do_check_operator(sql)
+        else:
+            raise ValueError(
+                f"Target must not be a literal value list and must be a column or "
+                f"operation collection variable: {target}"
+            )


### PR DESCRIPTION
Adds support in empty operator for:
- operation collection type being empty
- reject operation constants and literal lists.
- soft FALSE for non-existent columns <- this also catches literal value strings for target which shouldn't be allowed (doesn't align with the intended meaning of EMPTY

Add support in contains operator for:
- target is a literal value list
- slight structural refactor too to make multiple target types a little easier to read.