### PR TITLE
feat: add where_populated param to inconsistent_across_dataset

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/is_inconsistent_across_dataset_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/is_inconsistent_across_dataset_operator.py
@@ -13,6 +13,7 @@ class IsInconsistentAcrossDatasetOperator(BaseSqlOperator):
         """
         target = other_value.get("target")
         comparator = other_value.get("comparator")
+        where_populated = other_value.get("where_populated", False)
 
         if not target or not isinstance(target, str) or target in self.operation_variables:
             raise ValueError("Target is required and must be a valid column name.")
@@ -40,14 +41,25 @@ class IsInconsistentAcrossDatasetOperator(BaseSqlOperator):
         if len(valid_comparators) == 0:
             return self._do_check_operator(lambda: "FALSE")
         elif len(valid_comparators) == 1:
-            return self._handle_single_comparator(target_column, valid_comparators[0])
+            return self._handle_single_comparator(target_column, valid_comparators[0], where_populated)
         else:
-            return self._handle_multiple_comparators(target_column, valid_comparators)
+            return self._handle_multiple_comparators(target_column, valid_comparators, where_populated)
 
-    def _handle_single_comparator(self, target_column, comparator_column):
+    def _handle_single_comparator(self, target_column, comparator_column, where_populated=False):
         cache_key = f"{target_column}_inconsistent_across_{comparator_column}"
 
         def generate_update_query(db_table: str, db_column: str) -> str:
+            populated_filter = ""
+            current_row_filter = ""
+            if where_populated:
+                populated_filter = (
+                    f" AND t2.{self._column_sql(target_column, alias=False)} IS NOT NULL"
+                    f" AND t2.{self._column_sql(comparator_column, alias=False)} IS NOT NULL"
+                )
+                current_row_filter = (
+                    f" AND t1.{self._column_sql(target_column, alias=False)} IS NOT NULL"
+                    f" AND t1.{self._column_sql(comparator_column, alias=False)} IS NOT NULL"
+                )
             return f"""
                 UPDATE {db_table} AS t
                 SET {db_column} = sub.is_inconsistent
@@ -69,8 +81,8 @@ class IsInconsistentAcrossDatasetOperator(BaseSqlOperator):
                                 (t2.{self._column_sql(comparator_column, alias=False)} IS NULL
                                 AND
                                 t1.{self._column_sql(comparator_column, alias=False)} IS NULL)
-                            )
-                        ) > 1 AS is_inconsistent
+                            ){populated_filter}
+                        ) > 1{current_row_filter} AS is_inconsistent
                     FROM {db_table} AS t1
                     ORDER BY id
                 ) AS sub
@@ -79,7 +91,7 @@ class IsInconsistentAcrossDatasetOperator(BaseSqlOperator):
 
         return self._do_complex_check_operator(cache_key, generate_update_query)
 
-    def _handle_multiple_comparators(self, target_column, comparator_columns):
+    def _handle_multiple_comparators(self, target_column, comparator_columns, where_populated=False):
         cache_key = f"{target_column}_inconsistent_across_{'_'.join(comparator_columns)}"
 
         def generate_update_query(db_table: str, db_column: str) -> str:
@@ -92,6 +104,15 @@ class IsInconsistentAcrossDatasetOperator(BaseSqlOperator):
                 )
                 where_conditions.append(f"({condition})")
             where_clause = " AND ".join(where_conditions)
