### PR TITLE
op: Calc operation

### DIFF
--- a/cdisc_rules_engine/models/sql_operation_params.py
+++ b/cdisc_rules_engine/models/sql_operation_params.py
@@ -37,6 +37,7 @@ class SqlOperationParams:
     table: str = None
     use_rule_type_table: str = None
     delimiter: str = None
+    value: str = None
 
     # standard_substandard: str = None
     # attribute_name: str = None

--- a/cdisc_rules_engine/sql_operations/calc.py
+++ b/cdisc_rules_engine/sql_operations/calc.py
@@ -1,0 +1,184 @@
+import re
+
+from cdisc_rules_engine.exceptions.custom_exceptions import ColumnNotFoundError, RuleExecutionError
+from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
+from cdisc_rules_engine.sql_operations.sql_base_operation import SqlBaseOperation
+
+
+class SqlCalcOperation(SqlBaseOperation):
+    _NUMERIC_CAST_REGEX = r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$"
+
+    _TOKEN_RE = re.compile(
+        r"""
+          (?P<WS>\s+)
+        | (?P<NUMBER>\d+\.\d+|\.\d+|\d+)
+        | (?P<OPREF>\$[A-Za-z_][A-Za-z0-9_]*)
+        | (?P<IDENT>[A-Za-z_][A-Za-z0-9_]*)
+        | (?P<OP>[+\-*/()])
+        """,
+        re.VERBOSE,
+    )
+
+    def _execute_operation(self):
+        formula = self.params.value
+        if formula is None or not str(formula).strip():
+            raise RuleExecutionError("calc operation requires a non-empty 'value' formula")
+
+        self._params: dict[str, str] = {}
+        self._column_placeholders: dict[str, str] = {}
+        self._opref_fragments: dict[str, str] = {}
+        self._placeholder_counter = 0
+
+        tokens = self._tokenie(str(formula))
+        self._tokens = tokens
+        self._pos = 0
+
+        expression_sql = self._parse_expression()
+        if self._pos != len(self._tokens):
+            unexpected = self._tokens[self._pos][1]
+            raise RuleExecutionError(f"Unexpected token '{unexpected}' in calc formula '{formula}'")
+
+        query = f"SELECT {expression_sql} AS value"
+        return SqlOperationResult(
+            query=query,
+            type="constant",
+            subtype="Num",
+            params=self._params or None,
+        )
+
+    def _tokenie(self, formula: str):
+        tokens = []
+        pos = 0
+        length = len(formula)
+        while pos < length:
+            match = self._TOKEN_RE.match(formula, pos)
+            if not match:
+                raise RuleExecutionError(f"Invalid character '{formula[pos]}' in calc formula '{formula}'")
+            kind = match.lastgroup
+            value = match.group()
+            pos = match.end()
+            if kind == "WS":
+                continue
+            tokens.append((kind, value))
+        return tokens
+
+    def _peek(self):
+        if self._pos < len(self._tokens):
+            return self._tokens[self._pos]
+        return (None, "")
+
+    def _advance(self):
+        token = self._tokens[self._pos]
+        self._pos += 1
+        return token
+
+    def _parse_expression(self) -> str:
+        node = self._parse_term()
+        while self._peek() == ("OP", "+") or self._peek() == ("OP", "-"):
+            operator = self._advance()[1]
+            right = self._parse_term()
+            node = f"({node} {operator} {right})"
+        return node
+
+    def _parse_term(self) -> str:
+        node = self._parse_factor()
+        while self._peek() == ("OP", "*") or self._peek() == ("OP", "/"):
+            operator = self._advance()[1]
+            right = self._parse_factor()
+            if operator == "/":
+                node = f"({node} / NULLIF({right}, 0))"
+            else:
+                node = f"({node} * {right})"
+        return node
+
+    def _parse_factor(self) -> str:
+        token = self._peek()
+        if token == ("OP", "+"):
+            self._advance()
+            return self._parse_factor()
+        if token == ("OP", "-"):
+            self._advance()
+            return f"(-{self._parse_factor()})"
+        return self._parse_primary()
+
+    def _parse_primary(self) -> str:
+        kind, value = self._peek()
+        if kind is None:
+            raise RuleExecutionError(f"Unexpected end of calc formula '{self.params.value}'")
+        if value == "(":
+            self._advance()
+            node = self._parse_expression()
+            if self._peek() != ("OP", ")"):
+                raise RuleExecutionError(f"Missing closing parenthesis in calc formula '{self.params.value}'")
+            self._advance()
+            return f"({node})"
+        if kind == "NUMBER":
+            self._advance()
+            return f"({value})"
+        if kind == "OPREF":
+            self._advance()
+            return self._resolve_opref(value)
+        if kind == "IDENT":
+            self._advance()
+            return self._resolve_column(value)
+        raise RuleExecutionError(f"Unexpected token '{value}' in calc formula '{self.params.value}'")
+
+    def _next_placeholder(self, prefix: str) -> str:
+        placeholder = f"$calc_{prefix}{self._placeholder_counter}$"
+        self._placeholder_counter += 1
+        return placeholder
+
+    def _resolve_column(self, name: str) -> str:
+        if name in self._column_placeholders:
+            return self._column_placeholders[name]
+
+        column = self.data_service.pgi.schema.get_column(self.params.domain, name)
+        if column is None:
+            raise ColumnNotFoundError(column_name=name, table_id=self.params.domain)
+
+        placeholder = self._next_placeholder("c")
+        self._params[placeholder] = column.name
+
+        if column.type == "Num":
+            fragment = f"({placeholder})"
+        else:
+            fragment = f"({self._safe_numeric_cast(placeholder)})"
+        self._column_placeholders[name] = fragment
+        return fragment
+
+    def _resolve_opref(self, name: str) -> str:
+        if name in self._opref_fragments:
+            return self._opref_fragments[name]
+
+        previous_operations = self.params.previous_operations or {}
+        op_result = previous_operations.get(name)
+        if op_result is None:
+            raise RuleExecutionError(
+                f"Operation reference '{name}' in calc formula is not a known previous operation result"
+            )
+        if op_result.type != "constant":
+            raise RuleExecutionError(
+                f"Operation reference '{name}' in calc formula must be a constant (scalar) result, "
+                f"got '{op_result.type}'"
+            )
+
+        renamed_query = op_result.query
+        for placeholder, column_name in sorted(
+            (op_result.params or {}).items(), key=lambda item: len(item[0]), reverse=True
+        ):
+            new_placeholder = self._next_placeholder("o")
+            renamed_query = renamed_query.replace(placeholder, new_placeholder)
+            self._params[new_placeholder] = column_name
+
+        if op_result.subtype == "Num":
+            fragment = f"({renamed_query})"
+        else:
+            fragment = f"({self._safe_numeric_cast(f'({renamed_query})')})"
+        self._opref_fragments[name] = fragment
+        return fragment
+
+    def _safe_numeric_cast(self, expr: str) -> str:
+        return (
+            f"CASE WHEN TRIM(CAST({expr} AS TEXT)) ~ '{self._NUMERIC_CAST_REGEX}' "
+            f"THEN CAST(TRIM(CAST({expr} AS TEXT)) AS NUMERIC) ELSE NULL END"
+        )

