### PR TITLE
co: Has Previous Enumerated Column

### DIFF
--- a/cdisc_rules_engine/check_operators/sql/has_previous_enumerated_column_operator.py
+++ b/cdisc_rules_engine/check_operators/sql/has_previous_enumerated_column_operator.py
@@ -1,0 +1,32 @@
+import re
+from .base_sql_operator import BaseSqlOperator
+
+
+class HasPreviousEnumeratedColumnOperator(BaseSqlOperator):
+    """
+    Checks if the chronologically previous enumerated column exists.
+    """
+
+    def execute_operator(self, other_value):
+        target_column = self.replace_prefix(other_value.get("target"))
+
+        if not isinstance(target_column, str):
+            raise TypeError(f"Expected a target column string, got {type(target_column).__name__}: {target_column}.")
+
+        match = re.search(r"(\d+)(?=\D*$)", target_column)
+        if not match:
+            raise ValueError(f"Column '{target_column}' does not contain an enumerated number.")
+
+        num_str = match.group(1)
+        num = int(num_str)
+
+        if num == 1:
+            return self._do_check_operator(lambda: "TRUE")
+
+        prev_num_str = str(num - 1).zfill(len(num_str))
+        prev_column = target_column[: match.start()] + prev_num_str + target_column[match.end() :]
+
+        if self._exists(prev_column.lower()):
+            return self._do_check_operator(lambda: "TRUE")
+        else:
+            return self._do_check_operator(lambda: "FALSE")

--- a/cdisc_rules_engine/check_operators/sql/postgresql_operators.py
+++ b/cdisc_rules_engine/check_operators/sql/postgresql_operators.py
@@ -25,6 +25,7 @@ from .equals_string_part_operator import EqualsStringPartOperator
 from .exists_operator import ExistsOperator
 from .has_different_values_operator import HasDifferentValuesOperator
 from .has_next_corresponding_record_operator import HasNextCorrespondingRecordOperator
+from .has_previous_enumerated_column_operator import HasPreviousEnumeratedColumnOperator
 from .inconsistent_enumerated_columns_operator import (
     InconsistentEnumeratedColumnsOperator,
 )
@@ -319,6 +320,8 @@ class PostgresQLOperators(BaseType):
         ),
         "is_substring_of": lambda data: IsSubstringOfOperator(data),
         "is_not_substring_of": lambda data: NotOperator(data, IsSubstringOfOperator),
+        "has_previous_enumerated_column": lambda data: HasPreviousEnumeratedColumnOperator(data),
+        "does_not_have_previous_enumerated_column": lambda data: NotOperator(data, HasPreviousEnumeratedColumnOperator),
     }
 
     def __init__(self, data):

--- a/tests/unit/sql/test_check_operators/test_has_previous_enumerated_column.py
+++ b/tests/unit/sql/test_check_operators/test_has_previous_enumerated_column.py
@@ -1,0 +1,112 @@
+import pytest
+from cdisc_rules_engine.check_operators.sql.has_previous_enumerated_column_operator import (
+    HasPreviousEnumeratedColumnOperator,
+)
+from cdisc_rules_engine.data_service.postgresql_data_service import PostgresQLDataService
+
+
+@pytest.mark.parametrize(
+    "data, target, expected",
+    [
+        (
+            {"STUDYID": ["1", "2"], "TRT01P": ["A", "B"]},
+            "TRT01P",
+            [True, True],
+        ),
+        (
+            {"STUDYID": ["1", "2"], "PARAM1": ["A", "B"]},
+            "PARAM1",
+            [True, True],
+        ),
+        (
+            {"STUDYID": ["1", "2"], "TRT01P": ["A", "B"], "TRT02P": ["C", "D"]},
+            "TRT02P",
+            [True, True],
+        ),
+        (
+            {"STUDYID": ["1", "2"], "PARAM1": ["A", "B"], "PARAM2": ["C", "D"]},
+            "PARAM2",
+            [True, True],
+        ),
+        (
+            {"STUDYID": ["1", "2"], "TRT01P": ["A", "B"], "TRT03P": ["C", "D"]},
+            "TRT03P",
+            [False, False],
+        ),
+        (
+            {"STUDYID": ["1", "2"], "PARAM2": ["C", "D"]},
+            "PARAM2",
+            [False, False],
+        ),
+    ],
+)
+def test_has_previous_enumerated_column(data, target, expected, sdtm_standards_context):
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service,
+        table_name="ADSL",
+        column_data=data,
+        standards_context=sdtm_standards_context,
+    )
+
+    operator_data = {
+        "data_service": data_service,
+        "dataset_id": "ADSL",
+    }
+
+    operator = HasPreviousEnumeratedColumnOperator(operator_data)
+    result = operator.execute_operator({"target": target})
+
+    assert result.tolist() == expected
+
+
+@pytest.mark.parametrize(
+    "data, target",
+    [
+        ({"STUDYID": ["1", "2"]}, 123),
+        ({"STUDYID": ["1", "2"]}, None),
+    ],
+)
+def test_has_previous_enumerated_column_type_error(data, target, sdtm_standards_context):
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service,
+        table_name="ADSL",
+        column_data=data,
+        standards_context=sdtm_standards_context,
+    )
+
+    operator_data = {
+        "data_service": data_service,
+        "dataset_id": "ADSL",
+    }
+
+    operator = HasPreviousEnumeratedColumnOperator(operator_data)
+    with pytest.raises(TypeError, match="Expected a target column string"):
+        operator.execute_operator({"target": target})
+
+
+@pytest.mark.parametrize(
+    "data, target",
+    [
+        ({"STUDYID": ["1", "2"]}, "STUDYID"),
+        ({"STUDYID": ["1", "2"], "TRTP": ["A", "B"]}, "TRTP"),
+    ],
+)
+def test_has_previous_enumerated_column_value_error(data, target, sdtm_standards_context):
+    data_service = PostgresQLDataService.instance()
+    PostgresQLDataService.add_test_dataset(
+        data_service,
+        table_name="ADSL",
+        column_data=data,
+        standards_context=sdtm_standards_context,
+    )
+
+    operator_data = {
+        "data_service": data_service,
+        "dataset_id": "ADSL",
+    }
+
+    operator = HasPreviousEnumeratedColumnOperator(operator_data)
+    with pytest.raises(ValueError, match="does not contain an enumerated number"):
+        operator.execute_operator({"target": target})


### PR DESCRIPTION
Operator to check if the dataset has a variable name that matches the name of the target column -1. Regex looks for the first example of digits in a target column name and then hunts for an example of that same string with the next lowest integer in the same format (leading zeroes included).

Also unit tests.