### PR TITLE
feat: allow numeric comparison in equal_to

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/base_sql_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/base_sql_operator.py
@@ -448,8 +448,6 @@ class BaseSqlOperator:
                 return self._is_empty_sql_column(target, alias)
             elif target in self.operation_variables:
                 return self._is_empty_sql_operation_variable(target)
-            else:
-                return "FALSE"
 
         if isinstance(target, str) and target == "":
             return "TRUE"
@@ -535,3 +533,15 @@ class BaseSqlOperator:
             filter_value = filter_value.replace("'", "").replace('"', "").strip()
 
         return filter_attribute, filter_value
+
+    @staticmethod
+    def _safe_numeric_cast_sql(value_sql: str) -> str:
+        """
+        Safely cast a SQL expression to NUMERIC.
+        Non-numeric values return NULL instead of raising a Postgres cast error.
+        """
+        return f"""CASE
+                WHEN TRIM(CAST({value_sql} AS TEXT)) ~ '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?$'
+                    THEN CAST(TRIM(CAST({value_sql} AS TEXT)) AS NUMERIC)
+                ELSE NULL
+            END"""

--- a/cdisc_rules_engine/check_operators/sql/equal_to_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/equal_to_operator.py
@@ -29,6 +29,7 @@ class EqualToOperator(BaseSqlOperator):
         value_is_reference = other_value.get("value_is_reference", False)
         type_insensitive = other_value.get("type_insensitive", False)
         comparator = other_value.get("comparator")
+
         if not value_is_literal:
             comparator = self.replace_prefix(comparator)
 
@@ -62,7 +63,7 @@ class EqualToOperator(BaseSqlOperator):
         invert: bool = False,
         value_is_literal: bool = False,
         case_insensitive: bool = False,
-        type_insensitive: bool = False,
+        type_insensitive=False,
     ):
         """
         Beware of empty values.
@@ -72,8 +73,14 @@ class EqualToOperator(BaseSqlOperator):
         comparator = self._sql(original_comparator, lowercase=case_insensitive, value_is_literal=value_is_literal)
 
         if type_insensitive:
-            target = f"""CAST({target} AS TEXT)"""
-            comparator = f"""CAST({comparator} AS TEXT)"""
+            target = (
+                self._safe_numeric_cast_sql(target) if type_insensitive == "numeric" else f"""CAST({target} AS TEXT)"""
+            )
+            comparator = (
+                self._safe_numeric_cast_sql(comparator)
+                if type_insensitive == "numeric"
+                else f"""CAST({comparator} AS TEXT)"""
+            )
 
         if original_target not in self.operation_variables and not self._exists(original_target):
             target = "NULL"
@@ -104,7 +111,7 @@ class EqualToOperator(BaseSqlOperator):
         pivot_column,
         invert: bool = False,
         case_insensitive: bool = False,
-        type_insensitive: bool = False,
+        type_insensitive=False,
     ):
         """
         Beware of empty values.
@@ -120,7 +127,11 @@ class EqualToOperator(BaseSqlOperator):
         pivot_col = self._column_sql(pivot_column, alias=False)
 
         if type_insensitive:
-            target_col = f"""CAST({target_col} AS TEXT)"""
+            target_col = (
+                self._safe_numeric_cast_sql(target_col)
+                if type_insensitive == "numeric"
+                else f"""CAST({target_col} AS TEXT)"""
+            )
 
         # Find all of the values of the pivot column -> all columns to compare against
         self.sql_data_service.pgi.execute_sql(f"SELECT DISTINCT {pivot_col} col FROM {self._table_sql()};")
@@ -133,7 +144,7 @@ class EqualToOperator(BaseSqlOperator):
             c = self._column_sql(original_c, lowercase=case_insensitive, alias=True)
 
             if type_insensitive:
-                c = f"""CAST({c} AS TEXT)"""
+                c = self._safe_numeric_cast_sql(c) if type_insensitive == "numeric" else f"""CAST({c} AS TEXT)"""
 
             if invert:
                 return f"""CASE

--- a/tests/unit/sql/test_check_operators/test_sql_equality_checks.py
+++ b/tests/unit/sql/test_check_operators/test_sql_equality_checks.py
@@ -170,6 +170,29 @@ def test_equality_operators_type_insensitive(data, comparator, operator, expecte
     "data,comparator,expected_result",
     [
         (
+            {"target": ["12", "abc", "1.5"], "VAR2": [12, 12, 1.5]},
+            "VAR2",
+            [True, False, True],
+        ),
+    ],
+)
+def test_equal_to_type_insensitive_numeric_safe_cast(data, comparator, expected_result):
+    sql_ops = create_sql_operators(data)
+    result = sql_ops.equal_to(
+        {
+            "target": "target",
+            "comparator": comparator,
+            "value_is_literal": False,
+            "type_insensitive": "numeric",
+        }
+    )
+    assert_series_equals(result, expected_result)
+
+
+@pytest.mark.parametrize(
+    "data,comparator,expected_result",
+    [
+        (
             {"target": ["A", "B", "", "", None], "VAR2": ["A", "B", "C", None, None]},
             "VAR2",
             [False, False, True, False, False],


### PR DESCRIPTION
If 'numeric' is specified in the rule parameter 'type_insensitive' then the equal_to op will attempt to cast the values to numeric before comparing rather than text. This allows us to properly compare eg 36.00 and 36.0. 

Implemented a safe numeric cast method - any non-numerics will return null rather than error