--- a/cdisc_rules_engine/sql_operations/sql_base_operation.py
+++ b/cdisc_rules_engine/sql_operations/sql_base_operation.py
@@ -4,6 +4,7 @@ from cdisc_rules_engine.data_service.postgresql_data_service import (
     PostgresQLDataService,
 )
 from cdisc_rules_engine.exceptions.custom_exceptions import (
+    ColumnNotFoundError,
     DatasetNotFoundError,
     DomainNotFoundInDefineXMLError,
     EngineError,
@@ -77,6 +78,7 @@ class SqlBaseOperation:
             InvalidDictionaryVariable,
             UnsupportedDictionaryType,
             FailedSchemaValidation,
+            ColumnNotFoundError,
         ) as e:
             logger.debug(f"error in operation {self.__class__.__name__}: {str(e)}")
             raise

--- a/cdisc_rules_engine/sql_operations/sql_operations_factory.py
+++ b/cdisc_rules_engine/sql_operations/sql_operations_factory.py
@@ -2,6 +2,7 @@ from cdisc_rules_engine.data_service.postgresql_data_service import (
     PostgresQLDataService,
 )
 from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
+from cdisc_rules_engine.sql_operations.calc import SqlCalcOperation
 from cdisc_rules_engine.sql_operations.dataset_column_order import (
     SqlDatasetColumnOrderOperation,
 )