+            current_row_filter = ""
+            if where_populated:
+                populated_columns = [target_column, *comparator_columns]
+                where_clause += " AND " + " AND ".join(
+                    f"t2.{self._column_sql(column, alias=False)} IS NOT NULL" for column in populated_columns
+                )
+                current_row_filter = " AND " + " AND ".join(
+                    f"t1.{self._column_sql(column, alias=False)} IS NOT NULL" for column in populated_columns
+                )
 
             return f"""
                 UPDATE {db_table} AS t
@@ -108,7 +129,7 @@ class IsInconsistentAcrossDatasetOperator(BaseSqlOperator):
                             )
                             FROM {db_table} AS t2
                             WHERE {where_clause}
-                        ) > 1 AS is_inconsistent
+                        ) > 1 {current_row_filter} AS is_inconsistent
                     FROM {db_table} AS t1
                     ORDER BY id
                 ) AS sub

--- a/cdisc_rules_engine/enums/optional_condition_parameters.py
+++ b/cdisc_rules_engine/enums/optional_condition_parameters.py
@@ -20,3 +20,4 @@ class OptionalConditionParameters(BaseEnum):
     EXTERNAL_DICTIONARY_TYPE = "external_dictionary_type"
     VERSION = "version"
     VARIABLE_REGEX_PATTERN = "variable_regex_pattern"
+    WHERE_POPULATED = "where_populated"

--- a/tests/unit/cdisc/test_check_operators/test_value_set_checks.py
+++ b/tests/unit/cdisc/test_check_operators/test_value_set_checks.py
@@ -156,18 +156,6 @@ def test_is_inconsistent_across_dataset_with_nulls(target, comparator, dataset_t
     assert result.equals(df.convert_to_series(expected_result))
 
 
-def test_is_inconsistent_across_dataset_where_populated():
-    data = {
-        "KEY": ["A", "A", "A", "B", "B"],
-        "VALUE": ["X", "Y", None, "Z", None],
-    }
-    df = PandasDataset.from_dict(data)
-    result = DataframeType({"value": df, "column_prefix_map": {"--": ""}}).is_inconsistent_across_dataset(
-        {"target": "VALUE", "comparator": "KEY", "where_populated": True}
-    )
-    assert result.equals(df.convert_to_series([True, True, False, False, False]))
-
-
 def test_is_inconsistent_across_dataset_empty_dataset():
     data = {"USUBJID": [], "BGSTRESU": []}
     df = PandasDataset.from_dict(data)

--- a/tests/unit/cdisc/test_check_operators/test_value_set_checks.py
+++ b/tests/unit/cdisc/test_check_operators/test_value_set_checks.py
@@ -156,6 +156,18 @@ def test_is_inconsistent_across_dataset_with_nulls(target, comparator, dataset_t
     assert result.equals(df.convert_to_series(expected_result))
 
 
+def test_is_inconsistent_across_dataset_where_populated():
+    data = {
+        "KEY": ["A", "A", "A", "B", "B"],
+        "VALUE": ["X", "Y", None, "Z", None],
+    }
+    df = PandasDataset.from_dict(data)
+    result = DataframeType({"value": df, "column_prefix_map": {"--": ""}}).is_inconsistent_across_dataset(
+        {"target": "VALUE", "comparator": "KEY", "where_populated": True}
+    )
+    assert result.equals(df.convert_to_series([True, True, False, False, False]))
+
+
 def test_is_inconsistent_across_dataset_empty_dataset():
     data = {"USUBJID": [], "BGSTRESU": []}
     df = PandasDataset.from_dict(data)

--- a/tests/unit/sql/test_check_operators/test_sql_value_set_checks.py
+++ b/tests/unit/sql/test_check_operators/test_sql_value_set_checks.py
@@ -48,3 +48,13 @@ def test_sql_is_inconsistent_across_dataset_with_nulls(target, comparator, expec
     sql_ops = create_sql_operators(data)
     result = sql_ops.is_inconsistent_across_dataset({"target": target, "comparator": comparator})
     assert_series_equals(result, expected_result)
+
+
+def test_sql_is_inconsistent_across_dataset_where_populated():
+    data = {
+        "KEY": ["A", "A", "A", "B", "B"],
+        "VALUE": ["X", "Y", None, "Z", None],
+    }
+    sql_ops = create_sql_operators(data)
+    result = sql_ops.is_inconsistent_across_dataset({"target": "VALUE", "comparator": "KEY", "where_populated": True})
+    assert_series_equals(result, [True, True, False, False, False])


### PR DESCRIPTION
Many ADaM rules (and I think a few SDTM rules) only care about inconsistent values when both values are populated. Simply adding 'empty' checks isn't good enough, as the inconsistent op itself needs to exclude the rows where one or both of the values is missing. This change adds that functionality, specified by a 'where_populated: true' param