### PR TITLE
fix: report multiple errors per row

### DIFF
--- a/tests/rule_regression/regression.py
+++ b/tests/rule_regression/regression.py
@@ -623,7 +623,13 @@ def extract_results_regression(results):
     res_regression = []
 
     if isinstance(results, dict):
-        result_list = [res[0] for res in results.values()]
+        result_list = []
+        for dataset_results in results.values():
+            if not dataset_results:
+                continue
+            merged_result = dataset_results[0].copy()
+            merged_result["errors"] = [error for result in dataset_results for error in result.get("errors", [])]
+            result_list.append(merged_result)
     elif isinstance(results, list):
         result_list = results
     else:

--- a/tests/unit/test_rule_regression.py
+++ b/tests/unit/test_rule_regression.py
@@ -1,0 +1,30 @@
+from rule_regression.regression import extract_results_regression
+
+
+def test_extract_results_regression_merges_regex_expansions_for_dataset():
+    results = {
+        "adsl": [
+            {
+                "dataset": "adsl.csv",
+                "domain": "adsl",
+                "executionStatus": "success",
+                "message": "Inconsistent treatment mapping",
+                "errors": [{"row": 1, "value": {"TRT01AN": 1, "TRT01A": "X"}}],
+            },
+            {
+                "dataset": "adsl.csv",
+                "domain": "adsl",
+                "executionStatus": "success",
+                "message": "Inconsistent treatment mapping",
+                "errors": [{"row": 1, "value": {"TRT02AN": 1, "TRT02A": "X"}}],
+            },
+        ]
+    }
+
+    regression = extract_results_regression(results)
+
+    assert regression[0]["number_errors"] == 2
+    assert regression[0]["errors"] == [
+        {"row": 1, "SEQ": None, "USUBJID": None, "value": {"TRT01AN": 1, "TRT01A": "X"}},
+        {"row": 1, "SEQ": None, "USUBJID": None, "value": {"TRT02AN": 1, "TRT02A": "X"}},
+    ]


### PR DESCRIPTION
Previously, regression was throwing away all but the first error per row. Instead it should report every error per row. This change allows that.

This doesn't affect SDTM, since the nature of the rules means there's only ever one error per row, but it's relevant for ADaM wildcard rules