@@ -51,6 +52,7 @@ class SqlOperationsFactory:
     _operations_map = {
         "codelist_extensible": None,
         "codelist_terms": None,
+        "calc": SqlCalcOperation,
         "dataset_names": SqlDatasetNamesOperation,
         "define_extensible_codelists": None,
         "distinct": SqlDistinctOperation,

--- a/cdisc_rules_engine/utilities/sql_rule_processor.py
+++ b/cdisc_rules_engine/utilities/sql_rule_processor.py
@@ -81,6 +81,7 @@ class SQLRuleProcessor:
                 case_sensitive=operation.get("case_sensitive", True),
                 table=operation_table,
                 use_rule_type_table=operation.get("use_rule_type_table", False),
+                value=operation.get("value"),
             )
 
             operation = SqlOperationsFactory.get_service(rule_name, params=params, data_service=data_service)

--- a/tests/unit/sql/test_operations/test_calc.py
+++ b/tests/unit/sql/test_operations/test_calc.py
@@ -1,0 +1,206 @@
+import pytest
+
+from cdisc_rules_engine.check_operators.sql import PostgresQLOperators
+from cdisc_rules_engine.data_service.postgresql_data_service import (
+    PostgresQLDataService,
+)
+from cdisc_rules_engine.exceptions.custom_exceptions import RuleExecutionError
+from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
+from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
+from cdisc_rules_engine.sql_operations.calc import SqlCalcOperation
+from cdisc_rules_engine.standards.default_standards_context import (
+    DefaultStandardsContext,
+)
+
+TEST_TABLE_NAME = "test_table"
+
+
+def _build_calc(column_data, formula, previous_operations=None):
+    data_service = PostgresQLDataService.instance()
+    standards_context = DefaultStandardsContext()
+    PostgresQLDataService.add_test_dataset(
+        data_service,
+        table_name=TEST_TABLE_NAME,
+        column_data=column_data,
+        standards_context=standards_context,
+    )
+    params = SqlOperationParams(
+        domain=TEST_TABLE_NAME,
+        target="FAKEVARIABLE",
+        standards_context=standards_context,
+        value=formula,
+        previous_operations=previous_operations or {},
+    )
+    result = SqlCalcOperation(params, data_service).execute()
+    return data_service, result
+
+
+def _eval_calc(data_service, calc_result):
+    query = calc_result.query
+    for placeholder, column_name in (calc_result.params or {}).items():
+        column_hash = data_service.pgi.schema.get_column_hash(TEST_TABLE_NAME, column_name)
+        query = query.replace(placeholder, f"co.{column_hash}")
+    table_hash = data_service.pgi.schema.get_table_hash(TEST_TABLE_NAME)
+    full_query = f"SELECT id, ({query}) AS v FROM {table_hash} AS co ORDER BY id ASC"
+    data_service.pgi.execute_sql(full_query)
+    rows = data_service.pgi.fetch_all()
+    return [row["v"] for row in rows]
+
+
+def _make_operators(data_service, calc_result):
+    config = {
+        "dataset_id": TEST_TABLE_NAME,
+        "data_service": data_service,
+        "operation_variables": {"$calc": calc_result},
+        "dataset_metadata": data_service.get_dataset_metadata(TEST_TABLE_NAME),
+    }
+    return PostgresQLOperators(config)
+
+
+def _approx(values):
+    return [pytest.approx(v) if v is not None else None for v in values]
+
+
+def test_calc_result_structure():
+    column_data = {"AVAL": [10.0], "BASE": [5.0]}
+    _, result = _build_calc(column_data, "((AVAL - BASE) / BASE) * 100")
+
+    assert isinstance(result, SqlOperationResult)
+    assert result.type == "constant"
+    assert result.subtype == "Num"
+    assert result.query.startswith("SELECT ")
+    assert result.query.endswith(" AS value")
+    assert "NULLIF" in result.query
+    assert sorted(result.params.values()) == ["aval", "base"]
+
+
+@pytest.mark.parametrize(
+    "formula,expected",
+    [
+        ("AVAL / BASE", [2.0, 4.0, None]),
+        ("AVAL - BASE", [5.0, 15.0, 8.0]),
+        ("BASE - AVAL", [-5.0, -15.0, -8.0]),
+        ("((AVAL - BASE) / BASE) * 100", [100.0, 300.0, None]),
+        ("((BASE - AVAL) / AVAL) * 100", [-50.0, -75.0, -100.0]),
+    ],
+)
+def test_calc_adam_formulas(formula, expected):
+    column_data = {
+        "AVAL": [10.0, 20.0, 8.0],
+        "BASE": [5.0, 5.0, 0.0],
+    }
+    data_service, result = _build_calc(column_data, formula)
+    assert _eval_calc(data_service, result) == _approx(expected)
+
+
+def test_calc_operator_precedence_and_parentheses():
+    column_data = {"AVAL": [1.0]}
+    data_service, result = _build_calc(column_data, "2 + 3 * 4")
+    assert _eval_calc(data_service, result) == _approx([14.0])
+
+    data_service, result = _build_calc(column_data, "(2 + 3) * 4")
+    assert _eval_calc(data_service, result) == _approx([20.0])
+
+
+def test_calc_unary_minus_and_decimals():
+    column_data = {"AVAL": [10.0]}
+    data_service, result = _build_calc(column_data, "-AVAL + 2.5")
+    assert _eval_calc(data_service, result) == _approx([-7.5])
+
+
+def test_calc_division_by_zero_and_null_are_skipped():
+    column_data = {
+        "AVAL": [10.0, 10.0, None],
+        "BASE": [0.0, 5.0, 5.0],
+    }
+    data_service, result = _build_calc(column_data, "AVAL / BASE")
+    assert _eval_calc(data_service, result) == _approx([None, 2.0, None])
+
+
+def test_calc_char_column_is_safely_cast():
+    column_data = {"STRESC": ["10", "abc", "4"], "DIVISOR": [2.0, 2.0, 2.0]}
+    data_service, result = _build_calc(column_data, "STRESC / DIVISOR")
+    assert _eval_calc(data_service, result) == _approx([5.0, None, 2.0])
+
+
+def test_calc_used_in_equal_to():
+    column_data = {
+        "AVAL": [10.0, 8.0, 5.0],
+        "BASE": [5.0, 4.0, 5.0],
+        "PCHG": [100.0, 100.0, 999.0],
+    }
+    data_service, result = _build_calc(column_data, "((AVAL - BASE) / BASE) * 100")
+    operators = _make_operators(data_service, result)
+
+    equal = operators.equal_to({"target": "$calc", "comparator": "PCHG"})
+    assert list(equal) == [True, True, False]
+
+
+def test_calc_used_in_not_equal_to():
+    column_data = {
+        "AVAL": [10.0, 8.0, 5.0],
+        "BASE": [5.0, 4.0, 5.0],
+        "PCHG": [100.0, 100.0, 999.0],
+    }
+    data_service, result = _build_calc(column_data, "((AVAL - BASE) / BASE) * 100")
+    operators = _make_operators(data_service, result)
+
+    not_equal = operators.not_equal_to({"target": "$calc", "comparator": "PCHG"})
+    assert list(not_equal) == [False, False, True]
+
+
+def test_calc_with_previous_constant_operation_reference():
+    column_data = {"AVAL": [10.0, 20.0]}
+    previous_operations = {
+        "$offset": SqlOperationResult(query="SELECT 2.0", type="constant", subtype="Num"),
+    }
+    data_service, result = _build_calc(column_data, "AVAL - $offset", previous_operations)
+    assert _eval_calc(data_service, result) == _approx([8.0, 18.0])
+
+
+def test_calc_with_parameterized_previous_operation_reference():
+    column_data = {"AVAL": [10.0, 20.0], "BASE": [3.0, 4.0]}
+    previous_operations = {
+        "$base_ref": SqlOperationResult(query="SELECT $1", type="constant", subtype="Num", params={"$1": "BASE"}),
+    }
+    data_service, result = _build_calc(column_data, "AVAL - $base_ref", previous_operations)
+    assert "base" in [value.lower() for value in result.params.values()]
+    assert _eval_calc(data_service, result) == _approx([7.0, 16.0])
+
+
+def test_calc_empty_formula_raises():
+    with pytest.raises(RuleExecutionError, match="non-empty"):
+        _build_calc({"AVAL": [1.0]}, "   ")
+
+
+def test_calc_unknown_column_raises():
+    with pytest.raises(RuleExecutionError, match="not found in domain"):
+        _build_calc({"AVAL": [1.0]}, "AVAL + NOTACOLUMN")
+
+
+def test_calc_unknown_operation_reference_raises():
+    with pytest.raises(RuleExecutionError, match="not a known previous operation"):
+        _build_calc({"AVAL": [1.0]}, "AVAL + $missing")
+
+
+def test_calc_collection_operation_reference_raises():
+    previous_operations = {
+        "$list": SqlOperationResult(query="SELECT 1", type="collection", subtype="Char"),
+    }
+    with pytest.raises(RuleExecutionError, match="must be a constant"):
+        _build_calc({"AVAL": [1.0]}, "AVAL + $list", previous_operations)
+
+
+def test_calc_invalid_character_raises():
+    with pytest.raises(RuleExecutionError, match="Invalid character"):
+        _build_calc({"AVAL": [1.0]}, "AVAL % 2")
+
+
+def test_calc_unresolved_placeholder_raises():
+    with pytest.raises(RuleExecutionError, match="Invalid character"):
+        _build_calc({"AVAL": [1.0]}, "AVAL / {{root}}")
+
+
+def test_calc_unbalanced_parentheses_raises():
+    with pytest.raises(RuleExecutionError, match="closing parenthesis"):
+        _build_calc({"AVAL": [1.0]}, "(AVAL + 1")

