### PR TITLE
feat: regex variable handling

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/postgresql_operators.py
+++ b/cdisc_rules_engine/check_operators/sql/postgresql_operators.py
@@ -1,3 +1,5 @@
+import re
+
 from business_rules.fields import FIELD_DATAFRAME
 from business_rules.operators import BaseType, type_operator
 from cdisc_rules_engine.constants.metadata_columns import DATASET_NAME
@@ -321,7 +323,7 @@ class PostgresQLOperators(BaseType):
         self.data = data
 
     @staticmethod
-    def _is_missing_column_reference(operator_instance, value):
+    def _is_missing_column_reference(operator_instance, value, variable_regex_pattern=False):
         if not isinstance(value, str) or value == "":
             return False
 
@@ -335,6 +337,10 @@ class PostgresQLOperators(BaseType):
         if not isinstance(resolved_value, str) or resolved_value == "":
             return False
 
+        if variable_regex_pattern:
+            variables = getattr(operator_instance.dataset_metadata, "variables", [])
+            return not any(re.fullmatch(resolved_value, variable.name) for variable in variables)
+
         return not operator_instance._exists(resolved_value)
 
     @classmethod
@@ -346,10 +352,15 @@ class PostgresQLOperators(BaseType):
             return []
 
         missing_columns = []
+        variable_regex_pattern = other_value.get("variable_regex_pattern", False)
 
         always_column_keys = ["target"]
         for key in always_column_keys:
-            if cls._is_missing_column_reference(operator_instance, other_value.get(key)):
+            if cls._is_missing_column_reference(
+                operator_instance,
+                other_value.get(key),
+                variable_regex_pattern=variable_regex_pattern,
+            ):
                 missing_columns.append(other_value.get(key))
 
         comparator = other_value.get("comparator")

--- a/cdisc_rules_engine/enums/optional_condition_parameters.py
+++ b/cdisc_rules_engine/enums/optional_condition_parameters.py
@@ -19,3 +19,4 @@ class OptionalConditionParameters(BaseEnum):
     STRICT_INCREMENTAL_ORDERING = "strict_incremental_ordering"
     EXTERNAL_DICTIONARY_TYPE = "external_dictionary_type"
     VERSION = "version"
+    VARIABLE_REGEX_PATTERN = "variable_regex_pattern"

--- a/cdisc_rules_engine/sql_rules_engine.py
+++ b/cdisc_rules_engine/sql_rules_engine.py
@@ -205,6 +205,18 @@ class SQLRulesEngine:
         """
         Executes the given rule on a given dataset (or a view of it).
         """
