### PR TITLE
update redis even though we don't use it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pre-commit==2.20.0
 pyinstaller==6.11.0
 python-dotenv==1.2.2
 pyyaml==6.0.2
-redis==4.5.0
+redis==4.5.4
 requests~=2.32.3
 setuptools~=75.6.0
 cachetools==5.5.0


### PR DESCRIPTION
Per the dependabot's request, I've bumped the version of redis in the requirements.txt file. We could just delete but I fear that too much of the cdisc engine depends on it to run (a caching system I believe). And I'd like to still be able to run cdisc engine on main even it is it janky.