--- a/tests/unit/sql/test_operations/test_calc.py
+++ b/tests/unit/sql/test_operations/test_calc.py
@@ -4,7 +4,10 @@ from cdisc_rules_engine.check_operators.sql import PostgresQLOperators
 from cdisc_rules_engine.data_service.postgresql_data_service import (
     PostgresQLDataService,
 )
-from cdisc_rules_engine.exceptions.custom_exceptions import RuleExecutionError
+from cdisc_rules_engine.exceptions.custom_exceptions import (
+    ColumnNotFoundError,
+    RuleExecutionError,
+)
 from cdisc_rules_engine.models.sql_operation_params import SqlOperationParams
 from cdisc_rules_engine.models.sql_operation_result import SqlOperationResult
 from cdisc_rules_engine.sql_operations.calc import SqlCalcOperation
@@ -174,7 +177,7 @@ def test_calc_empty_formula_raises():
 
 
 def test_calc_unknown_column_raises():
-    with pytest.raises(RuleExecutionError, match="not found in domain"):
+    with pytest.raises(ColumnNotFoundError, match="not found in table"):
         _build_calc({"AVAL": [1.0]}, "AVAL + NOTACOLUMN")
 
 


### PR DESCRIPTION
New calc operation. Allows the use of formulas (+ - * /, parentheses, numbers, column names, and $operation references). 
Guards against division-by-zero and non-numeric casts. Non-existent columns or inappropriate operations (not constant or missing).
Quite a lot of unit tests. Some parsing, some precedence of ops and some error handling.
No regression changes from this feature as no existing rules utilise it.