+        expanded_rules = SQLRuleProcessor.expand_rule_for_variable_regex(rule, dataset_metadata.variables)
+        results = []
+        for expanded_rule in expanded_rules:
+            results.extend(self._execute_expanded_rule(expanded_rule, dataset_metadata, dataset_id))
+        return results
+
+    def _execute_expanded_rule(
+        self,
+        rule: dict,
+        dataset_metadata: BaseDatasetMetadata,
+        dataset_id: str,
+    ) -> List[str]:
         # Add conditions to rule for all variables if variables: all appears in condition
         rule_copy = deepcopy(rule)
         updated_conditions = SQLRuleProcessor.duplicate_conditions_for_all_targets(

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -1,3 +1,6 @@
+import re
+from copy import deepcopy
+from itertools import product
 from typing import List
 
 from cdisc_rules_engine.data_service.postgresql_data_service import (
@@ -171,6 +174,47 @@ class SQLRuleProcessor:
                     new_conditions_list.append(condition)
             new_conditions_dict[key] = new_conditions_list
         return new_conditions_dict
+
+    @staticmethod
+    def expand_rule_for_variable_regex(rule: dict, targets: List[VariableMetadata]) -> List[dict]:
+        conditions: ConditionInterface = rule["conditions"]
+        patterns = list(
+            dict.fromkeys(
+                condition["value"].get("target")
+                for condition in conditions.values()
+                if condition.get("value", {}).get("variable_regex_pattern", False)
+            )
+        )
+        if not patterns:
+            return [rule]
+
+        matches_by_pattern = [
+            [target.name for target in targets if re.fullmatch(pattern, target.name)] for pattern in patterns
+        ]
+        if any(not matches for matches in matches_by_pattern):
+            return [rule]
+
+        expanded_rules = []
+        for matched_targets in product(*matches_by_pattern):
+            bindings = dict(zip(patterns, matched_targets))
+            expanded_rule = deepcopy(rule)
+            for condition in expanded_rule["conditions"].values():
+                value = condition.get("value", {})
+                if value.get("variable_regex_pattern", False):
+                    value["target"] = bindings[value["target"]]
+                    value.pop("variable_regex_pattern")
+
+            output_variables = []
+            for output_variable in expanded_rule.get("output_variables") or []:
+                matched_output_variables = [
+                    target for target in matched_targets if re.fullmatch(output_variable, target)
+                ]
+                output_variables.extend(matched_output_variables or [output_variable])
+            if output_variables:
+                expanded_rule["output_variables"] = list(dict.fromkeys(output_variables))
+            expanded_rules.append(expanded_rule)
+
+        return expanded_rules
 
     # @staticmethod
     # def extract_referenced_variables_from_rule(rule: dict):

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -19,6 +19,8 @@ from cdisc_rules_engine.standards.base_standards_context import BaseStandardsCon
 
 
 class SQLRuleProcessor:
+    REGEX_CAPTURE_REFERENCE = re.compile(r"\{\{(?P<name>[A-Za-z_]\w*)\}\}")
+
     # @staticmethod
     # def _ct_package_type_api_name(ct_package_type: str | None) -> str:
     #     if ct_package_type is None:
@@ -175,8 +177,46 @@ class SQLRuleProcessor:
             new_conditions_dict[key] = new_conditions_list
         return new_conditions_dict
 
+    @classmethod
+    def _replace_regex_capture_references(cls, value, captures: dict[str, str]):
+        if isinstance(value, str):
+
+            def replace_capture(match):
+                capture_name = match.group("name")
+                capture_value = captures.get(capture_name)
+                if capture_value is None:
+                    raise ValueError(f"Unresolved regex capture '{capture_name}'")
+                return capture_value
+
+            return cls.REGEX_CAPTURE_REFERENCE.sub(replace_capture, value)
+        if isinstance(value, dict):
+            return {key: cls._replace_regex_capture_references(item, captures) for key, item in value.items()}
+        if isinstance(value, list):
+            return [cls._replace_regex_capture_references(item, captures) for item in value]
+        if isinstance(value, tuple):
+            return tuple(cls._replace_regex_capture_references(item, captures) for item in value)
+        return value
+
     @staticmethod
-    def expand_rule_for_variable_regex(rule: dict, targets: List[VariableMetadata]) -> List[dict]:
+    def _compile_variable_regex_patterns(patterns: List[str]) -> dict[str, re.Pattern]:
+        compiled_patterns = {pattern: re.compile(pattern) for pattern in patterns}
+        capture_patterns = {}
+        for pattern, compiled_pattern in compiled_patterns.items():
+            for capture_name in compiled_pattern.groupindex:
+                if capture_name in capture_patterns:
+                    raise ValueError(f"Regex capture name '{capture_name}' is defined by multiple patterns")
+                capture_patterns[capture_name] = pattern
+        return compiled_patterns
+
+    @staticmethod
+    def _find_variable_regex_matches(compiled_patterns, targets: List[VariableMetadata]):
+        return [
+            [(target.name, match) for target in targets if (match := pattern.fullmatch(target.name))]
+            for pattern in compiled_patterns.values()
+        ]
+
+    @classmethod
+    def expand_rule_for_variable_regex(cls, rule: dict, targets: List[VariableMetadata]) -> List[dict]:
         conditions: ConditionInterface = rule["conditions"]
         patterns = list(
             dict.fromkeys(
@@ -188,26 +228,35 @@ class SQLRuleProcessor:
         if not patterns:
             return [rule]
 
-        matches_by_pattern = [
-            [target.name for target in targets if re.fullmatch(pattern, target.name)] for pattern in patterns
-        ]
+        compiled_patterns = cls._compile_variable_regex_patterns(patterns)
+        matches_by_pattern = cls._find_variable_regex_matches(compiled_patterns, targets)
         if any(not matches for matches in matches_by_pattern):
             return [rule]
 
         expanded_rules = []
-        for matched_targets in product(*matches_by_pattern):
-            bindings = dict(zip(patterns, matched_targets))
+        for matched_values in product(*matches_by_pattern):
+            bindings = dict(zip(patterns, (target_name for target_name, _ in matched_values)))
+            captures = {
+                capture_name: capture_value
+                for _, match in matched_values
+                for capture_name, capture_value in match.groupdict().items()
+            }
             expanded_rule = deepcopy(rule)
             for condition in expanded_rule["conditions"].values():
                 value = condition.get("value", {})
                 if value.get("variable_regex_pattern", False):
                     value["target"] = bindings[value["target"]]
                     value.pop("variable_regex_pattern")
+                condition.update(cls._replace_regex_capture_references(condition, captures))
+
+            for key, value in expanded_rule.items():
+                if key != "conditions":
+                    expanded_rule[key] = cls._replace_regex_capture_references(value, captures)
 
             output_variables = []
             for output_variable in expanded_rule.get("output_variables") or []:
                 matched_output_variables = [
-                    target for target in matched_targets if re.fullmatch(output_variable, target)
+                    target_name for target_name, _ in matched_values if re.fullmatch(output_variable, target_name)
                 ]
                 output_variables.extend(matched_output_variables or [output_variable])
             if output_variables:

--- a/resources/custom_adam_rules/regex_test_rule.yml
+++ b/resources/custom_adam_rules/regex_test_rule.yml
@@ -1,0 +1,46 @@
+# Variable: AVISIT
+# Rule: Subject does not have all visit entries
+# verified
+Authorities:
+  - Organization: CDISC
+    Standards:
+      - Name: ADaMIG
+        References:
+          - Citations:
+              - Cited Guidance: Custom Rule
+                Document: Custom Rule
+                Item: Custom Rule
+                Section: Custom Rule
+            Origin: ADaM Conformance Rules
+            Rule Identifier:
+              Id: "111"
+              Version: "2"
+            Version: "5.0"
+        Version: "1.3"
+Check:
+  all:
+    - name: ^AGE.*$
+      variable_regex_pattern: true
+      operator: matches_regex
+      value: ".*55.*"
+Core:
+  Id: Testing Custom Rule | Regex Test
+  Status: Draft
+  Version: "1"
+Description: Test var exists
+Executability: Fully Executable
+Outcome:
+  Message: Test var exists
+  Output Variables:
+    - ^AGE.*$
+Rule Type: Record Data
+Scope:
+  Data Structures:
+    Include:
+      - BDS
+  Domains:
+    Include:
+      - ADEG
+      - ADVS
+      - ADEF
+Sensitivity: Group

--- a/tests/resources/sql_test_rules/regex_test_rule.yml
+++ b/tests/resources/sql_test_rules/regex_test_rule.yml
@@ -19,7 +19,7 @@ Authorities:
         Version: "1.3"
 Check:
   all:
-    - name: ^AGE.*$
+    - name: "^(?P<age>AGE.*)$"
       variable_regex_pattern: true
       operator: matches_regex
       value: ".*55.*"
@@ -32,7 +32,7 @@ Executability: Fully Executable
 Outcome:
   Message: Test var exists
   Output Variables:
-    - ^AGE.*$
+    - "{{age}}"
 Rule Type: Record Data
 Scope:
   Data Structures:
@@ -43,4 +43,4 @@ Scope:
       - ADEG
       - ADVS
       - ADEF
-Sensitivity: Group
+Sensitivity: Record

--- a/tests/resources/sql_test_rules/regex_test_rule_2.yml
+++ b/tests/resources/sql_test_rules/regex_test_rule_2.yml
@@ -1,0 +1,49 @@
+# Variable: AVISIT
+# Rule: Subject does not have all visit entries
+# verified
+Authorities:
+  - Organization: CDISC
+    Standards:
+      - Name: ADaMIG
+        References:
+          - Citations:
+              - Cited Guidance: Custom Rule
+                Document: Custom Rule
+                Item: Custom Rule
+                Section: Custom Rule
+            Origin: ADaM Conformance Rules
+            Rule Identifier:
+              Id: "111"
+              Version: "2"
+            Version: "5.0"
+        Version: "1.3"
+Check:
+  all:
+    - name: "^(?P<root>.*)FL$"
+      variable_regex_pattern: true
+      operator: not_equal_to
+      value: "{{root}}"
+    - name: "{{root}}"
+      operator: exists
+Core:
+  Id: Testing Custom Rule | Regex Test 2
+  Status: Draft
+  Version: "1"
+Description: Test var exists
+Executability: Fully Executable
+Outcome:
+  Message: Test var exists
+  Output Variables:
+    - "{{root}}"
+    - "{{root}}FL"
+Rule Type: Record Data
+Scope:
+  Data Structures:
+    Include:
+      - BDS
+  Domains:
+    Include:
+      - ADEG
+      - ADVS
+      - ADEF
+Sensitivity: Record

--- a/tests/resources/sql_test_rules/regex_test_rule_3.yml
+++ b/tests/resources/sql_test_rules/regex_test_rule_3.yml
@@ -1,0 +1,53 @@
+# Variable: AVISIT
+# Rule: Subject does not have all visit entries
+# verified
+Authorities:
+  - Organization: CDISC
+    Standards:
+      - Name: ADaMIG
+        References:
+          - Citations:
+              - Cited Guidance: Custom Rule
+                Document: Custom Rule
+                Item: Custom Rule
+                Section: Custom Rule
+            Origin: ADaM Conformance Rules
+            Rule Identifier:
+              Id: "111"
+              Version: "2"
+            Version: "5.0"
+        Version: "1.3"
+Check:
+  all:
+    - name: '^(?P<root>.*)(?P<number>\d+)FL$'
+      variable_regex_pattern: true
+      operator: not_equal_to
+      value: "{{root}}"
+    - name: "{{root}}{{number}}"
+      operator: exists
+    - name: "AGEGR{{number}}"
+      operator: equal_to
+      value: "<55 YEARS"
+Core:
+  Id: Testing Custom Rule | Regex Test 3
+  Status: Draft
+  Version: "1"
+Description: Test var exists
+Executability: Fully Executable
+Outcome:
+  Message: Test var exists
+  Output Variables:
+    - "{{root}}{{number}}"
+    - "{{root}}{{number}}FL"
+    - "AGEGR{{number}}"
+Rule Type: Record Data
+Scope:
+  Data Structures:
+    Include:
+      - BDS
+  Domains:
+    Include:
+      - ADEG
+      - ADVS
+      - ADEF
+Sensitivity: Record

--- a/tests/resources/sql_test_rules/velonyx_custom_rule_cnsr_01.yml
+++ b/tests/resources/sql_test_rules/velonyx_custom_rule_cnsr_01.yml
@@ -1,0 +1,53 @@
+# Variable: ADTTE.CNSR
+# Condition: DTHFL = "Y"
+# Rule: CNSR = 1
+# verified
+Authorities:
+  - Organization: CDISC
+    Standards:
+      - Name: ADaMIG
+        References:
+          - Citations:
+              - Cited Guidance: Custom Rule
+                Document: Custom Rule
+                Item: Custom Rule
+                Section: Custom Rule
+            Origin: ADaM Conformance Rules
+            Rule Identifier:
+              Id: "111"
+              Version: "2"
+            Version: "5.0"
+        Version: "1.3"
+Check:
+  all:
+    - name: DTHFL
+      operator: equal_to
+      value: Y
+    - name: CNSR
+      operator: not_equal_to
+      value: 1
+Core:
+  Id: Velonyx Custom Rule | CNSR 01
+  Status: Draft
+  Version: "1"
+Description: Trigger error when CNSR is not 1 when DTHFL is Y
+Executability: Fully Executable
+Match Datasets:
+  - Keys:
+      - USUBJID
+    Name: ADSL
+Outcome:
+  # Error message phrased differently to usual so we can show the rule clearly in the platform
+  Message: ADTTE.CNSR should be 1 when ADSL.DTHFL is Y
+  Output Variables:
+    - ADSL.DTHFL
+    - CNSR
+Rule Type: Record Data
+Scope:
+  Data Structures:
+    Include:
+      - BDS
+  Domains:
+    Include:
+      - ADTTE
+Sensitivity: Record

--- a/tests/resources/sql_test_rules/visits_check_custom_rule.yml
+++ b/tests/resources/sql_test_rules/visits_check_custom_rule.yml
@@ -1,0 +1,65 @@
+# Variable: AVISIT
+# Rule: Subject does not have all visit entries
+# verified
+Authorities:
+  - Organization: CDISC
+    Standards:
+      - Name: ADaMIG
+        References:
+          - Citations:
+              - Cited Guidance: Custom Rule
+                Document: Custom Rule
+                Item: Custom Rule
+                Section: Custom Rule
+            Origin: ADaM Conformance Rules
+            Rule Identifier:
+              Id: "111"
+              Version: "2"
+            Version: "5.0"
+        Version: "1.3"
+Check:
+  all:
+    - name: $visits_per_subject
+      operator: not_contains_all
+      value: $all_visits
+Core:
+  Id: Visits Check Custom Rule | Visit Completeness
+  Status: Draft
+  Version: "1"
+Description: Raise error when subject does not have all visit entries
+Executability: Fully Executable
+Operations:
+  - operator: distinct
+    name: AVISIT
+    id: $all_visits
+    group:
+      - PARAM
+  - operator: distinct
+    name: AVISIT
+    id: $visits_per_subject
+    group:
+      - USUBJID
+      - PARAM
+  - operator: minus
+    id: $missing_visits
+    name: $all_visits
+    subtract: $visits_per_subject
+Outcome:
+  Message: Subject does not have all visit entries
+  Output Variables:
+    - PARAM
+    - $missing_visits
+Rule Type: Record Data
+Scope:
+  Data Structures:
+    Include:
+      - BDS
+  Domains:
+    Include:
+      - ADEG
+      - ADVS
+      - ADEF
+Sensitivity: Group
+Grouping_Variables:
+  - USUBJID
+  - PARAM

--- a/tests/unit/cdisc/test_rule.py
+++ b/tests/unit/cdisc/test_rule.py
@@ -21,6 +21,10 @@ from cdisc_rules_engine.models.rule import Rule
             ["metadata"],
         ),
         (
+            {"operator": "test", "name": "^ID.*", "variable_regex_pattern": True},
+            ["variable_regex_pattern"],
+        ),
+        (
             {
                 "operator": "test",
                 "name": "IDVAR",

--- a/tests/unit/sql/test_check_operators/test_sql_postgresql_operators.py
+++ b/tests/unit/sql/test_check_operators/test_sql_postgresql_operators.py
@@ -1,0 +1,22 @@
+from cdisc_rules_engine.check_operators.sql import PostgresQLOperators
+
+from .helpers import create_sql_operators
+
+
+def test_regex_target_is_missing_only_when_no_columns_match():
+    sql_operators = create_sql_operators({"AESTDY": [1], "AEENDY": [2], "AETERM": ["Headache"]})
+    operator_instance = sql_operators._operator_map["empty"](sql_operators.data)
+
+    matching = PostgresQLOperators._missing_columns_for_operator(
+        "empty",
+        operator_instance,
+        {"target": "^AE.*DY$", "variable_regex_pattern": True},
+    )
+    missing = PostgresQLOperators._missing_columns_for_operator(
+        "empty",
+        operator_instance,
+        {"target": "^ZZ.*$", "variable_regex_pattern": True},
+    )
+
+    assert matching == []
+    assert missing == ["^ZZ.*$"]

--- a/tests/unit/sql/test_sql_rules_engine.py
+++ b/tests/unit/sql/test_sql_rules_engine.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from cdisc_rules_engine.models.rule_conditions.condition_composite_factory import ConditionCompositeFactory
+from cdisc_rules_engine.sql_rules_engine import SQLRulesEngine
+
+
+def test_execute_rule_runs_once_per_regex_variable():
+    rule = {
+        "conditions": ConditionCompositeFactory.get_condition_composite(
+            {
+                "all": [
+                    {
+                        "operator": "empty",
+                        "value": {"target": "^AE.*DY$", "variable_regex_pattern": True},
+                    }
+                ]
+            }
+        ),
+        "output_variables": ["^AE.*DY$"],
+    }
+    metadata = SimpleNamespace(variables=[SimpleNamespace(name=name) for name in ["AESTDY", "AEENDY", "AETERM"]])
+    engine = SQLRulesEngine.__new__(SQLRulesEngine)
+
+    with patch.object(engine, "_execute_expanded_rule", return_value=[]) as execute:
+        engine.execute_rule(rule, metadata, "ae")
+
+    expanded_rules = [call.args[0] for call in execute.call_args_list]
+    assert [expanded_rule["output_variables"] for expanded_rule in expanded_rules] == [
+        ["AESTDY"],
+        ["AEENDY"],
+    ]

--- a/tests/unit/sql/test_utilities/test_sql_rule_processor.py
+++ b/tests/unit/sql/test_utilities/test_sql_rule_processor.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+from cdisc_rules_engine.models.rule_conditions.condition_composite_factory import ConditionCompositeFactory
+from cdisc_rules_engine.utilities.sql_rule_processor import SQLRuleProcessor
+
+
+def test_expand_rule_for_variable_regex_binds_condition_and_output_variable():
+    conditions = ConditionCompositeFactory.get_condition_composite(
+        {
+            "all": [
+                {
+                    "name": "get_dataset",
+                    "operator": "empty",
+                    "value": {"target": "^AE.*DY$", "variable_regex_pattern": True},
+                }
+            ]
+        }
+    )
+    rule = {
+        "conditions": conditions,
+        "output_variables": ["USUBJID", "^AE.*DY$"],
+    }
+    targets = [SimpleNamespace(name=name) for name in ["USUBJID", "AESTDY", "AEENDY", "AETERM"]]
+
+    expanded_rules = SQLRuleProcessor.expand_rule_for_variable_regex(rule, targets)
+
+    assert [expanded_rule["conditions"].values()[0]["value"]["target"] for expanded_rule in expanded_rules] == [
+        "AESTDY",
+        "AEENDY",
+    ]
+    assert [expanded_rule["output_variables"] for expanded_rule in expanded_rules] == [
+        ["USUBJID", "AESTDY"],
+        ["USUBJID", "AEENDY"],
+    ]
+    assert all(
+        "variable_regex_pattern" not in expanded_rule["conditions"].values()[0]["value"]
+        for expanded_rule in expanded_rules
+    )
+
+
+def test_expand_rule_for_variable_regex_retains_rule_when_no_targets_match():
+    conditions = ConditionCompositeFactory.get_condition_composite(
+        {
+            "all": [
+                {
+                    "name": "get_dataset",
+                    "operator": "empty",
+                    "value": {"target": "^ZZ.*$", "variable_regex_pattern": True},
+                }
+            ]
+        }
+    )
+    rule = {"conditions": conditions}
+
+    expanded_rules = SQLRuleProcessor.expand_rule_for_variable_regex(rule, [SimpleNamespace(name="AESTDY")])
+
+    assert expanded_rules == [rule]

--- a/tests/unit/sql/test_utilities/test_sql_rule_processor.py
+++ b/tests/unit/sql/test_utilities/test_sql_rule_processor.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from cdisc_rules_engine.models.rule_conditions.condition_composite_factory import ConditionCompositeFactory
 from cdisc_rules_engine.utilities.sql_rule_processor import SQLRuleProcessor
 
@@ -55,3 +57,105 @@ def test_expand_rule_for_variable_regex_retains_rule_when_no_targets_match():
     expanded_rules = SQLRuleProcessor.expand_rule_for_variable_regex(rule, [SimpleNamespace(name="AESTDY")])
 
     assert expanded_rules == [rule]
+
+
+def test_expand_rule_for_variable_regex_reuses_named_captures_throughout_rule():
+    conditions = ConditionCompositeFactory.get_condition_composite(
+        {
+            "all": [
+                {
+                    "name": "get_dataset",
+                    "operator": "equal_to",
+                    "value": {
+                        "target": r"^(?P<test>TEST(?P<number>[0-9]+))$",
+                        "comparator": "{{test}}N",
+                        "value_is_reference": True,
+                        "variable_regex_pattern": True,
+                    },
+                },
+                {
+                    "any": [
+                        {
+                            "name": "get_dataset",
+                            "operator": "not_empty",
+                            "value": {"target": "{{test}}N"},
+                        }
+                    ]
+                },
+            ]
+        }
+    )
+    rule = {
+        "conditions": conditions,
+        "operations": [{"id": "$result", "operator": "distinct", "name": "{{test}}N"}],
+        "output_variables": ["USUBJID", "{{test}}", "{{test}}N"],
+    }
+    targets = [SimpleNamespace(name=name) for name in ["USUBJID", "TEST1", "TEST1N", "TEST20", "TEST20N"]]
+
+    expanded_rules = SQLRuleProcessor.expand_rule_for_variable_regex(rule, targets)
+
+    condition_values = [expanded_rule["conditions"].values()[0]["value"] for expanded_rule in expanded_rules]
+    assert [(value["target"], value["comparator"]) for value in condition_values] == [
+        ("TEST1", "TEST1N"),
+        ("TEST20", "TEST20N"),
+    ]
+    assert [expanded_rule["conditions"].values()[1]["value"]["target"] for expanded_rule in expanded_rules] == [
+        "TEST1N",
+        "TEST20N",
+    ]
+    assert [expanded_rule["operations"][0]["name"] for expanded_rule in expanded_rules] == ["TEST1N", "TEST20N"]
+    assert [expanded_rule["output_variables"] for expanded_rule in expanded_rules] == [
+        ["USUBJID", "TEST1", "TEST1N"],
+        ["USUBJID", "TEST20", "TEST20N"],
+    ]
+
+
+def test_expand_rule_for_variable_regex_rejects_unresolved_capture_reference():
+    conditions = ConditionCompositeFactory.get_condition_composite(
+        {
+            "all": [
+                {
+                    "name": "get_dataset",
+                    "operator": "empty",
+                    "value": {
+                        "target": r"^TEST(?P<number>[0-9]+)$",
+                        "variable_regex_pattern": True,
+                    },
+                }
+            ]
+        }
+    )
+    rule = {"conditions": conditions, "output_variables": ["TEST{{missing}}"]}
+
+    with pytest.raises(ValueError, match="Unresolved regex capture 'missing'"):
+        SQLRuleProcessor.expand_rule_for_variable_regex(rule, [SimpleNamespace(name="TEST1")])
+
+
+def test_expand_rule_for_variable_regex_rejects_duplicate_capture_names():
+    conditions = ConditionCompositeFactory.get_condition_composite(
+        {
+            "all": [
+                {
+                    "name": "get_dataset",
+                    "operator": "empty",
+                    "value": {
+                        "target": r"^TEST(?P<number>[0-9]+)$",
+                        "variable_regex_pattern": True,
+                    },
+                },
+                {
+                    "name": "get_dataset",
+                    "operator": "empty",
+                    "value": {
+                        "target": r"^VALUE(?P<number>[0-9]+)$",
+                        "variable_regex_pattern": True,
+                    },
+                },
+            ]
+        }
+    )
+    rule = {"conditions": conditions}
+    targets = [SimpleNamespace(name=name) for name in ["TEST1", "VALUE1"]]
+
+    with pytest.raises(ValueError, match="Regex capture name 'number' is defined by multiple patterns"):
+        SQLRuleProcessor.expand_rule_for_variable_regex(rule, targets)


### PR DESCRIPTION
This PR implements regex matching in variables - it will generate every combo of rules for regex (ie if two regex matches match two variables each, it will run the rule four times). Also added support for regex group naming and reuse within the rule.

It also supports regex variable reporting - the output looks appropriate