### PR TITLE
feat: add codelist name to library value builder

### DIFF
--- a/cdisc_rules_engine/sql_dataset_builders/sql_value_check_against_library_dataset_builder.py
+++ b/cdisc_rules_engine/sql_dataset_builders/sql_value_check_against_library_dataset_builder.py
@@ -103,4 +103,20 @@ class SqlValueCheckAgainstLibraryDatasetBuilder(SqlBaseDatasetBuilder):
 
         self.data_service.pgi.execute_sql(codelist_query)
 
+        self.data_service.pgi.add_column(table_name, SqlColumnSchema.define("library_variable_codelist_name", "Char"))
+        codelist_name_col_hash = self.data_service.pgi.schema.get_column_hash(
+            table_name, "library_variable_codelist_name"
+        )
+        codelist_name_query = f"""
+            UPDATE {schema.hash} t
+            SET {codelist_name_col_hash} = sub.library_variable_codelist_name
+            FROM (
+                SELECT item_code, name as library_variable_codelist_name
+                FROM {StaticTables.IG_CODELIST_TABLE_NAME.value}
+            ) sub
+            WHERE t.{new_col_hash_map['library_variable_ccode']} = sub.item_code;
+        """
+
+        self.data_service.pgi.execute_sql(codelist_name_query)
+
         return table_name


### PR DESCRIPTION
Quick extra col addition, for helpful reference in rules.

When we next get a chance for major refactor I think we want to try to standardise some of the dataset builder methods - maybe having subclasses for different groups of builders with shared methods etc.

For now, I think adding just to this builder is fine.