### PR TITLE
feat: enable simul xpt+sas7bdat in sql engine

### DIFF
--- a/core.py
+++ b/core.py
@@ -35,7 +35,7 @@ from scripts.run_validation import run_validation
 from version import __version__
 
 
-def valid_data_file(data_path: list) -> Tuple[list, set]:
+def valid_data_file(data_path: list, allow_sql_mixed_formats: bool = False) -> Tuple[list, set]:
     allowed_formats = [format.value for format in DataFormatTypes]
     found_formats = set()
     file_list = []
@@ -45,9 +45,14 @@ def valid_data_file(data_path: list) -> Tuple[list, set]:
             found_formats.add(file_extension)
             file_list.append(file)
     if len(found_formats) > 1:
+        allowed_sql_mix = {DataFormatTypes.XPT.value, DataFormatTypes.SAS7BDAT.value}
+        if allow_sql_mixed_formats and found_formats.issubset(allowed_sql_mix):
+            return file_list, found_formats
         return [], found_formats
-    elif len(found_formats) == 1:
+    if len(found_formats) == 1:
         return file_list, found_formats
+
+    return [], set()
 
 
 @click.group()
@@ -226,7 +231,7 @@ def cli():
     help="Run validation using an in-memory Postgres instance",
 )
 @click.pass_context
-def validate(
+def validate(  # noqa: C901
     ctx,
     cache: str,
     pool_size: int,
@@ -279,6 +284,7 @@ def validate(
             ctx.exit()
 
     cache_path: str = os.path.join(os.path.dirname(__file__), cache)
+    allowed_sql_mix = {DataFormatTypes.XPT.value, DataFormatTypes.SAS7BDAT.value}
 
     dict_container = SqlExternalDictionariesContainer if sql_engine else ExternalDictionariesContainer
     external_dictionaries = dict_container(
@@ -303,19 +309,29 @@ def validate(
         if dataset_path:
             logger.error("Argument --dataset-path cannot be used together with argument --data")
             ctx.exit()
-        dataset_paths, found_formats = valid_data_file([str(Path(data).joinpath(fn)) for fn in os.listdir(data)])
+        dataset_paths, found_formats = valid_data_file(
+            [str(Path(data).joinpath(fn)) for fn in os.listdir(data)],
+            allow_sql_mixed_formats=sql_engine,
+        )
         if len(found_formats) > 1:
-            logger.error(
-                f"Argument --data contains more than one allowed file format ({', '.join(found_formats)})."  # noqa: E501
-            )
-            ctx.exit()
+            if not (sql_engine and found_formats.issubset(allowed_sql_mix)):
+                logger.error(
+                    f"Argument --data contains more than one allowed file format ({', '.join(found_formats)}). "
+                    "Mixed formats are supported only for SQL engine runs and only for XPT + SAS7BDAT files."
+                )
+                ctx.exit()
     elif dataset_path:
-        dataset_paths, found_formats = valid_data_file([dp for dp in dataset_path])
+        dataset_paths, found_formats = valid_data_file(
+            [dp for dp in dataset_path],
+            allow_sql_mixed_formats=sql_engine,
+        )
         if len(found_formats) > 1:
-            logger.error(
-                f"Argument --dataset_path contains more than one allowed file format ({', '.join(found_formats)})."  # noqa: E501
-            )
-            ctx.exit()
+            if not (sql_engine and found_formats.issubset(allowed_sql_mix)):
+                logger.error(
+                    f"Argument --dataset_path contains more than one allowed file format ({', '.join(found_formats)}). "
+                    "Mixed formats are supported only for SQL engine runs and only for XPT + SAS7BDAT files."
+                )
+                ctx.exit()
     else:
         logger.error("You must pass one of the following arguments: --dataset-path, --data")
         # no need to define dataset_paths here, the program execution will stop


### PR DESCRIPTION
For some reason the engine was limited to running a single set of file formats (ie .xpt OR .sas7bdat, but not both). However, functionally there is no reason the engine can't handle both at once. I have enabled mixed format running for the sql engine alone, and only if the file formats are exclusively .xpt and .sas7bdat. If needed, this can be expanded further.