### PR TITLE
feat: allow empty table creation

### DIFF
--- a/cdisc_rules_engine/data_service/sql_interface.py
+++ b/cdisc_rules_engine/data_service/sql_interface.py
@@ -194,6 +194,9 @@ class PostgresQLInterface:
             logger.info(f"Inserted 1 row into {table_name}")
             return 1
         else:
+            if not data:
+                logger.info(f"No rows to insert into {table_name}; leaving table empty")
+                return 0
             query = SQLSerialiser.insert_many_dicts(schema, data)
             rows = self.execute_sql(query)
             logger.info(f"Inserted {rows} rows into {table_name}")

--- a/tests/unit/sql/test_services/test_data_service/test_postgresql_data_service.py
+++ b/tests/unit/sql/test_services/test_data_service/test_postgresql_data_service.py
@@ -1,6 +1,7 @@
 from cdisc_rules_engine.data_service.postgresql_data_service import (
     PostgresQLDataService,
 )
+from cdisc_rules_engine.models.sql.table_schema import SqlTableSchema
 from cdisc_rules_engine.standards.default_standards_context import (
     DefaultStandardsContext,
 )
@@ -30,3 +31,19 @@ def test_get_uploaded_dataset_ids(get_sample_lb_dataset, get_sample_supp_dataset
         [get_sample_lb_dataset, get_sample_supp_dataset], DefaultStandardsContext()
     )
     assert 2 == len(sql_data_service.get_uploaded_dataset_ids())
+
+
+def test_insert_empty_data_creates_no_rows_and_does_not_raise():
+    data_service = PostgresQLDataService.instance()
+    table_name = "empty_table"
+    schema = SqlTableSchema.from_data(table_name, {"col1": "sample"}, data_service.pgi)
+    data_service.pgi.create_table(schema)
+
+    inserted_rows = data_service.pgi.insert_data(table_name, [])
+
+    assert inserted_rows == 0
+
+    table_hash = data_service.pgi.schema.get_table_hash(table_name)
+    data_service.pgi.execute_sql(f"SELECT COUNT(*) AS cnt FROM {table_hash}")
+    result = data_service.pgi.fetch_one()
+    assert result["cnt"] == 0


### PR DESCRIPTION
Previously engine would error if no data was passed. However, some rules require testing of empty tables (ie ensure row_count > 0 needs a failing case) and so I've adapted the engine to allow empty table creation.