### PR TITLE
feat: return empty set if domain missing

### DIFF
--- a/cdisc_rules_engine/sql_operations/distinct.py
+++ b/cdisc_rules_engine/sql_operations/distinct.py
@@ -5,6 +5,9 @@ from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperatio
 class SqlDistinctOperation(SqlBaseOperation):
     def _execute_operation(self):
         dataset_id = self.data_service.pgi.schema.get_table_hash(self.params.domain)
+        if not dataset_id:
+            query = self._empty_result_set_query()
+            return SqlOperationResult(query=query, type="collection", subtype="Char", params={})
         column_id = self.data_service.pgi.schema.get_column_hash(self.params.domain, self.params.target)
         column_type = self.data_service.pgi.schema.get_column(self.params.domain, self.params.target).type
 

--- a/cdisc_rules_engine/sql_operations/sql_base_operation.py
+++ b/cdisc_rules_engine/sql_operations/sql_base_operation.py
@@ -246,3 +246,10 @@ class SqlBaseOperation:
     @staticmethod
     def _replace_variable_wildcards(variables_metadata, domain):
         return [var["name"].replace("--", domain) for var in variables_metadata]
+
+    @staticmethod
+    def _empty_result_set_query() -> str:
+        """
+        Returns a SQL query that produces an empty result set with a single column named 'value'.
+        """
+        return "SELECT value FROM (VALUES (NULL)) AS t(value) WHERE FALSE"


### PR DESCRIPTION
Small tweak to return empty set if the domain isn't present. Also added a generic empty set query we can use for convenience - as we do op refactoring we can adjust.

Note that there may be a need at some point to handle missing cols in distinct too, but unclear about correct behaviour for this (should distinct ever be called on an optional column?) so will wait for a rule example before changing.